### PR TITLE
Add POT creation script, split POT files and a Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/ClassicPress/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Translating ClassicPress
+
+## Background
+
+This repository contains files and scripts used for translating ClassicPress into other languages. If you are looking for the right place to contribute translations you need to visit our project on [CrownIn](https://classicpress.crowdin.com/u/projects/1).
+
+If you are here to review or contribute to the translation file process, them **welcome**!
+
+## Requirements
+
+To work with this repository you will need to be using Linux or MacOS locally. You will need:
+- WP-CLI installed (see [external documentation](https://wp-cli.org/) on how to install)
+- MacOS users will need **gsed**, we recommend installing via [brew](https://brew.sh/)
+- git
+
+## Creating POT files
+
+To create new POT files for a new release:
+
+`bin/create_pot.sh`
+
+This command will clone ClassicPress locally, build the distribution code and then create three POT files:
+
+- en_US.pot
+- admin-en_US.pot
+- admin-network-en_US.pot
+
+The first of these contains string that exist in the root files and `wp-includes`, the second  contains the majority of string the appear in the Admin area after logging in and the last contains Admin area files used in Multisite installs only. The purpose of the three files is to reduce loading times by only loading string translations that are likely to be needed.
+
+Once these files are committed to GitHub, Crowdin will automatically sync them for known branches to allow translation contributors to get to work. For brand new major releases of ClassicPress a new branch is needed and further configuration in Crowdin may be needed.  
+
+## Creating POT files
+
+Once the Crowdin contributors have added some translations, these are synced back to GitHub into a service branch. This is a branch prefixed with`l10n_`. and it will contain PO files. The script at `bin/build_zip.sh` can be used to create MO files from these files and also create language pack zip files ready to upload to the API server. A json file will also be needed to deliver information to ClassicPress instals about the available language packs.

--- a/admin-en_US.pot
+++ b/admin-en_US.pot
@@ -1,0 +1,18989 @@
+# Copyright (C) 2024 ClassicPress
+# This file is distributed under the same license as the ClassicPress package.
+msgid ""
+msgstr ""
+"Project-Id-Version: ClassicPress 2.0.0\n"
+"Report-Msgid-Bugs-To: https://forums.classicpress.net/c/team-discussions/internationalisation/42\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-04-16T12:24:56+00:00\n"
+"X-Generator: WP-CLI 2.10.0\n"
+
+#. translators: Page title of the About ClassicPress page in the admin.
+#: wp-admin/about.php:15
+msgctxt "page title"
+msgid "About"
+msgstr ""
+
+#: wp-admin/about.php:20
+#: wp-admin/credits.php:22
+#: wp-admin/freedoms.php:36
+msgid "Welcome to ClassicPress!"
+msgstr ""
+
+#. translators: %s: Plugin version.
+#. translators: %s: Plugin version number.
+#. translators: %s: Theme version number.
+#. translators: %s: ClassicPress version.
+#: wp-admin/about.php:23
+#: wp-admin/credits.php:25
+#: wp-admin/freedoms.php:39
+#: wp-admin/includes/ajax-actions.php:4538
+#: wp-admin/includes/ajax-actions.php:4581
+#: wp-admin/includes/class-wp-debug-data.php:917
+#: wp-admin/includes/class-wp-debug-data.php:964
+#: wp-admin/includes/class-wp-debug-data.php:1286
+#: wp-admin/includes/class-wp-plugins-list-table.php:1052
+#: wp-admin/includes/update.php:232
+#: wp-admin/includes/update.php:264
+msgid "Version %s"
+msgstr ""
+
+#. translators: link to "business-focused CMS" article
+#. translators: link to ClassicPress website
+#: wp-admin/about.php:30
+#: wp-admin/credits.php:32
+#: wp-admin/freedoms.php:46
+msgid "Thank you for using ClassicPress, the <a href=\"%s\">CMS for Creators</a>."
+msgstr ""
+
+#: wp-admin/about.php:35
+#: wp-admin/credits.php:37
+#: wp-admin/freedoms.php:51
+msgid "Stable. Lightweight. Instantly Familiar."
+msgstr ""
+
+#: wp-admin/about.php:40
+#: wp-admin/credits.php:43
+#: wp-admin/freedoms.php:57
+msgid "About"
+msgstr ""
+
+#: wp-admin/about.php:41
+#: wp-admin/credits.php:13
+#: wp-admin/credits.php:44
+#: wp-admin/freedoms.php:58
+msgid "Credits"
+msgstr ""
+
+#: wp-admin/about.php:42
+#: wp-admin/credits.php:45
+#: wp-admin/freedoms.php:19
+#: wp-admin/freedoms.php:59
+msgid "Freedoms"
+msgstr ""
+
+#: wp-admin/about.php:43
+#: wp-admin/credits.php:46
+#: wp-admin/freedoms.php:60
+#: wp-admin/menu.php:342
+#: wp-admin/options-privacy.php:22
+#: wp-admin/options-privacy.php:157
+#: wp-admin/privacy-policy-guide.php:40
+msgid "Privacy"
+msgstr ""
+
+#. translators: link to learn more about translating ClassicPress
+#: wp-admin/about.php:53
+msgid "Help us translate ClassicPress into your language! <a href=\"%s\">Learn more</a>."
+msgstr ""
+
+#: wp-admin/about.php:60
+msgid "About ClassicPress"
+msgstr ""
+
+#. translators: link to ClassicPress site
+#: wp-admin/about.php:67
+msgid "<a href=\"%s\"><strong>ClassicPress</strong></a> is a fork of the WordPress %s branch, including the battle-tested and proven classic editor interface using TinyMCE."
+msgstr ""
+
+#: wp-admin/about.php:75
+msgid "This has been a solid foundation for millions of sites for many years, and we believe it will also be an excellent foundation for the future."
+msgstr ""
+
+#: wp-admin/about.php:80
+msgid "Join our growing community"
+msgstr ""
+
+#. translators: 1: link with instructions to join ClassicPress Zulip, 2: link to community forums
+#: wp-admin/about.php:85
+msgid "For general discussion about ClassicPress, <a href=\"%1$s\"><strong>join our Zulip group</strong></a> or our <a href=\"%2$s\"><strong>community forum</strong></a>."
+msgstr ""
+
+#. translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum
+#: wp-admin/about.php:95
+msgid "If you need help with something else, please see our <a href=\"%1$s\"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href=\"%2$s\"><strong>support forum</strong></a>."
+msgstr ""
+
+#. translators: 1: link to ClassicPress GitHub repository, 2: link to GitHub issues list
+#: wp-admin/about.php:105
+msgid "ClassicPress is developed <a href=\"%1$s\"><strong>on GitHub</strong></a>. For specific bug reports or technical suggestions, see the <a href=\"%2$s\"><strong>issues list</strong></a> and add your report if it is not already present."
+msgstr ""
+
+#: wp-admin/about.php:111
+msgid "ClassicPress changelogs"
+msgstr ""
+
+#: wp-admin/about.php:112
+msgid "ClassicPress 2.0.0"
+msgstr ""
+
+#. translators: link to ClassicPress 1.0.0 changelog
+#: wp-admin/about.php:117
+msgid "For a list of new features and other changes from WordPress %1$s, see the <a href=\"%2$s\"><strong>ClassicPress 2.0.0 (Bella) release notes</strong></a>."
+msgstr ""
+
+#. translators: current ClassicPress version
+#: wp-admin/about.php:127
+msgid "ClassicPress 1.0.1 - %s"
+msgstr ""
+
+#. translators: link to ClassicPress release announcements subforum
+#: wp-admin/about.php:136
+msgid "The changes and new features included in recent versions of ClassicPress can be found in our <a href=\"%s\"><strong>Release Announcements subforum</strong></a>."
+msgstr ""
+
+#: wp-admin/about.php:141
+msgid "ClassicPress 1.0.0"
+msgstr ""
+
+#. translators: link to ClassicPress 1.0.0 changelog
+#: wp-admin/about.php:146
+msgid "For a list of new features and other changes in WordPress %1$s, see the <a href=\"%2$s\"><strong>ClassicPress 1.0.0 (Aurora) release notes</strong></a>."
+msgstr ""
+
+#: wp-admin/about.php:152
+msgid "ClassicPress Maintenance and Security Releases"
+msgstr ""
+
+#: wp-admin/about.php:155
+msgid "This version of ClassicPress includes all changes from the following versions of WordPress:"
+msgstr ""
+
+#. translators: %s: WordPress version.
+#. translators: %s: ClassicPress version number
+#: wp-admin/about.php:164
+#: wp-admin/about.php:251
+msgid "<strong>Version %s</strong> addressed some security issues."
+msgstr ""
+
+#. translators: %s: HelpHub URL.
+#. translators: %s: HelpHub URL
+#. translators: %s: Codex URL
+#: wp-admin/about.php:171
+#: wp-admin/about.php:196
+#: wp-admin/about.php:221
+#: wp-admin/about.php:272
+msgid "For more information, see <a href=\"%s\">the release notes</a>."
+msgstr ""
+
+#. translators: %s: WordPress version.
+#. translators: %s: WordPress version
+#. translators: %s: ClassicPress version.
+#: wp-admin/about.php:174
+#: wp-admin/about.php:199
+#: wp-admin/about.php:224
+#: wp-admin/upgrade.php:81
+msgid "https://wordpress.org/support/wordpress-version/version-%s/"
+msgstr ""
+
+#. translators: 1: WordPress version number, 2: plural number of bugs.
+#: wp-admin/about.php:184
+#: wp-admin/about.php:209
+msgid "<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug."
+msgid_plural "<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/about.php:239
+msgid "Maintenance Release"
+msgstr ""
+
+#: wp-admin/about.php:240
+msgid "Maintenance Releases"
+msgstr ""
+
+#: wp-admin/about.php:242
+msgid "Security Release"
+msgstr ""
+
+#: wp-admin/about.php:243
+msgid "Security Releases"
+msgstr ""
+
+#: wp-admin/about.php:245
+msgid "Maintenance and Security Release"
+msgstr ""
+
+#: wp-admin/about.php:246
+msgid "Maintenance and Security Releases"
+msgstr ""
+
+#. translators: %s: ClassicPress version number
+#: wp-admin/about.php:249
+msgid "<strong>Version %s</strong> addressed one security issue."
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: plural number of bugs.
+#: wp-admin/about.php:254
+msgid "<strong>Version %1$s</strong> addressed %2$s bug."
+msgid_plural "<strong>Version %1$s</strong> addressed %2$s bugs."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: ClassicPress version number, 2: plural number of bugs. Singular security issue.
+#: wp-admin/about.php:260
+msgid "<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bug."
+msgid_plural "<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bugs."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: ClassicPress version number, 2: plural number of bugs. More than one security issue.
+#: wp-admin/about.php:266
+msgid "<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug."
+msgid_plural "<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: https://www.classicpress.net
+#: wp-admin/admin-footer.php:37
+msgid "Thank you for creating with <a href=\"%s\">ClassicPress</a>."
+msgstr ""
+
+#: wp-admin/admin-footer.php:38
+#: wp-admin/upgrade.php:69
+msgid "https://www.classicpress.net/"
+msgstr ""
+
+#. translators: Network admin screen title. %s: Network title.
+#: wp-admin/admin-header.php:40
+msgid "Network Admin: %s"
+msgstr ""
+
+#. translators: User dashboard screen title. %s: Network title.
+#: wp-admin/admin-header.php:43
+msgid "User Dashboard: %s"
+msgstr ""
+
+#. translators: Admin screen title. %s: Admin screen name.
+#: wp-admin/admin-header.php:50
+msgid "%s &#8212; ClassicPress"
+msgstr ""
+
+#. translators: Editor admin screen title. 1: "Edit item" text for the post type, 2: Post title.
+#: wp-admin/admin-header.php:60
+msgid "%1$s &#8220;%2$s&#8221;"
+msgstr ""
+
+#. translators: Admin screen title. 1: Admin screen name, 2: Network or site name.
+#: wp-admin/admin-header.php:68
+msgid "%1$s &lsaquo; %2$s &#8212; ClassicPress"
+msgstr ""
+
+#. translators: %s: Admin screen title.
+#: wp-admin/admin-header.php:73
+msgid "Recovery Mode &#8212; %s"
+msgstr ""
+
+#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
+#. translators: 1: Post edited date, 2: Post edited time.
+#. translators: 1: Post creation date, 2: Post creation time.
+#. translators: Default date format, see https://www.php.net/manual/datetime.format.php
+#. translators: 1: Date, 2: Time.
+#: wp-admin/admin.php:113
+#: wp-admin/edit-form-advanced.php:663
+#: wp-admin/edit-form-advanced.php:666
+#: wp-admin/includes/ajax-actions.php:1559
+#: wp-admin/includes/ajax-actions.php:2802
+#: wp-admin/includes/ajax-actions.php:2805
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:70
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:85
+#: wp-admin/includes/class-wp-privacy-policy-content.php:366
+#: wp-admin/includes/dashboard.php:679
+#: wp-admin/includes/media.php:1638
+#: wp-admin/includes/schema.php:438
+#: wp-admin/options-general.php:493
+#: wp-admin/options-general.php:524
+#: wp-admin/update-core.php:907
+msgid "F j, Y"
+msgstr ""
+
+#. translators: Comment time format. See https://www.php.net/manual/datetime.format.php
+#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
+#. translators: 1: Post edited date, 2: Post edited time.
+#. translators: 1: Post creation date, 2: Post creation time.
+#. translators: Post time format. See https://www.php.net/manual/datetime.format.php
+#. translators: Default time format, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/admin.php:114
+#: wp-admin/comment.php:223
+#: wp-admin/edit-form-advanced.php:663
+#: wp-admin/edit-form-advanced.php:666
+#: wp-admin/includes/ajax-actions.php:1559
+#: wp-admin/includes/ajax-actions.php:2803
+#: wp-admin/includes/ajax-actions.php:2806
+#: wp-admin/includes/class-wp-comments-list-table.php:1018
+#: wp-admin/includes/class-wp-posts-list-table.php:1172
+#: wp-admin/includes/schema.php:440
+#: wp-admin/options-general.php:493
+#: wp-admin/options-general.php:572
+msgid "g:i a"
+msgstr ""
+
+#: wp-admin/admin.php:262
+msgid "Invalid plugin page."
+msgstr ""
+
+#. translators: %s: Admin page generated by a plugin.
+#: wp-admin/admin.php:269
+msgid "Cannot load %s."
+msgstr ""
+
+#: wp-admin/admin.php:305
+#: wp-admin/import.php:15
+msgid "Sorry, you are not allowed to import content into this site."
+msgstr ""
+
+#: wp-admin/admin.php:338
+#: wp-admin/import.php:19
+#: wp-admin/menu.php:322
+msgid "Import"
+msgstr ""
+
+#: wp-admin/async-upload.php:38
+#: wp-admin/includes/ajax-actions.php:2426
+#: wp-admin/includes/ajax-actions.php:2492
+#: wp-admin/media-new.php:16
+#: wp-admin/media-upload.php:20
+#: wp-admin/upload.php:13
+msgid "Sorry, you are not allowed to upload files."
+msgstr ""
+
+#: wp-admin/async-upload.php:46
+#: wp-admin/edit.php:18
+#: wp-admin/edit.php:41
+#: wp-admin/post-new.php:24
+#: wp-admin/post.php:131
+#: wp-admin/post.php:249
+#: wp-admin/post.php:286
+#: wp-admin/post.php:315
+msgid "Invalid post type."
+msgstr ""
+
+#: wp-admin/async-upload.php:72
+#: wp-admin/includes/media.php:3281
+msgid "Copy URL to clipboard"
+msgstr ""
+
+#: wp-admin/async-upload.php:73
+#: wp-admin/includes/class-wp-media-list-table.php:863
+#: wp-admin/includes/class-wp-privacy-policy-content.php:409
+#: wp-admin/includes/media.php:3282
+#: wp-admin/site-health-info.php:55
+msgid "Copied!"
+msgstr ""
+
+#: wp-admin/async-upload.php:77
+msgctxt "media item"
+msgid "Edit"
+msgstr ""
+
+#: wp-admin/async-upload.php:79
+msgctxt "media item"
+msgid "Success"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/async-upload.php:120
+#: wp-admin/includes/dashboard.php:1529
+#: wp-admin/includes/file.php:344
+#: wp-admin/index.php:166
+msgid "Dismiss"
+msgstr ""
+
+#. translators: %s: Name of the file that failed to upload.
+#: wp-admin/async-upload.php:124
+msgid "&#8220;%s&#8221; has failed to upload."
+msgstr ""
+
+#: wp-admin/authorize-application.php:66
+msgid "Authorize Application"
+msgstr ""
+
+#: wp-admin/authorize-application.php:87
+msgid "The Authorize Application request is not allowed."
+msgstr ""
+
+#: wp-admin/authorize-application.php:88
+#: wp-admin/authorize-application.php:95
+#: wp-admin/authorize-application.php:113
+msgid "Cannot Authorize Application"
+msgstr ""
+
+#: wp-admin/authorize-application.php:94
+msgid "Your website appears to use Basic Authentication, which is not currently compatible with application passwords."
+msgstr ""
+
+#: wp-admin/authorize-application.php:98
+#: wp-admin/authorize-application.php:116
+msgid "Go Back"
+msgstr ""
+
+#: wp-admin/authorize-application.php:106
+msgid "Application passwords are not available for your account. Please contact the site administrator for assistance."
+msgstr ""
+
+#: wp-admin/authorize-application.php:108
+msgid "Application passwords are not available."
+msgstr ""
+
+#: wp-admin/authorize-application.php:145
+msgid "An application would like to connect to your account."
+msgstr ""
+
+#. translators: %s: Application name.
+#: wp-admin/authorize-application.php:151
+msgid "Would you like to give the application identifying itself as %s access to your account? You should only do this if you trust the application in question."
+msgstr ""
+
+#: wp-admin/authorize-application.php:157
+msgid "Would you like to give this application access to your account? You should only do this if you trust the application in question."
+msgstr ""
+
+#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
+#: wp-admin/authorize-application.php:170
+msgid "This will grant access to <a href=\"%1$s\">the %2$s site in this installation that you have permissions on</a>."
+msgid_plural "This will grant access to <a href=\"%1$s\">all %2$s sites in this installation that you have permissions on</a>."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
+#: wp-admin/authorize-application.php:178
+msgid "This will grant access to <a href=\"%1$s\">the %2$s site on the network as you have Super Admin rights</a>."
+msgid_plural "This will grant access to <a href=\"%1$s\">all %2$s sites on the network as you have Super Admin rights</a>."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Application name.
+#: wp-admin/authorize-application.php:204
+#: wp-admin/user-edit.php:991
+#: wp-admin/js/auth-app.js:90
+msgid "Your new password for %s is:"
+msgstr ""
+
+#: wp-admin/authorize-application.php:211
+#: wp-admin/user-edit.php:998
+#: wp-admin/js/auth-app.js:98
+msgid "Be sure to save this in a safe location. You will not be able to retrieve it."
+msgstr ""
+
+#: wp-admin/authorize-application.php:239
+#: wp-admin/user-edit.php:837
+msgid "New Application Password Name"
+msgstr ""
+
+#: wp-admin/authorize-application.php:263
+msgid "Yes, I approve of this connection"
+msgstr ""
+
+#. translators: %s: The URL the user is being redirected to.
+#: wp-admin/authorize-application.php:277
+#: wp-admin/authorize-application.php:311
+msgid "You will be sent to %s"
+msgstr ""
+
+#: wp-admin/authorize-application.php:290
+msgid "You will be given a password to manually enter into the application in question."
+msgstr ""
+
+#: wp-admin/authorize-application.php:297
+msgid "No, I do not approve of this connection"
+msgstr ""
+
+#: wp-admin/authorize-application.php:315
+msgid "You will be returned to the ClassicPress Dashboard, and no changes will be made."
+msgstr ""
+
+#: wp-admin/comment.php:46
+msgid "You cannot edit this comment because the associated post is in the Trash. Please restore the post first, then try again."
+msgstr ""
+
+#: wp-admin/comment.php:57
+#: wp-admin/edit-form-comment.php:22
+#: wp-admin/includes/template.php:460
+msgid "Edit Comment"
+msgstr ""
+
+#: wp-admin/comment.php:62
+#: wp-admin/edit-comments.php:189
+#: wp-admin/edit-form-advanced.php:340
+#: wp-admin/edit-link-form.php:66
+#: wp-admin/edit-tags.php:268
+#: wp-admin/edit.php:247
+#: wp-admin/edit.php:300
+#: wp-admin/erase-personal-data.php:23
+#: wp-admin/export-personal-data.php:23
+#: wp-admin/export.php:51
+#: wp-admin/import.php:24
+#: wp-admin/includes/class-custom-background.php:89
+#: wp-admin/includes/class-custom-image-header.php:100
+#: wp-admin/includes/class-wp-screen.php:831
+#: wp-admin/index.php:44
+#: wp-admin/link-manager.php:57
+#: wp-admin/media-new.php:49
+#: wp-admin/media.php:86
+#: wp-admin/nav-menus.php:643
+#: wp-admin/nav-menus.php:684
+#: wp-admin/options-discussion.php:24
+#: wp-admin/options-general.php:46
+#: wp-admin/options-media.php:34
+#: wp-admin/options-permalink.php:23
+#: wp-admin/options-privacy.php:38
+#: wp-admin/options-reading.php:25
+#: wp-admin/options-writing.php:23
+#: wp-admin/plugin-editor.php:125
+#: wp-admin/plugin-install.php:93
+#: wp-admin/plugins.php:543
+#: wp-admin/revision.php:151
+#: wp-admin/site-health.php:80
+#: wp-admin/theme-editor.php:28
+#: wp-admin/theme-install.php:124
+#: wp-admin/themes.php:143
+#: wp-admin/update-core.php:845
+#: wp-admin/upload.php:138
+#: wp-admin/upload.php:319
+#: wp-admin/user-edit.php:70
+#: wp-admin/user-new.php:279
+#: wp-admin/users.php:34
+#: wp-admin/widgets-form.php:43
+msgid "Overview"
+msgstr ""
+
+#: wp-admin/comment.php:64
+msgid "You can edit the information left in a comment if needed. This is often useful when you notice that a commenter has made a typographical error."
+msgstr ""
+
+#: wp-admin/comment.php:65
+msgid "You can also moderate the comment from this screen using the Status box, where you can also change the timestamp of the comment."
+msgstr ""
+
+#: wp-admin/comment.php:70
+#: wp-admin/edit-comments.php:209
+#: wp-admin/edit-form-advanced.php:314
+#: wp-admin/edit-form-advanced.php:331
+#: wp-admin/edit-form-advanced.php:350
+#: wp-admin/edit-link-form.php:75
+#: wp-admin/edit-tags.php:302
+#: wp-admin/edit.php:291
+#: wp-admin/edit.php:316
+#: wp-admin/erase-personal-data.php:64
+#: wp-admin/export-personal-data.php:64
+#: wp-admin/export.php:58
+#: wp-admin/import.php:31
+#: wp-admin/includes/class-custom-background.php:99
+#: wp-admin/includes/class-custom-image-header.php:136
+#: wp-admin/index.php:112
+#: wp-admin/link-manager.php:78
+#: wp-admin/media-new.php:60
+#: wp-admin/media.php:96
+#: wp-admin/nav-menus.php:691
+#: wp-admin/options-discussion.php:31
+#: wp-admin/options-general.php:52
+#: wp-admin/options-media.php:40
+#: wp-admin/options-permalink.php:59
+#: wp-admin/options-privacy.php:46
+#: wp-admin/options-reading.php:52
+#: wp-admin/options-writing.php:52
+#: wp-admin/plugin-editor.php:142
+#: wp-admin/plugin-install.php:117
+#: wp-admin/plugins.php:586
+#: wp-admin/revision.php:156
+#: wp-admin/site-health.php:89
+#: wp-admin/theme-editor.php:51
+#: wp-admin/theme-install.php:142
+#: wp-admin/themes.php:206
+#: wp-admin/tools.php:55
+#: wp-admin/update-core.php:866
+#: wp-admin/upload.php:158
+#: wp-admin/upload.php:351
+#: wp-admin/user-edit.php:76
+#: wp-admin/user-new.php:300
+#: wp-admin/users.php:81
+#: wp-admin/widgets-form.php:70
+msgid "For more information:"
+msgstr ""
+
+#: wp-admin/comment.php:71
+#: wp-admin/edit-comments.php:210
+msgid "<a href=\"https://wordpress.org/documentation/article/comments-screen/\">Documentation on Comments</a>"
+msgstr ""
+
+#: wp-admin/comment.php:72
+#: wp-admin/edit-comments.php:213
+#: wp-admin/edit-form-advanced.php:316
+#: wp-admin/edit-form-advanced.php:334
+#: wp-admin/edit-form-advanced.php:352
+#: wp-admin/edit-link-form.php:77
+#: wp-admin/edit-tags.php:312
+#: wp-admin/edit.php:293
+#: wp-admin/edit.php:318
+#: wp-admin/erase-personal-data.php:66
+#: wp-admin/export-personal-data.php:66
+#: wp-admin/export.php:60
+#: wp-admin/includes/class-custom-image-header.php:138
+#: wp-admin/index.php:114
+#: wp-admin/link-manager.php:80
+#: wp-admin/media-new.php:62
+#: wp-admin/media.php:98
+#: wp-admin/nav-menus.php:693
+#: wp-admin/options-discussion.php:33
+#: wp-admin/options-general.php:54
+#: wp-admin/options-media.php:42
+#: wp-admin/options-permalink.php:67
+#: wp-admin/options-reading.php:54
+#: wp-admin/options-writing.php:54
+#: wp-admin/plugin-editor.php:145
+#: wp-admin/plugin-install.php:119
+#: wp-admin/plugins.php:589
+#: wp-admin/revision.php:158
+#: wp-admin/theme-editor.php:56
+#: wp-admin/theme-install.php:145
+#: wp-admin/themes.php:210
+#: wp-admin/tools.php:57
+#: wp-admin/upload.php:160
+#: wp-admin/upload.php:353
+#: wp-admin/user-edit.php:78
+#: wp-admin/user-new.php:302
+#: wp-admin/users.php:84
+#: wp-admin/widgets-form.php:72
+msgid "<a href=\"https://wordpress.org/support/forums/\">Support forums</a>"
+msgstr ""
+
+#: wp-admin/comment.php:79
+#: wp-admin/comment.php:279
+#: wp-admin/edit-comments.php:278
+msgid "Invalid comment ID."
+msgstr ""
+
+#: wp-admin/comment.php:79
+#: wp-admin/comment.php:279
+#: wp-admin/includes/post.php:1761
+#: wp-admin/plugin-editor.php:335
+#: wp-admin/theme-editor.php:384
+msgid "Go back"
+msgstr ""
+
+#: wp-admin/comment.php:83
+msgid "Sorry, you are not allowed to edit this comment."
+msgstr ""
+
+#: wp-admin/comment.php:87
+msgid "This comment is in the Trash. Please move it out of the Trash if you want to edit it."
+msgstr ""
+
+#: wp-admin/comment.php:101
+msgid "Moderate Comment"
+msgstr ""
+
+#: wp-admin/comment.php:133
+msgid "You are about to mark the following comment as spam:"
+msgstr ""
+
+#: wp-admin/comment.php:134
+#: wp-admin/includes/class-wp-comments-list-table.php:368
+msgctxt "comment"
+msgid "Mark as spam"
+msgstr ""
+
+#: wp-admin/comment.php:137
+msgid "You are about to move the following comment to the Trash:"
+msgstr ""
+
+#: wp-admin/comment.php:138
+#: wp-admin/edit-form-comment.php:242
+#: wp-admin/includes/class-wp-comments-list-table.php:380
+#: wp-admin/includes/class-wp-media-list-table.php:187
+#: wp-admin/includes/class-wp-posts-list-table.php:448
+#: wp-admin/includes/media.php:1679
+#: wp-admin/includes/meta-boxes.php:368
+#: wp-admin/includes/meta-boxes.php:472
+msgid "Move to Trash"
+msgstr ""
+
+#: wp-admin/comment.php:141
+msgid "You are about to delete the following comment:"
+msgstr ""
+
+#: wp-admin/comment.php:142
+msgid "Permanently delete comment"
+msgstr ""
+
+#: wp-admin/comment.php:145
+msgid "You are about to approve the following comment:"
+msgstr ""
+
+#: wp-admin/comment.php:146
+msgid "Approve comment"
+msgstr ""
+
+#: wp-admin/comment.php:154
+msgid "This comment is currently approved."
+msgstr ""
+
+#: wp-admin/comment.php:157
+msgid "This comment is currently marked as spam."
+msgstr ""
+
+#: wp-admin/comment.php:160
+msgid "This comment is currently in the Trash."
+msgstr ""
+
+#: wp-admin/comment.php:168
+#: wp-admin/includes/network.php:440
+#: wp-admin/includes/network.php:448
+#: wp-admin/includes/network.php:456
+#: wp-admin/plugins.php:343
+#: wp-admin/plugins.php:349
+#: wp-admin/theme-editor.php:311
+msgid "Caution:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/comment.php:172
+#: wp-admin/edit-form-comment.php:48
+#: wp-admin/includes/class-plugin-installer-skin.php:218
+#: wp-admin/includes/class-theme-installer-skin.php:241
+#: wp-admin/includes/class-wp-comments-list-table.php:469
+#: wp-admin/includes/class-wp-debug-data.php:1100
+#: wp-admin/includes/class-wp-debug-data.php:1195
+#: wp-admin/includes/class-wp-media-list-table.php:330
+#: wp-admin/includes/class-wp-post-comments-list-table.php:25
+#: wp-admin/includes/class-wp-posts-list-table.php:667
+#: wp-admin/includes/class-wp-posts-list-table.php:1703
+#: wp-admin/includes/meta-boxes.php:976
+#: wp-admin/includes/meta-boxes.php:1708
+#: wp-admin/includes/plugin-install.php:306
+#: wp-admin/includes/theme-install.php:109
+msgid "Author"
+msgstr ""
+
+#: wp-admin/comment.php:177
+#: wp-admin/edit-form-comment.php:63
+#: wp-admin/includes/class-wp-users-list-table.php:375
+#: wp-admin/includes/template.php:493
+#: wp-admin/user-edit.php:533
+#: wp-admin/user-new.php:422
+#: wp-admin/user-new.php:536
+msgid "Email"
+msgstr ""
+
+#: wp-admin/comment.php:183
+#: wp-admin/edit-form-comment.php:69
+#: wp-admin/includes/class-walker-nav-menu-edit.php:195
+#: wp-admin/includes/class-wp-links-list-table.php:133
+#: wp-admin/includes/media.php:2884
+#: wp-admin/includes/nav-menu.php:300
+#: wp-admin/includes/template.php:498
+msgid "URL"
+msgstr ""
+
+#. translators: Column name or table row header.
+#: wp-admin/comment.php:188
+#: wp-admin/includes/class-wp-comments-list-table.php:474
+msgid "In response to"
+msgstr ""
+
+#. translators: %s: Comment link.
+#: wp-admin/comment.php:206
+#: wp-admin/includes/class-wp-comments-list-table.php:926
+msgid "In reply to %s."
+msgstr ""
+
+#: wp-admin/comment.php:214
+msgid "Submitted on"
+msgstr ""
+
+#. translators: 1: Comment date, 2: Comment time.
+#. translators: Publish box date string. 1: Date, 2: Time.
+#. translators: 1: Post date, 2: Post time.
+#. translators: Publish box date string. 1: Date, 2: Time. See https://www.php.net/manual/datetime.format.php
+#: wp-admin/comment.php:219
+#: wp-admin/edit-form-advanced.php:169
+#: wp-admin/edit-form-comment.php:146
+#: wp-admin/includes/class-wp-comments-list-table.php:1014
+#: wp-admin/includes/class-wp-posts-list-table.php:1168
+#: wp-admin/includes/meta-boxes.php:232
+#: wp-admin/includes/meta-boxes.php:439
+msgid "%1$s at %2$s"
+msgstr ""
+
+#. translators: Comment date format. See https://www.php.net/manual/datetime.format.php
+#. translators: Date format in table columns, see https://www.php.net/manual/datetime.format.php
+#. translators: Post date format. See https://www.php.net/manual/datetime.format.php
+#: wp-admin/comment.php:221
+#: wp-admin/includes/ajax-actions.php:2205
+#: wp-admin/includes/class-wp-comments-list-table.php:1016
+#: wp-admin/includes/class-wp-media-list-table.php:539
+#: wp-admin/includes/class-wp-posts-list-table.php:1170
+msgid "Y/m/d"
+msgstr ""
+
+#. translators: Field name in comment form.
+#: wp-admin/comment.php:234
+msgctxt "noun"
+msgid "Comment"
+msgstr ""
+
+#: wp-admin/comment.php:238
+#: wp-admin/edit-form-comment.php:159
+#: wp-admin/includes/class-wp-comments-list-table.php:810
+#: wp-admin/includes/class-wp-links-list-table.php:337
+#: wp-admin/includes/class-wp-media-list-table.php:758
+#: wp-admin/includes/class-wp-media-list-table.php:810
+#: wp-admin/includes/class-wp-posts-list-table.php:440
+#: wp-admin/includes/class-wp-posts-list-table.php:1450
+#: wp-admin/includes/class-wp-terms-list-table.php:477
+#: wp-admin/includes/class-wp-users-list-table.php:472
+#: wp-admin/includes/dashboard.php:759
+#: wp-admin/includes/meta-boxes.php:135
+#: wp-admin/includes/meta-boxes.php:197
+#: wp-admin/includes/meta-boxes.php:292
+#: wp-admin/includes/post.php:1548
+msgid "Edit"
+msgstr ""
+
+#: wp-admin/comment.php:247
+#: wp-admin/includes/class-walker-nav-menu-edit.php:304
+#: wp-admin/includes/class-wp-posts-list-table.php:2046
+#: wp-admin/includes/class-wp-terms-list-table.php:699
+#: wp-admin/includes/dashboard.php:214
+#: wp-admin/includes/file.php:2530
+#: wp-admin/includes/image-edit.php:106
+#: wp-admin/includes/media.php:1676
+#: wp-admin/includes/media.php:2211
+#: wp-admin/includes/meta-boxes.php:166
+#: wp-admin/includes/meta-boxes.php:224
+#: wp-admin/includes/template.php:510
+#: wp-admin/includes/template.php:759
+#: wp-admin/includes/template.php:894
+#: wp-admin/nav-menus.php:1163
+#: wp-admin/options-general.php:254
+#: wp-admin/user-edit.php:555
+#: wp-admin/user-edit.php:705
+#: wp-admin/widgets-form.php:337
+#: wp-admin/widgets-form.php:340
+#: wp-admin/widgets-form.php:545
+#: wp-admin/js/post.js:1028
+msgid "Cancel"
+msgstr ""
+
+#: wp-admin/comment.php:282
+#: wp-admin/edit-comments.php:281
+#: wp-admin/includes/comment.php:55
+msgid "Sorry, you are not allowed to edit comments on this post."
+msgstr ""
+
+#: wp-admin/comment.php:370
+msgid "Unknown action."
+msgstr ""
+
+#. translators: %s: https://www.classicpress.net/contributors
+#: wp-admin/credits.php:54
+msgid "ClassicPress is created by a <a href=\"%1$s\">worldwide team</a> of passionate individuals."
+msgstr ""
+
+#. translators: %s: https://www.classicpress.net/get-involved
+#: wp-admin/credits.php:60
+msgid "Interested in helping out with development? <a href=\"%s\">Get involved in ClassicPress</a>."
+msgstr ""
+
+#: wp-admin/customize.php:17
+#: wp-admin/customize.php:34
+#: wp-admin/edit-comments.php:13
+#: wp-admin/edit-tags.php:28
+#: wp-admin/edit-tags.php:85
+#: wp-admin/edit-tags.php:116
+#: wp-admin/edit-tags.php:136
+#: wp-admin/edit-tags.php:172
+#: wp-admin/edit.php:46
+#: wp-admin/includes/bookmark.php:31
+#: wp-admin/media-upload.php:46
+#: wp-admin/nav-menus.php:25
+#: wp-admin/options.php:50
+#: wp-admin/options.php:83
+#: wp-admin/post-new.php:60
+#: wp-admin/press-this.php:21
+#: wp-admin/term.php:42
+#: wp-admin/themes.php:14
+#: wp-admin/themes.php:42
+#: wp-admin/themes.php:62
+#: wp-admin/user-new.php:15
+#: wp-admin/user-new.php:22
+#: wp-admin/user-new.php:55
+#: wp-admin/user-new.php:188
+#: wp-admin/users.php:15
+#: wp-admin/widgets.php:17
+msgid "You need a higher level of permission."
+msgstr ""
+
+#: wp-admin/customize.php:18
+msgid "Sorry, you are not allowed to customize this site."
+msgstr ""
+
+#: wp-admin/customize.php:35
+msgid "Sorry, you are not allowed to edit this changeset."
+msgstr ""
+
+#: wp-admin/customize.php:71
+msgid "Your scheduled changes just published"
+msgstr ""
+
+#: wp-admin/customize.php:72
+#: wp-admin/customize.php:81
+msgid "Customize New Changes"
+msgstr ""
+
+#: wp-admin/customize.php:79
+#: wp-admin/includes/class-custom-image-header.php:818
+#: wp-admin/includes/class-custom-image-header.php:1004
+#: wp-admin/includes/class-custom-image-header.php:1015
+#: wp-admin/includes/file.php:632
+#: wp-admin/media-upload.php:38
+#: wp-admin/themes.php:27
+#: wp-admin/themes.php:70
+#: wp-admin/users.php:157
+#: wp-admin/js/tags.js:62
+#: wp-admin/js/updates.js:1940
+msgid "Something went wrong."
+msgstr ""
+
+#: wp-admin/customize.php:80
+msgid "This changeset cannot be further modified."
+msgstr ""
+
+#: wp-admin/customize.php:147
+#: wp-admin/includes/class-wp-debug-data.php:411
+#: wp-admin/includes/dashboard.php:1176
+msgid "Loading&hellip;"
+msgstr ""
+
+#: wp-admin/customize.php:189
+#: wp-admin/includes/meta-boxes.php:389
+#: wp-admin/includes/meta-boxes.php:390
+#: wp-admin/includes/meta-boxes.php:1607
+#: wp-admin/js/post.js:795
+msgid "Publish"
+msgstr ""
+
+#: wp-admin/customize.php:189
+msgid "Activate &amp; Publish"
+msgstr ""
+
+#: wp-admin/customize.php:192
+#: wp-admin/customize.php:197
+#: wp-admin/edit-form-advanced.php:392
+msgid "Publish Settings"
+msgstr ""
+
+#: wp-admin/customize.php:195
+#: wp-admin/theme-install.php:386
+#: wp-admin/theme-install.php:448
+#: wp-admin/themes.php:569
+#: wp-admin/themes.php:929
+#: wp-admin/themes.php:1160
+msgctxt "theme"
+msgid "Cannot Activate"
+msgstr ""
+
+#: wp-admin/customize.php:202
+#: wp-admin/includes/class-theme-upgrader-skin.php:92
+#: wp-admin/includes/theme.php:1018
+#: wp-admin/menu.php:207
+#: wp-admin/theme-install.php:375
+#: wp-admin/themes.php:549
+#: wp-admin/themes.php:908
+#: wp-admin/themes.php:1141
+msgid "Customize"
+msgstr ""
+
+#: wp-admin/customize.php:203
+#: wp-admin/includes/class-custom-background.php:265
+#: wp-admin/includes/class-custom-image-header.php:538
+#: wp-admin/includes/class-wp-posts-list-table.php:1500
+#: wp-admin/includes/class-wp-theme-install-list-table.php:346
+#: wp-admin/includes/meta-boxes.php:73
+#: wp-admin/includes/post.php:1837
+#: wp-admin/theme-install.php:378
+#: wp-admin/theme-install.php:391
+#: wp-admin/theme-install.php:401
+#: wp-admin/theme-install.php:408
+#: wp-admin/theme-install.php:565
+msgid "Preview"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/customize.php:209
+msgid "Close the Customizer and go back to the previous page"
+msgstr ""
+
+#. translators: %s: The site/panel title in the Customizer.
+#: wp-admin/customize.php:231
+msgid "You are customizing %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/customize.php:237
+#: wp-admin/includes/class-wp-screen.php:954
+msgid "Help"
+msgstr ""
+
+#: wp-admin/customize.php:244
+msgid "The Customizer allows you to preview changes to your site before publishing them. You can navigate to different pages on your site within the preview. Edit shortcuts are shown for some editable elements. The Customizer is intended for use with non-block themes."
+msgstr ""
+
+#: wp-admin/customize.php:249
+msgid "<a href=\"https://wordpress.org/documentation/article/customizer/\">Documentation on Customizer</a>"
+msgstr ""
+
+#: wp-admin/customize.php:262
+msgctxt "label for hide controls button without length constraints"
+msgid "Hide Controls"
+msgstr ""
+
+#: wp-admin/customize.php:264
+msgctxt "short (~12 characters) label for hide controls button"
+msgid "Hide Controls"
+msgstr ""
+
+#: wp-admin/edit-comments.php:14
+msgid "Sorry, you are not allowed to edit comments."
+msgstr ""
+
+#. translators: 1: Comments count, 2: Post title.
+#: wp-admin/edit-comments.php:156
+msgid "Comments (%1$s) on &#8220;%2$s&#8221;"
+msgstr ""
+
+#. translators: %s: Post title.
+#. translators: %s: Link to post.
+#: wp-admin/edit-comments.php:164
+#: wp-admin/edit-comments.php:233
+msgid "Comments on &#8220;%s&#8221;"
+msgstr ""
+
+#. translators: %s: Comments count.
+#: wp-admin/edit-comments.php:175
+#: wp-admin/js/edit-comments.js:195
+#: wp-admin/js/edit-comments.js:215
+msgid "Comments (%s)"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#. translators: Default privacy policy heading.
+#: wp-admin/edit-comments.php:180
+#: wp-admin/edit-comments.php:241
+#: wp-admin/includes/class-wp-comments-list-table.php:501
+#: wp-admin/includes/class-wp-media-list-table.php:365
+#: wp-admin/includes/class-wp-media-list-table.php:367
+#: wp-admin/includes/class-wp-posts-list-table.php:711
+#: wp-admin/includes/class-wp-posts-list-table.php:713
+#: wp-admin/includes/class-wp-posts-list-table.php:1881
+#: wp-admin/includes/class-wp-privacy-policy-content.php:475
+#: wp-admin/includes/file.php:20
+#: wp-admin/includes/meta-boxes.php:1699
+#: wp-admin/js/edit-comments.js:220
+msgid "Comments"
+msgstr ""
+
+#: wp-admin/edit-comments.php:191
+msgid "You can manage comments made on your site similar to the way you manage posts and other content. This screen is customizable in the same ways as other management screens, and you can act on comments using the on-hover action links or the bulk actions."
+msgstr ""
+
+#: wp-admin/edit-comments.php:197
+msgid "Moderating Comments"
+msgstr ""
+
+#: wp-admin/edit-comments.php:199
+msgid "A red bar on the left means the comment is waiting for you to moderate it."
+msgstr ""
+
+#: wp-admin/edit-comments.php:200
+msgid "In the <strong>Author</strong> column, in addition to the author&#8217;s name, email address, and blog URL, the commenter&#8217;s IP address is shown. Clicking on this link will show you all the comments made from this IP address."
+msgstr ""
+
+#: wp-admin/edit-comments.php:201
+msgid "In the <strong>Comment</strong> column, hovering over any comment gives you options to approve, reply (and approve), quick edit, edit, spam mark, or trash that comment."
+msgstr ""
+
+#: wp-admin/edit-comments.php:202
+msgid "In the <strong>In response to</strong> column, there are three elements. The text is the name of the post that inspired the comment, and links to the post editor for that entry. The View Post link leads to that post on your live site. The small bubble with the number in it shows the number of approved comments that post has received. If there are pending comments, a red notification circle with the number of pending comments is displayed. Clicking the notification circle will filter the comments screen to show only pending comments on that post."
+msgstr ""
+
+#: wp-admin/edit-comments.php:203
+msgid "In the <strong>Submitted on</strong> column, the date and time the comment was left on your site appears. Clicking on the date/time link will take you to that comment on your live site."
+msgstr ""
+
+#: wp-admin/edit-comments.php:204
+msgid "Many people take advantage of keyboard shortcuts to moderate their comments more quickly. Use the link to the side to learn more."
+msgstr ""
+
+#: wp-admin/edit-comments.php:211
+msgid "<a href=\"https://wordpress.org/documentation/article/understand-comment-spam/\">Documentation on Comment Spam</a>"
+msgstr ""
+
+#: wp-admin/edit-comments.php:212
+#: wp-admin/user-edit.php:349
+msgid "<a href=\"https://wordpress.org/documentation/article/keyboard-shortcuts-classic-editor/#keyboard-shortcuts-for-comments\">Documentation on Keyboard Shortcuts</a>"
+msgstr ""
+
+#: wp-admin/edit-comments.php:218
+msgid "Filter comments list"
+msgstr ""
+
+#: wp-admin/edit-comments.php:219
+msgid "Comments list navigation"
+msgstr ""
+
+#: wp-admin/edit-comments.php:220
+msgid "Comments list"
+msgstr ""
+
+#. translators: %s: Search query.
+#: wp-admin/edit-comments.php:263
+#: wp-admin/edit-tags.php:342
+#: wp-admin/edit.php:407
+#: wp-admin/link-manager.php:111
+#: wp-admin/plugins.php:737
+#: wp-admin/upload.php:381
+#: wp-admin/users.php:638
+#: wp-admin/js/updates.js:2665
+msgid "Search results for: %s"
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:301
+msgid "%s comment approved."
+msgid_plural "%s comments approved."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:307
+msgid "%s comment marked as spam."
+msgid_plural "%s comments marked as spam."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:307
+#: wp-admin/edit-comments.php:318
+#: wp-admin/edit.php:428
+#: wp-admin/includes/image-edit.php:88
+#: wp-admin/includes/media.php:1680
+#: wp-admin/includes/template.php:554
+#: wp-admin/includes/template.php:563
+#: wp-admin/upload.php:71
+#: wp-admin/upload.php:92
+msgid "Undo"
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:312
+msgid "%s comment restored from the spam."
+msgid_plural "%s comments restored from the spam."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:318
+msgid "%s comment moved to the Trash."
+msgid_plural "%s comments moved to the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:323
+msgid "%s comment restored from the Trash."
+msgid_plural "%s comments restored from the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/edit-comments.php:328
+msgid "%s comment permanently deleted."
+msgid_plural "%s comments permanently deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/edit-comments.php:336
+msgid "This comment is already approved."
+msgstr ""
+
+#: wp-admin/edit-comments.php:336
+#: wp-admin/edit-comments.php:342
+msgid "Edit comment"
+msgstr ""
+
+#: wp-admin/edit-comments.php:339
+msgid "This comment is already in the Trash."
+msgstr ""
+
+#: wp-admin/edit-comments.php:339
+msgid "View Trash"
+msgstr ""
+
+#: wp-admin/edit-comments.php:342
+msgid "This comment is already marked as spam."
+msgstr ""
+
+#: wp-admin/edit-comments.php:357
+msgid "Search Comments"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:127
+#: wp-admin/edit-form-advanced.php:134
+msgid "Preview post"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:141
+msgid "View post"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:148
+#: wp-admin/edit-form-advanced.php:155
+msgid "Preview page"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:162
+msgid "View page"
+msgstr ""
+
+#. translators: Publish box date format, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/edit-form-advanced.php:171
+#: wp-admin/edit-form-comment.php:148
+#: wp-admin/includes/meta-boxes.php:234
+#: wp-admin/includes/meta-boxes.php:441
+msgctxt "publish box date format"
+msgid "M j, Y"
+msgstr ""
+
+#. translators: Publish box time format, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/edit-form-advanced.php:173
+#: wp-admin/edit-form-comment.php:150
+#: wp-admin/includes/meta-boxes.php:236
+#: wp-admin/includes/meta-boxes.php:443
+msgctxt "publish box time format"
+msgid "H:i"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:178
+#: wp-admin/edit-form-advanced.php:181
+msgid "Post updated."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:179
+#: wp-admin/edit-form-advanced.php:194
+msgid "Custom field updated."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:180
+#: wp-admin/edit-form-advanced.php:195
+msgid "Custom field deleted."
+msgstr ""
+
+#. translators: %s: Date and time of the revision.
+#: wp-admin/edit-form-advanced.php:183
+msgid "Post restored to revision from %s."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:184
+msgid "Post published."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:185
+msgid "Post saved."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:186
+msgid "Post submitted."
+msgstr ""
+
+#. translators: %s: Scheduled date for the post.
+#: wp-admin/edit-form-advanced.php:188
+msgid "Post scheduled for: %s."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:189
+msgid "Post draft updated."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:193
+#: wp-admin/edit-form-advanced.php:196
+msgid "Page updated."
+msgstr ""
+
+#. translators: %s: Date and time of the revision.
+#: wp-admin/edit-form-advanced.php:198
+msgid "Page restored to revision from %s."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:199
+msgid "Page published."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:200
+msgid "Page saved."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:201
+msgid "Page submitted."
+msgstr ""
+
+#. translators: %s: Scheduled date for the page.
+#: wp-admin/edit-form-advanced.php:203
+msgid "Page scheduled for: %s."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:204
+msgid "Page draft updated."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:206
+#: wp-admin/media.php:109
+#: wp-admin/upload.php:18
+#: wp-admin/upload.php:89
+msgid "Media file updated."
+msgstr ""
+
+#. translators: %s: URL to view the autosave.
+#: wp-admin/edit-form-advanced.php:249
+msgid "There is an autosave of this post that is more recent than the version below. <a href=\"%s\">View the autosave</a>"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:278
+msgid "The title field and the big Post Editing Area are fixed in place, but you can reposition all the other boxes using drag and drop. You can also minimize or expand them by clicking the title bar of each box. Use the Screen Options tab to unhide more boxes (Excerpt, Send Trackbacks, Custom Fields, Discussion, Slug, Author) or to choose a 1- or 2-column layout for this screen."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:283
+msgid "Customizing This Display"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:288
+msgid "<strong>Title</strong> &mdash; Enter a title for your post. After you enter a title, you&#8217;ll see the permalink below, which you can edit."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:289
+msgid "<strong>Post editor</strong> &mdash; Enter the text for your post. There are two modes of editing: Visual and Text. Choose the mode by clicking on the appropriate tab."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:290
+msgid "Visual mode gives you an editor that is similar to a word processor. Click the Toolbar Toggle button to get a second row of controls."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:291
+msgid "The Text mode allows you to enter HTML along with your post text. Note that &lt;p&gt; and &lt;br&gt; tags are converted to line breaks when switching to the Text editor to make it less cluttered. When you type, a single line break can be used instead of typing &lt;br&gt;, and two line breaks instead of paragraph tags. The line breaks are converted back to tags automatically."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:292
+msgid "You can insert media files by clicking the button above the post editor and following the directions. You can align or edit images using the inline formatting toolbar available in Visual mode."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:293
+msgid "You can enable distraction-free writing mode using the icon to the right. This feature is not available for old browsers or devices with small screens, and requires that the full-height editor be enabled in Screen Options."
+msgstr ""
+
+#. translators: %s: Alt + F10
+#: wp-admin/edit-form-advanced.php:296
+msgid "Keyboard users: When you are working in the visual editor, you can use %s to access the toolbar."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:303
+msgid "Title and Post Editor"
+msgstr ""
+
+#. translators: %s: URL to Press This bookmarklet.
+#: wp-admin/edit-form-advanced.php:311
+msgid "You can also create posts with the <a href=\"%s\">Press This bookmarklet</a>."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:315
+msgid "<a href=\"https://wordpress.org/documentation/article/write-posts-classic-editor/\">Documentation on Writing and Editing Posts</a>"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:319
+#: wp-admin/edit.php:302
+msgid "Pages are similar to posts in that they have a title, body text, and associated metadata, but they are different in that they are not part of the chronological blog stream, kind of like permanent posts. Pages are not categorized or tagged, but can have a hierarchy. You can nest pages under other pages by making one the &#8220;Parent&#8221; of the other, creating a group of pages."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:320
+msgid "Creating a Page is very similar to creating a Post, and the screens can be customized in the same way using drag and drop, the Screen Options tab, and expanding/collapsing boxes as you choose. This screen also has the distraction-free writing space, available in both the Visual and Text modes via the Fullscreen buttons. The Page editor mostly works the same as the Post editor, but there are some Page-specific features in the Page Attributes box."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:325
+msgid "About Pages"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:332
+msgid "<a href=\"https://wordpress.org/documentation/article/pages-add-new-screen/\">Documentation on Adding New Pages</a>"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:333
+msgid "<a href=\"https://wordpress.org/documentation/article/pages-screen/\">Documentation on Editing Pages</a>"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:342
+#: wp-admin/media.php:88
+msgid "This screen allows you to edit fields for metadata in a file within the media library."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:343
+#: wp-admin/media.php:89
+msgid "For images only, you can click on Edit Image under the thumbnail to expand out an inline image editor with icons for cropping, rotating, or flipping the image as well as for undoing and redoing. The boxes on the right give you more options for scaling the image, for cropping it, and for cropping the thumbnail in a different way than you crop the original image. You can click on Help in those boxes to get more information."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:344
+#: wp-admin/media.php:90
+msgid "Note that you crop the image by clicking on it (the Crop icon is already selected) and dragging the cropping frame to select the desired part. Then click Save to retain the cropping."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:345
+#: wp-admin/media.php:91
+msgid "Remember to click Update to save metadata entered or changed."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:351
+#: wp-admin/media.php:97
+msgid "<a href=\"https://wordpress.org/documentation/article/edit-media/\">Documentation on Edit Media</a>"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:357
+msgid "You can upload and insert media (images, audio, documents, etc.) by clicking the Add Media button. You can select from the images and files already uploaded to the Media Library, or upload new media to add to your page or post. To create an image gallery, select the images to add and click the &#8220;Create a new gallery&#8221; button."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:358
+msgid "You can also embed media from many popular websites including Twitter, YouTube, Flickr and others by pasting the media URL on its own line into the content of your post/page. <a href=\"https://wordpress.org/documentation/article/embeds/\">Learn more about embeds</a>."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:363
+msgid "Inserting Media"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:370
+msgid "Several boxes on this screen contain settings for how your content will be published, including:"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:372
+msgid "<strong>Publish</strong> &mdash; You can set the terms of publishing your post in the Publish box. For Status, Visibility, and Publish (immediately), click on the Edit link to reveal more options. Visibility includes options for password-protecting a post or making it stay at the top of your blog indefinitely (sticky). The Password protected option allows you to set an arbitrary password for each post. The Private option hides the post from everyone except editors and administrators. Publish (immediately) allows you to set a future or past date and time, so you can schedule a post to be published in the future or backdate a post."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:376
+msgid "<strong>Format</strong> &mdash; Post Formats designate how your theme will display a specific post. For example, you could have a <em>standard</em> blog post with a title and paragraphs, or a short <em>aside</em> that omits the title and contains a short text blurb. Your theme could enable all or some of 10 possible formats. <a href=\"https://wordpress.org/documentation/article/post-formats/#supported-formats\">Learn more about each post format</a>."
+msgstr ""
+
+#. translators: %s: Featured image.
+#: wp-admin/edit-form-advanced.php:382
+msgid "<strong>%s</strong> &mdash; This allows you to associate an image with your post without inserting it. This is usually useful only if your theme makes use of the image as a post thumbnail on the home page, a custom header, etc."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:397
+msgid "<strong>Send Trackbacks</strong> &mdash; Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. Enter the URL(s) you want to send trackbacks. If you link to other WordPress sites they&#8217;ll be notified automatically using pingbacks, and this field is unnecessary."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:398
+msgid "<strong>Discussion</strong> &mdash; You can turn comments and pings on or off, and if there are comments on the post, you can see them here and moderate them."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:403
+#: wp-admin/options-discussion.php:16
+msgid "Discussion Settings"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:408
+msgid "<strong>Parent</strong> &mdash; You can arrange your pages in hierarchies. For example, you could have an &#8220;About&#8221; page that has &#8220;Life Story&#8221; and &#8220;My Dog&#8221; pages under it. There are no limits to how many levels you can nest pages."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:409
+msgid "<strong>Template</strong> &mdash; Some themes have custom templates you can use for certain pages that might have additional features or custom layouts. If so, you&#8217;ll see them in this dropdown menu."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:410
+msgid "<strong>Order</strong> &mdash; Pages are usually ordered alphabetically, but you can choose your own order by entering a number (1 for first, etc.) in this field."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:415
+msgid "Page Attributes"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:457
+msgctxt "Admin Post Navigation"
+msgid "Previous post: "
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:459
+msgctxt "Admin Post Navigation"
+msgid "&larr; Previous"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:467
+msgctxt "Admin Post Navigation"
+msgid "Next post: "
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:469
+msgctxt "Admin Post Navigation"
+msgid "Next &rarr;"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:486
+msgid "<strong>Connection lost.</strong> Saving has been disabled until you are reconnected."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:487
+msgid "This post is being backed up in your browser, just in case."
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:555
+msgid "Add title"
+msgstr ""
+
+#: wp-admin/edit-form-advanced.php:582
+msgid "Get Shortlink"
+msgstr ""
+
+#. translators: %s: Number of words.
+#: wp-admin/edit-form-advanced.php:650
+msgid "Word count: %s"
+msgstr ""
+
+#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
+#. translators: 1: User's display name, 2: Date of last edit, 3: Time of last edit.
+#: wp-admin/edit-form-advanced.php:663
+#: wp-admin/includes/ajax-actions.php:2813
+msgid "Last edited by %1$s on %2$s at %3$s"
+msgstr ""
+
+#. translators: 1: Post edited date, 2: Post edited time.
+#. translators: 1: Date of last edit, 2: Time of last edit.
+#: wp-admin/edit-form-advanced.php:666
+#: wp-admin/includes/ajax-actions.php:2816
+msgid "Last edited on %1$s at %2$s"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:37
+msgctxt "comment"
+msgid "Permalink:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-form-comment.php:53
+msgid "Comment Author"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:59
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:28
+#: wp-admin/includes/class-wp-debug-data.php:1086
+#: wp-admin/includes/class-wp-debug-data.php:1181
+#: wp-admin/includes/class-wp-users-list-table.php:374
+#: wp-admin/includes/template.php:488
+#: wp-admin/user-edit.php:428
+msgid "Name"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-form-comment.php:84
+#: wp-admin/includes/template.php:469
+msgid "Comment"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:105
+#: wp-admin/edit-link-form.php:30
+#: wp-admin/includes/image-edit.php:107
+#: wp-admin/includes/meta-boxes.php:44
+#: wp-admin/includes/meta-boxes.php:429
+#: wp-admin/includes/meta-boxes.php:1118
+#: wp-admin/includes/meta-boxes.php:1600
+#: wp-admin/includes/widgets.php:277
+#: wp-admin/js/widgets.js:202
+#: wp-admin/js/widgets.js:429
+#: wp-admin/js/widgets/custom-html-widgets.js:261
+msgid "Save"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:113
+#: wp-admin/export.php:234
+#: wp-admin/export.php:286
+#: wp-admin/includes/meta-boxes.php:104
+msgid "Status:"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:117
+msgid "Approved"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:120
+msgid "Pending"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:123
+msgid "Spam"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-form-comment.php:133
+msgid "Comment status"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:136
+msgctxt "comment status"
+msgid "Approved"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:137
+msgctxt "comment status"
+msgid "Pending"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:138
+msgctxt "comment status"
+msgid "Spam"
+msgstr ""
+
+#. translators: %s: Comment date.
+#: wp-admin/edit-form-comment.php:156
+msgid "Submitted on: %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-form-comment.php:162
+#: wp-admin/includes/meta-boxes.php:296
+msgid "Edit date and time"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-form-comment.php:169
+#: wp-admin/includes/meta-boxes.php:304
+msgid "Date and time"
+msgstr ""
+
+#. translators: %s: Post link.
+#: wp-admin/edit-form-comment.php:197
+msgid "In response to: %s"
+msgstr ""
+
+#. translators: %s: Comment link.
+#: wp-admin/edit-form-comment.php:214
+msgid "In reply to: %s"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:242
+#: wp-admin/includes/class-wp-comments-list-table.php:793
+#: wp-admin/includes/class-wp-media-list-table.php:779
+#: wp-admin/includes/class-wp-media-list-table.php:841
+#: wp-admin/includes/class-wp-posts-list-table.php:1486
+#: wp-admin/includes/dashboard.php:785
+#: wp-admin/includes/media.php:1669
+msgid "Delete Permanently"
+msgstr ""
+
+#: wp-admin/edit-form-comment.php:245
+#: wp-admin/edit-tag-form.php:298
+#: wp-admin/includes/class-wp-plugins-list-table.php:608
+#: wp-admin/includes/class-wp-posts-list-table.php:2041
+#: wp-admin/includes/class-wp-posts-list-table.php:2043
+#: wp-admin/includes/class-wp-theme-install-list-table.php:318
+#: wp-admin/includes/class-wp-theme-install-list-table.php:477
+#: wp-admin/includes/meta-boxes.php:401
+#: wp-admin/includes/meta-boxes.php:402
+#: wp-admin/includes/meta-boxes.php:483
+#: wp-admin/includes/meta-boxes.php:484
+#: wp-admin/includes/template.php:662
+#: wp-admin/media.php:137
+#: wp-admin/media.php:157
+#: wp-admin/js/post.js:798
+#: wp-admin/js/post.js:821
+msgid "Update"
+msgstr ""
+
+#. translators: %s: URL to Links screen.
+#: wp-admin/edit-link-form.php:16
+msgid "<a href=\"%s\">Links</a> / Edit Link"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:17
+#: wp-admin/includes/meta-boxes.php:1159
+msgid "Update Link"
+msgstr ""
+
+#. translators: %s: URL to Links screen.
+#: wp-admin/edit-link-form.php:22
+msgid "<a href=\"%s\">Links</a> / Add New Link"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:23
+#: wp-admin/includes/meta-boxes.php:1161
+msgid "Add Link"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:31
+#: wp-admin/includes/class-wp-links-list-table.php:134
+msgid "Categories"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-link-form.php:32
+#: wp-admin/includes/meta-boxes.php:1244
+msgid "Target"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:33
+#: wp-admin/includes/class-walker-nav-menu-edit.php:226
+#: wp-admin/includes/nav-menu.php:1128
+msgid "Link Relationship (XFN)"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:34
+msgid "Advanced"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:68
+msgid "You can add or edit links on this screen by entering information in each of the boxes. Only the link&#8217;s web address and name (the text you want to display on your site as the link) are required fields."
+msgstr ""
+
+#: wp-admin/edit-link-form.php:69
+msgid "The boxes for link name, web address, and description have fixed positions, while the others may be repositioned using drag and drop. You can also hide boxes you do not use in the Screen Options tab, or minimize boxes by clicking on the title bar of the box."
+msgstr ""
+
+#: wp-admin/edit-link-form.php:70
+msgid "XFN stands for <a href=\"https://gmpg.org/xfn/\">XHTML Friends Network</a>, which is optional. ClassicPress allows the generation of XFN attributes to show how you are related to the authors/owners of the site to which you are linking."
+msgstr ""
+
+#: wp-admin/edit-link-form.php:76
+msgid "<a href=\"https://codex.wordpress.org/Links_Add_New_Screen\">Documentation on Creating Links</a>"
+msgstr ""
+
+#. translators: Add new links.
+#: wp-admin/edit-link-form.php:90
+#: wp-admin/link-manager.php:104
+#: wp-admin/menu.php:83
+msgctxt "link"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:95
+msgid "Link added."
+msgstr ""
+
+#: wp-admin/edit-link-form.php:114
+#: wp-admin/includes/class-wp-links-list-table.php:132
+msgctxt "link name"
+msgid "Name"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:117
+msgid "Example: Nifty blogging software"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:122
+msgid "Web Address"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:125
+msgid "Example: <code>https://www.classicpress.net</code> &#8212; do not forget the <code>https://</code>"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:130
+#: wp-admin/edit-tag-form.php:203
+#: wp-admin/edit-tags.php:511
+#: wp-admin/includes/class-walker-nav-menu-edit.php:232
+#: wp-admin/includes/class-wp-plugins-list-table.php:462
+#: wp-admin/includes/class-wp-terms-list-table.php:193
+#: wp-admin/includes/media.php:1401
+#: wp-admin/includes/media.php:3198
+#: wp-admin/includes/nav-menu.php:1129
+#: wp-admin/themes.php:603
+msgid "Description"
+msgstr ""
+
+#: wp-admin/edit-link-form.php:133
+msgid "This will be shown when someone hovers over the link in the blogroll, or optionally below the link."
+msgstr ""
+
+#: wp-admin/edit-tag-form.php:147
+#: wp-admin/edit-tags.php:453
+#: wp-admin/includes/class-wp-terms-list-table.php:192
+#: wp-admin/includes/class-wp-terms-list-table.php:665
+msgctxt "term name"
+msgid "Name"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/edit-tag-form.php:152
+#: wp-admin/edit-tags.php:458
+#: wp-admin/includes/class-wp-posts-list-table.php:1645
+#: wp-admin/includes/class-wp-terms-list-table.php:194
+#: wp-admin/includes/class-wp-terms-list-table.php:670
+#: wp-admin/includes/meta-boxes.php:953
+#: wp-admin/includes/meta-boxes.php:1704
+msgid "Slug"
+msgstr ""
+
+#: wp-admin/edit-tag-form.php:186
+#: wp-admin/edit-tags.php:473
+#: wp-admin/includes/class-wp-debug-data.php:1080
+#: wp-admin/includes/media.php:1151
+#: wp-admin/includes/media.php:1279
+#: wp-admin/includes/media.php:2911
+#: wp-admin/includes/media.php:2927
+msgid "None"
+msgstr ""
+
+#: wp-admin/edit-tag-form.php:195
+#: wp-admin/edit-tags.php:504
+msgid "Categories, unlike tags, can have a hierarchy. You might have a Jazz category, and under that have children categories for Bebop and Big Band. Totally optional."
+msgstr ""
+
+#: wp-admin/edit-tag-form.php:302
+#: wp-admin/includes/class-wp-links-list-table.php:87
+#: wp-admin/includes/class-wp-links-list-table.php:343
+#: wp-admin/includes/class-wp-plugins-list-table.php:612
+#: wp-admin/includes/class-wp-plugins-list-table.php:823
+#: wp-admin/includes/class-wp-plugins-list-table.php:884
+#: wp-admin/includes/class-wp-terms-list-table.php:169
+#: wp-admin/includes/class-wp-terms-list-table.php:493
+#: wp-admin/includes/class-wp-themes-list-table.php:232
+#: wp-admin/includes/class-wp-users-list-table.php:280
+#: wp-admin/includes/class-wp-users-list-table.php:481
+#: wp-admin/includes/media.php:1671
+#: wp-admin/includes/meta-boxes.php:1151
+#: wp-admin/includes/template.php:660
+#: wp-admin/includes/theme.php:1022
+#: wp-admin/includes/widgets.php:271
+#: wp-admin/themes.php:651
+#: wp-admin/themes.php:1171
+#: wp-admin/widgets-form.php:335
+msgid "Delete"
+msgstr ""
+
+#: wp-admin/edit-tags.php:13
+#: wp-admin/edit-tags.php:19
+#: wp-admin/includes/class-wp-terms-list-table.php:57
+msgid "Invalid taxonomy."
+msgstr ""
+
+#: wp-admin/edit-tags.php:23
+msgid "Sorry, you are not allowed to edit terms in this taxonomy."
+msgstr ""
+
+#: wp-admin/edit-tags.php:29
+msgid "Sorry, you are not allowed to manage terms in this taxonomy."
+msgstr ""
+
+#: wp-admin/edit-tags.php:86
+msgid "Sorry, you are not allowed to create terms in this taxonomy."
+msgstr ""
+
+#: wp-admin/edit-tags.php:117
+#: wp-admin/edit.php:176
+#: wp-admin/post.php:319
+#: wp-admin/themes.php:63
+#: wp-admin/upload.php:283
+msgid "Sorry, you are not allowed to delete this item."
+msgstr ""
+
+#: wp-admin/edit-tags.php:137
+#: wp-admin/options.php:84
+msgid "Sorry, you are not allowed to delete these items."
+msgstr ""
+
+#: wp-admin/edit-tags.php:160
+#: wp-admin/edit-tags.php:180
+#: wp-admin/post.php:127
+#: wp-admin/term.php:31
+msgid "You attempted to edit an item that does not exist. Perhaps it was deleted?"
+msgstr ""
+
+#: wp-admin/edit-tags.php:173
+#: wp-admin/includes/class-wp-screen.php:288
+#: wp-admin/includes/post.php:2037
+#: wp-admin/media-upload.php:47
+#: wp-admin/post.php:20
+#: wp-admin/post.php:47
+#: wp-admin/post.php:139
+#: wp-admin/term.php:43
+msgid "Sorry, you are not allowed to edit this item."
+msgstr ""
+
+#. translators: %s: URL to Writing Settings screen.
+#: wp-admin/edit-tags.php:250
+msgid "You can use categories to define sections of your site and group related posts. The default category is &#8220;Uncategorized&#8221; until you change it in your <a href=\"%s\">writing settings</a>."
+msgstr ""
+
+#: wp-admin/edit-tags.php:254
+msgid "You can create groups of links by using Link Categories. Link Category names must be unique and Link Categories are separate from the categories you use for posts."
+msgstr ""
+
+#: wp-admin/edit-tags.php:256
+msgid "You can assign keywords to your posts using <strong>tags</strong>. Unlike categories, tags have no hierarchy, meaning there is no relationship from one tag to another."
+msgstr ""
+
+#: wp-admin/edit-tags.php:260
+msgid "You can delete Link Categories in the Bulk Action pull-down, but that action does not delete the links within the category. Instead, it moves them to the default Link Category."
+msgstr ""
+
+#: wp-admin/edit-tags.php:262
+msgid "What&#8217;s the difference between categories and tags? Normally, tags are ad-hoc keywords that identify important information in your post (names, subjects, etc) that may or may not recur in other posts, while categories are pre-determined sections. If you think of your site like a book, the categories are like the Table of Contents and the tags are like the terms in the index."
+msgstr ""
+
+#: wp-admin/edit-tags.php:275
+msgid "When adding a new category on this screen, you&#8217;ll fill in the following fields:"
+msgstr ""
+
+#: wp-admin/edit-tags.php:277
+msgid "When adding a new tag on this screen, you&#8217;ll fill in the following fields:"
+msgstr ""
+
+#: wp-admin/edit-tags.php:281
+msgid "<strong>Name</strong> &mdash; The name is how it appears on your site."
+msgstr ""
+
+#: wp-admin/edit-tags.php:283
+msgid "<strong>Slug</strong> &mdash; The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens."
+msgstr ""
+
+#: wp-admin/edit-tags.php:286
+msgid "<strong>Parent</strong> &mdash; Categories, unlike tags, can have a hierarchy. You might have a Jazz category, and under that have child categories for Bebop and Big Band. Totally optional. To create a subcategory, just choose another category from the Parent dropdown."
+msgstr ""
+
+#: wp-admin/edit-tags.php:289
+msgid "<strong>Description</strong> &mdash; The description is not prominent by default; however, some themes may display it."
+msgstr ""
+
+#: wp-admin/edit-tags.php:291
+msgid "You can change the display of this screen using the Screen Options tab to set how many items are displayed per screen and to display/hide columns in the table."
+msgstr ""
+
+#: wp-admin/edit-tags.php:296
+msgid "Adding Categories"
+msgstr ""
+
+#: wp-admin/edit-tags.php:296
+msgid "Adding Tags"
+msgstr ""
+
+#: wp-admin/edit-tags.php:305
+msgid "<a href=\"https://wordpress.org/documentation/article/posts-categories-screen/\">Documentation on Categories</a>"
+msgstr ""
+
+#: wp-admin/edit-tags.php:307
+msgid "<a href=\"https://codex.wordpress.org/Links_Link_Categories_Screen\">Documentation on Link Categories</a>"
+msgstr ""
+
+#: wp-admin/edit-tags.php:309
+msgid "<a href=\"https://wordpress.org/documentation/article/posts-tags-screen/\">Documentation on Tags</a>"
+msgstr ""
+
+#. translators: %s: Default category.
+#: wp-admin/edit-tags.php:621
+msgid "Deleting a category does not delete the posts in that category. Instead, posts that were only assigned to the deleted category are set to the default category %s. The default category cannot be deleted."
+msgstr ""
+
+#. translators: %s: URL to Categories to Tags Converter tool.
+#: wp-admin/edit-tags.php:632
+msgid "Categories can be selectively converted to tags using the <a href=\"%s\">category to tag converter</a>."
+msgstr ""
+
+#. translators: %s: URL to Categories to Tags Converter tool.
+#: wp-admin/edit-tags.php:645
+msgid "Tags can be selectively converted to categories using the <a href=\"%s\">tag to category converter</a>."
+msgstr ""
+
+#: wp-admin/edit.php:22
+#: wp-admin/edit.php:47
+#: wp-admin/post.php:135
+msgid "Sorry, you are not allowed to edit posts in this post type."
+msgstr ""
+
+#: wp-admin/edit.php:123
+#: wp-admin/post.php:253
+#: wp-admin/upload.php:247
+msgid "Sorry, you are not allowed to move this item to the Trash."
+msgstr ""
+
+#: wp-admin/edit.php:132
+#: wp-admin/post.php:264
+#: wp-admin/upload.php:251
+msgid "Error in moving the item to Trash."
+msgstr ""
+
+#: wp-admin/edit.php:156
+#: wp-admin/post.php:290
+#: wp-admin/upload.php:268
+msgid "Sorry, you are not allowed to restore this item from the Trash."
+msgstr ""
+
+#: wp-admin/edit.php:160
+#: wp-admin/post.php:294
+#: wp-admin/upload.php:272
+msgid "Error in restoring the item from Trash."
+msgstr ""
+
+#: wp-admin/edit.php:181
+#: wp-admin/post.php:325
+#: wp-admin/upload.php:287
+msgid "Error in deleting the attachment."
+msgstr ""
+
+#: wp-admin/edit.php:185
+#: wp-admin/post.php:329
+msgid "Error in deleting the item."
+msgstr ""
+
+#: wp-admin/edit.php:249
+msgid "This screen provides access to all of your posts. You can customize the display of this screen to suit your workflow."
+msgstr ""
+
+#: wp-admin/edit.php:255
+#: wp-admin/users.php:43
+msgid "Screen Content"
+msgstr ""
+
+#: wp-admin/edit.php:257
+msgid "You can customize the display of this screen&#8217;s contents in a number of ways:"
+msgstr ""
+
+#: wp-admin/edit.php:259
+msgid "You can hide/display columns based on your needs and decide how many posts to list per screen using the Screen Options tab."
+msgstr ""
+
+#: wp-admin/edit.php:260
+msgid "You can filter the list of posts by post status using the text links above the posts list to only show posts with that status. The default view is to show all posts."
+msgstr ""
+
+#: wp-admin/edit.php:261
+msgid "You can view posts in a simple title list or with an excerpt using the Screen Options tab."
+msgstr ""
+
+#: wp-admin/edit.php:262
+msgid "You can refine the list to show only posts in a specific category or from a specific month by using the dropdown menus above the posts list. Click the Filter button after making your selection. You also can refine the list by clicking on the post author, category or tag in the posts list."
+msgstr ""
+
+#: wp-admin/edit.php:269
+#: wp-admin/upload.php:329
+#: wp-admin/users.php:74
+msgid "Available Actions"
+msgstr ""
+
+#: wp-admin/edit.php:271
+msgid "Hovering over a row in the posts list will display action links that allow you to manage your post. You can perform the following actions:"
+msgstr ""
+
+#: wp-admin/edit.php:273
+msgid "<strong>Edit</strong> takes you to the editing screen for that post. You can also reach that screen by clicking on the post title."
+msgstr ""
+
+#: wp-admin/edit.php:274
+msgid "<strong>Quick Edit</strong> provides inline access to the metadata of your post, allowing you to update post details without leaving this screen."
+msgstr ""
+
+#: wp-admin/edit.php:275
+msgid "<strong>Trash</strong> removes your post from this list and places it in the Trash, from which you can permanently delete it."
+msgstr ""
+
+#: wp-admin/edit.php:276
+msgid "<strong>Preview</strong> will show you what your draft post will look like if you publish it. View will take you to your live site to view the post. Which link is available depends on your post&#8217;s status."
+msgstr ""
+
+#: wp-admin/edit.php:283
+#: wp-admin/includes/class-wp-list-table.php:568
+msgid "Bulk actions"
+msgstr ""
+
+#: wp-admin/edit.php:285
+msgid "You can also edit or move multiple posts to the Trash at once. Select the posts you want to act on using the checkboxes, then select the action you want to take from the Bulk actions menu and click Apply."
+msgstr ""
+
+#: wp-admin/edit.php:286
+msgid "When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the x next to its name in the Bulk Edit area that appears."
+msgstr ""
+
+#: wp-admin/edit.php:292
+msgid "<a href=\"https://wordpress.org/documentation/article/posts-screen/\">Documentation on Managing Posts</a>"
+msgstr ""
+
+#: wp-admin/edit.php:308
+msgid "Managing Pages"
+msgstr ""
+
+#: wp-admin/edit.php:310
+msgid "Managing pages is very similar to managing posts, and the screens can be customized in the same way."
+msgstr ""
+
+#: wp-admin/edit.php:311
+msgid "You can also perform the same types of actions, including narrowing the list by using the filters, acting on a page using the action links that appear when you hover over a row, or using the Bulk actions menu to edit the metadata for multiple pages at once."
+msgstr ""
+
+#: wp-admin/edit.php:317
+msgid "<a href=\"https://wordpress.org/documentation/article/pages-screen/\">Documentation on Managing Pages</a>"
+msgstr ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/edit.php:350
+msgid "%s post updated."
+msgid_plural "%s posts updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/edit.php:351
+msgid "1 post not updated, somebody is editing it."
+msgstr ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/edit.php:353
+msgid "%s post not updated, somebody is editing it."
+msgid_plural "%s posts not updated, somebody is editing them."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/edit.php:355
+msgid "%s post permanently deleted."
+msgid_plural "%s posts permanently deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/edit.php:357
+msgid "%s post moved to the Trash."
+msgid_plural "%s posts moved to the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/edit.php:359
+msgid "%s post restored from the Trash."
+msgid_plural "%s posts restored from the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/edit.php:363
+msgid "%s page updated."
+msgid_plural "%s pages updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/edit.php:364
+msgid "1 page not updated, somebody is editing it."
+msgstr ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/edit.php:366
+msgid "%s page not updated, somebody is editing it."
+msgid_plural "%s pages not updated, somebody is editing them."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/edit.php:368
+msgid "%s page permanently deleted."
+msgid_plural "%s pages permanently deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/edit.php:370
+msgid "%s page moved to the Trash."
+msgid_plural "%s pages moved to the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/edit.php:372
+msgid "%s page restored from the Trash."
+msgid_plural "%s pages restored from the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/erase-personal-data.php:13
+msgid "Sorry, you are not allowed to erase personal data on this site."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:17
+#: wp-admin/erase-personal-data.php:107
+#: wp-admin/menu.php:327
+msgid "Erase Personal Data"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:25
+msgid "This screen is where you manage requests to erase personal data."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:26
+msgid "Privacy Laws around the world require businesses and online services to delete, anonymize, or forget the data they collect about an individual. The rights those laws enshrine are sometimes called the \"Right to be Forgotten\"."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:27
+#: wp-admin/export-personal-data.php:27
+msgid "The tool associates data stored in ClassicPress with a supplied email address, including profile data and comments."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:28
+msgid "Note: As this tool only gathers data from ClassicPress and participating plugins, you may need to do more to comply with erasure requests. For example, you are also responsible for ensuring that data collected by or stored with the 3rd party services your organization uses gets deleted."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:35
+#: wp-admin/export-personal-data.php:35
+msgid "Default Data"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:37
+msgid "ClassicPress collects (but <em>never</em> publishes) a limited amount of data from logged-in users but then deletes it or anonymizes it. That data can include: "
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:38
+#: wp-admin/export-personal-data.php:38
+msgid "<strong>Profile Information</strong> &mdash; user email address, username, display name, nickname, first name, last name, description/bio, and registration date."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:39
+msgid "<strong>Community Events Location</strong> &mdash; The IP Address of the user which is used for the Upcoming Community Events shown in the dashboard widget."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:40
+#: wp-admin/export-personal-data.php:40
+msgid "<strong>Session Tokens</strong> &mdash; User login information, IP Addresses, Expiration Date, User Agent (Browser/OS), and Last Login."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:41
+msgid "<strong>Comments</strong> &mdash; ClassicPress does not delete comments. The software does anonymize (but, again, <em>never</em> publishes) the associated Email Address, IP Address, and User Agent (Browser/OS)."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:42
+msgid "<strong>Media</strong> &mdash; A list of URLs for all media file uploads made by the user."
+msgstr ""
+
+#. translators: %s: URL to Privacy Policy Guide screen.
+#: wp-admin/erase-personal-data.php:48
+msgid "If you are not sure, check the plugin documentation or contact the plugin author to see if the plugin collects data and if it supports the Data Eraser tool. This information may be available in the <a href=\"%s\">Privacy Policy Guide</a>."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:55
+#: wp-admin/export-personal-data.php:55
+msgid "Plugin Data"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:57
+msgid "Many plugins may collect or store personal data either in the ClassicPress database or remotely. Any Erase Personal Data request should delete data from plugins as well."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:58
+msgid "If you are a plugin author, you can <a href=\"https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-eraser-to-your-plugin/\" target=\"_blank\">learn more about how to add support for the Personal Data Eraser to a plugin here</a>."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:65
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-erase-personal-data-screen/\">Documentation on Erase Personal Data</a>"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:94
+msgid "Filter erase personal data list"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:95
+msgid "Erase personal data list navigation"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:96
+msgid "Erase personal data list"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:108
+msgid "This tool helps site owners comply with local laws and regulations by deleting or anonymizing known data for a given user."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:114
+msgid "Add Data Erasure Request"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:119
+#: wp-admin/export-personal-data.php:119
+msgid "Username or email address"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:127
+#: wp-admin/export-personal-data.php:127
+msgid "Confirmation email"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:132
+msgid "Send personal data erasure confirmation email."
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:138
+#: wp-admin/export-personal-data.php:138
+msgid "Send Request"
+msgstr ""
+
+#: wp-admin/erase-personal-data.php:150
+#: wp-admin/export-personal-data.php:150
+msgid "Search Requests"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:13
+msgid "Sorry, you are not allowed to export personal data on this site."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:17
+#: wp-admin/export-personal-data.php:107
+#: wp-admin/menu.php:326
+msgid "Export Personal Data"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:25
+msgid "This screen is where you manage requests for an export of personal data."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:26
+msgid "Privacy Laws around the world require businesses and online services to provide an export of some of the data they collect about an individual, and to deliver that export on request. The rights those laws enshrine are sometimes called the \"Right of Data Portability\". It allows individuals to obtain and reuse their personal data for their own purposes across different services. It allows them to move, copy or transfer personal data easily from one IT environment to another."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:28
+msgid "Note: Since this tool only gathers data from ClassicPress and participating plugins, you may need to do more to comply with export requests. For example, you should also send the requester some of the data collected from or stored with the 3rd party services your organization uses."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:37
+msgid "ClassicPress collects (but <em>never</em> publishes) a limited amount of data from registered users who have logged in to the site. Generally, these users are people who contribute to the site in some way -- content, store management, and so on. With rare exceptions, these users do not include occasional visitors who might have registered to comment on articles or buy products. The data ClassicPress retains can include:"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:39
+msgid "<strong>Community Events Location</strong> &mdash; The IP Address of the user, which populates the Upcoming Community Events dashboard widget with relevant information."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:41
+msgid "<strong>Comments</strong> &mdash; For user comments, Email Address, IP Address, User Agent (Browser/OS), Date/Time, Comment Content, and Content URL."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:42
+msgid "<strong>Media</strong> &mdash; A list of URLs for media files the user uploads."
+msgstr ""
+
+#. translators: %s: URL to Privacy Policy Guide screen.
+#: wp-admin/export-personal-data.php:48
+msgid "If you are not sure, check the plugin documentation or contact the plugin author to see if the plugin collects data and if it supports the Data Exporter tool. This information may be available in the <a href=\"%s\">Privacy Policy Guide</a>."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:57
+msgid "Many plugins may collect or store personal data either in the ClassicPress database or remotely. Any Export Personal Data request should include data from plugins as well."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:58
+msgid "Plugin authors can <a href=\"https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-exporter-to-your-plugin/\" target=\"_blank\">learn more about how to add the Personal Data Exporter to a plugin here</a>."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:65
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-export-personal-data-screen/\">Documentation on Export Personal Data</a>"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:94
+msgid "Filter export personal data list"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:95
+msgid "Export personal data list navigation"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:96
+msgid "Export personal data list"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:108
+msgid "This tool helps site owners comply with local laws and regulations by exporting known data for a given user in a .zip file."
+msgstr ""
+
+#: wp-admin/export-personal-data.php:114
+msgid "Add Data Export Request"
+msgstr ""
+
+#: wp-admin/export-personal-data.php:132
+msgid "Send personal data export confirmation email."
+msgstr ""
+
+#: wp-admin/export.php:13
+msgid "Sorry, you are not allowed to export the content of this site."
+msgstr ""
+
+#: wp-admin/export.php:20
+#: wp-admin/menu.php:323
+msgid "Export"
+msgstr ""
+
+#: wp-admin/export.php:52
+msgid "You can export a file of your site&#8217;s content in order to import it into another installation or platform. The export file will be an XML file format called WXR. Posts, pages, comments, custom fields, categories, and tags can be included. You can choose for the WXR file to include only certain posts or pages by setting the dropdown filters to limit the export by category, author, date range by month, or publishing status."
+msgstr ""
+
+#: wp-admin/export.php:53
+msgid "Once generated, your WXR file can be imported by another ClassicPress site or by another blogging platform able to access this format."
+msgstr ""
+
+#: wp-admin/export.php:59
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-export-screen/\">Documentation on Export</a>"
+msgstr ""
+
+#: wp-admin/export.php:173
+msgid "When you click the button below ClassicPress will create an XML file for you to save to your computer."
+msgstr ""
+
+#: wp-admin/export.php:174
+msgid "This format, which is called ClassicPress eXtended RSS or WXR, will contain your posts, pages, comments, custom fields, categories, and tags."
+msgstr ""
+
+#: wp-admin/export.php:175
+msgid "Once you&#8217;ve saved the download file, you can use the Import function in another ClassicPress installation to import the content from this site."
+msgstr ""
+
+#: wp-admin/export.php:177
+msgid "Choose what to export"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/export.php:183
+msgid "Content to export"
+msgstr ""
+
+#: wp-admin/export.php:187
+msgid "All content"
+msgstr ""
+
+#: wp-admin/export.php:188
+msgid "This will contain all of your posts, pages, comments, custom fields, terms, navigation menus, and custom posts."
+msgstr ""
+
+#: wp-admin/export.php:190
+#: wp-admin/includes/class-wp-users-list-table.php:377
+msgctxt "post type general name"
+msgid "Posts"
+msgstr ""
+
+#: wp-admin/export.php:193
+msgid "Categories:"
+msgstr ""
+
+#: wp-admin/export.php:194
+#: wp-admin/export.php:206
+#: wp-admin/export.php:236
+#: wp-admin/export.php:258
+#: wp-admin/export.php:288
+#: wp-admin/includes/class-wp-users-list-table.php:189
+msgid "All"
+msgstr ""
+
+#: wp-admin/export.php:198
+#: wp-admin/export.php:250
+msgid "Authors:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/export.php:218
+#: wp-admin/export.php:270
+#: wp-admin/export.php:315
+msgid "Date range:"
+msgstr ""
+
+#: wp-admin/export.php:221
+#: wp-admin/export.php:273
+#: wp-admin/export.php:318
+msgid "Start date:"
+msgstr ""
+
+#: wp-admin/export.php:223
+#: wp-admin/export.php:228
+#: wp-admin/export.php:275
+#: wp-admin/export.php:280
+#: wp-admin/export.php:320
+#: wp-admin/export.php:325
+#: wp-admin/includes/template.php:746
+#: wp-admin/nav-menus.php:902
+#: wp-admin/options-privacy.php:296
+#: wp-admin/options-reading.php:121
+#: wp-admin/options-reading.php:138
+#: wp-admin/privacy.php:220
+#: wp-admin/widgets-form.php:317
+msgid "&mdash; Select &mdash;"
+msgstr ""
+
+#: wp-admin/export.php:226
+#: wp-admin/export.php:278
+#: wp-admin/export.php:323
+msgid "End date:"
+msgstr ""
+
+#: wp-admin/export.php:247
+msgid "Pages"
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/export.php:308
+#: wp-admin/includes/class-wp-privacy-policy-content.php:488
+#: wp-admin/includes/media.php:2515
+#: wp-admin/includes/plugin-install.php:380
+#: wp-admin/menu.php:66
+#: wp-admin/menu.php:340
+msgid "Media"
+msgstr ""
+
+#: wp-admin/export.php:342
+msgid "Download Export File"
+msgstr ""
+
+#: wp-admin/freedoms.php:66
+msgid "From time to time, your ClassicPress site may send anonymous data to ClassicPress.net. Some examples of the kinds of data that may be sent are the version of ClassicPress your site is running and a list of installed plugins and themes."
+msgstr ""
+
+#: wp-admin/freedoms.php:68
+msgid "We take privacy and transparency very seriously. To learn more about what data we collect, how we use it, and what precautions we take to ensure site owners&#8217; privacy, please see the <a href=\"%s\">ClassicPress Privacy Policy</a>."
+msgstr ""
+
+#: wp-admin/freedoms.php:73
+msgid "ClassicPress is Free and open source software, built by a distributed community of volunteer developers from around the world. ClassicPress comes with some awesome, worldview-changing rights courtesy of its <a href=\"%s\">license</a>, the GPL."
+msgstr ""
+
+#: wp-admin/freedoms.php:76
+msgid "You have the freedom to run the program, for any purpose. (freedom 0)"
+msgstr ""
+
+#: wp-admin/freedoms.php:77
+msgid "You have access to the source code, the freedom to study how the program works, and the freedom to change it to make it do what you wish. (freedom 1)"
+msgstr ""
+
+#: wp-admin/freedoms.php:78
+msgid "You have the freedom to redistribute copies of the original program so you can help your neighbor. (freedom 2)"
+msgstr ""
+
+#: wp-admin/freedoms.php:79
+msgid "You have the freedom to distribute copies of your modified versions to others. By doing this you can give the whole community a chance to benefit from your changes. (freedom 3)"
+msgstr ""
+
+#: wp-admin/freedoms.php:85
+#: wp-admin/includes/plugin-install.php:731
+#: wp-admin/plugin-install.php:98
+#: wp-admin/plugins.php:550
+msgid "https://wordpress.org/plugins/"
+msgstr ""
+
+#: wp-admin/freedoms.php:86
+#: wp-admin/theme-install.php:111
+#: wp-admin/themes.php:157
+msgid "https://wordpress.org/themes/"
+msgstr ""
+
+#: wp-admin/freedoms.php:89
+msgid "Every plugin and theme in ClassicPress.net&#8217;s directory is 100%% GPL or a similarly free and compatible license, so you can feel safe finding <a href=\"%1$s\">plugins</a> and <a href=\"%2$s\">themes</a> there. If you get a plugin or theme from another source, make sure to ask them if it&#8217;s <a href=\"%3$s\">GPL</a> first. If they don&#8217;t respect the ClassicPress license, we don&#8217;t recommend them."
+msgstr ""
+
+#: wp-admin/freedoms.php:93
+msgid "Don&#8217;t you wish all software came with these freedoms? So do we! For more information, check out the <a href=\"https://www.fsf.org/\">Free Software Foundation</a>."
+msgstr ""
+
+#: wp-admin/import.php:25
+msgid "This screen lists links to plugins to import data from blogging/content management platforms. Choose the platform you want to import from, and click Install Now when you are prompted in the popup window. If your platform is not listed, click the link to search the plugin directory for other importer plugins to see if there is one for your platform."
+msgstr ""
+
+#: wp-admin/import.php:26
+msgid "In previous versions of ClassicPress, all importers were built-in. They have been turned into plugins since most people only use them once or infrequently."
+msgstr ""
+
+#: wp-admin/import.php:32
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-import-screen/\">Documentation on Import</a>"
+msgstr ""
+
+#: wp-admin/import.php:33
+msgid "<a href=\"https://wordpress.org/support/forums\">Support</a>"
+msgstr ""
+
+#: wp-admin/import.php:65
+#: wp-admin/includes/network.php:116
+#: wp-admin/themes.php:305
+#: wp-admin/users.php:329
+msgid "Error:"
+msgstr ""
+
+#. translators: %s: Importer slug.
+#: wp-admin/import.php:68
+msgid "The %s importer is invalid or is not installed."
+msgstr ""
+
+#: wp-admin/import.php:73
+msgid "If you have posts or comments in another system, ClassicPress can import those into this site. To get started, choose a system to import from below:"
+msgstr ""
+
+#: wp-admin/import.php:96
+msgid "No importers are available."
+msgstr ""
+
+#. translators: %s: Importer name.
+#: wp-admin/import.php:132
+#: wp-admin/import.php:181
+#: wp-admin/js/updates.js:861
+msgid "Run %s"
+msgstr ""
+
+#: wp-admin/import.php:133
+#: wp-admin/import.php:182
+#: wp-admin/js/updates.js:865
+msgid "Run Importer"
+msgstr ""
+
+#. translators: %s: Importer name.
+#. translators: %s: Plugin name and version.
+#. translators: %s: Plugin name.
+#: wp-admin/import.php:159
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:524
+#: wp-admin/js/updates.js:912
+#: wp-admin/js/updates.js:2147
+#: wp-admin/js/updates.js:2270
+msgctxt "plugin"
+msgid "Install %s now"
+msgstr ""
+
+#: wp-admin/import.php:160
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:526
+#: wp-admin/includes/class-wp-theme-install-list-table.php:336
+#: wp-admin/includes/plugin-install.php:339
+#: wp-admin/includes/plugin-install.php:891
+#: wp-admin/includes/theme-install.php:207
+#: wp-admin/press-this.php:63
+#: wp-admin/js/updates.js:916
+#: wp-admin/js/updates.js:2231
+#: wp-admin/js/updates.js:2274
+msgid "Install Now"
+msgstr ""
+
+#. translators: %s: URL to Import screen on the main site.
+#: wp-admin/import.php:165
+msgid "This importer is not installed. Please install importers from <a href=\"%s\">the main site</a>."
+msgstr ""
+
+#. translators: %s: Importer name.
+#. translators: %s: Plugin name and version.
+#. translators: %s: Plugin name.
+#: wp-admin/import.php:204
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:618
+#: wp-admin/includes/class-wp-plugins-list-table.php:1074
+msgid "More information about %s"
+msgstr ""
+
+#: wp-admin/import.php:205
+#: wp-admin/includes/class-wp-theme-install-list-table.php:379
+#: wp-admin/includes/class-wp-themes-list-table.php:270
+msgid "Details"
+msgstr ""
+
+#. translators: %s: URL to Add Plugins screen.
+#: wp-admin/import.php:228
+msgid "If the importer you need is not listed, <a href=\"%s\">search the plugin directory</a> to see if an importer is available."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:124
+#: wp-admin/includes/meta-boxes.php:574
+#: wp-admin/includes/post.php:562
+#: wp-admin/includes/post.php:2140
+#: wp-admin/js/inline-edit-post.js:504
+#: wp-admin/js/tags-box.js:9
+msgctxt "tag delimiter"
+msgid ","
+msgstr ""
+
+#. translators: 1: User login, 2: User email address.
+#: wp-admin/includes/ajax-actions.php:336
+msgctxt "user autocomplete result"
+msgid "%1$s (%2$s)"
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/ajax-actions.php:424
+#: wp-admin/includes/ajax-actions.php:1367
+#: wp-admin/includes/dashboard.php:342
+msgid "%s Comment"
+msgid_plural "%s Comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/ajax-actions.php:429
+#: wp-admin/includes/ajax-actions.php:500
+#: wp-admin/includes/ajax-actions.php:1372
+#: wp-admin/includes/dashboard.php:350
+#: wp-admin/menu.php:94
+msgid "%s Comment in moderation"
+msgid_plural "%s Comments in moderation"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#. translators: %s: Number of items.
+#. translators: Number of items.
+#. translators: %s: The remaining number of plugins.
+#: wp-admin/includes/ajax-actions.php:492
+#: wp-admin/includes/class-wp-list-table.php:989
+#: wp-admin/includes/class-wp-list-table.php:1620
+#: wp-admin/js/updates.js:1070
+msgid "%s item"
+msgid_plural "%s items"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: Comment ID.
+#: wp-admin/includes/ajax-actions.php:919
+msgid "Comment %d does not exist"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1036
+#: wp-admin/includes/ajax-actions.php:2301
+#: wp-admin/js/media.js:127
+#: wp-admin/js/media.js:132
+#: wp-admin/js/updates.js:1949
+msgid "An error has occurred. Please reload the page and try again."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1255
+msgid "You cannot reply to a comment on a draft post."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1279
+msgid "Sorry, you must be logged in to reply to a comment."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1285
+#: wp-admin/includes/ajax-actions.php:1402
+msgid "Please type your comment text."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1502
+msgid "Menu Item"
+msgstr ""
+
+#. translators: 1: Post creation date, 2: Post creation time.
+#: wp-admin/includes/ajax-actions.php:1559
+msgid "Draft created on %1$s at %2$s"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1576
+#: wp-admin/includes/ajax-actions.php:1584
+msgid "Please provide a custom field value."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1607
+msgid "Please provide a custom field name."
+msgstr ""
+
+#. translators: %s: The new user.
+#: wp-admin/includes/ajax-actions.php:1697
+msgid "User %s added"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1989
+#: wp-admin/includes/post.php:272
+msgid "Sorry, you are not allowed to edit this page."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:1993
+#: wp-admin/includes/media.php:3741
+#: wp-admin/includes/post.php:274
+#: wp-admin/includes/post.php:1964
+#: wp-admin/includes/post.php:1968
+msgid "Sorry, you are not allowed to edit this post."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2000
+msgid "Someone"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/ajax-actions.php:2003
+msgid "Saving is disabled: %s is currently editing this post."
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/ajax-actions.php:2007
+msgid "Saving is disabled: %s is currently editing this page."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2126
+#: wp-admin/includes/ajax-actions.php:2132
+#: wp-admin/includes/edit-tag-messages.php:18
+msgid "Item not updated."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2176
+#: wp-admin/includes/ajax-actions.php:3841
+#: wp-admin/includes/class-wp-list-table.php:339
+#: wp-admin/includes/class-wp-themes-list-table.php:92
+msgid "No items found."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2179
+#: wp-admin/includes/class-wp-posts-list-table.php:1638
+#: wp-admin/includes/dashboard.php:592
+#: wp-admin/includes/media.php:1391
+#: wp-admin/includes/media.php:2569
+#: wp-admin/includes/media.php:2892
+msgid "Title"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2179
+msgid "Type"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2179
+#: wp-admin/includes/class-wp-posts-list-table.php:717
+#: wp-admin/includes/class-wp-posts-list-table.php:1657
+msgid "Date"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2179
+#: wp-admin/includes/class-wp-posts-list-table.php:1937
+#: wp-admin/includes/class-wp-privacy-requests-table.php:44
+msgid "Status"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2182
+#: wp-admin/includes/media.php:3262
+#: wp-admin/includes/revision.php:59
+#: wp-admin/includes/revision.php:62
+#: wp-admin/includes/template.php:1973
+#: wp-admin/js/inline-edit-post.js:356
+msgid "(no title)"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2188
+#: wp-admin/includes/class-wp-posts-list-table.php:1180
+#: wp-admin/includes/class-wp-posts-list-table.php:1944
+#: wp-admin/includes/meta-boxes.php:112
+#: wp-admin/includes/meta-boxes.php:152
+#: wp-admin/js/post.js:836
+msgid "Published"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2191
+#: wp-admin/includes/class-wp-posts-list-table.php:1185
+#: wp-admin/includes/class-wp-posts-list-table.php:1945
+#: wp-admin/includes/meta-boxes.php:115
+#: wp-admin/includes/meta-boxes.php:156
+msgid "Scheduled"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2194
+#: wp-admin/includes/class-wp-posts-list-table.php:1951
+#: wp-admin/includes/meta-boxes.php:118
+#: wp-admin/includes/meta-boxes.php:158
+msgid "Pending Review"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2197
+#: wp-admin/includes/class-wp-posts-list-table.php:1952
+#: wp-admin/includes/meta-boxes.php:122
+#: wp-admin/includes/meta-boxes.php:160
+#: wp-admin/includes/meta-boxes.php:162
+msgid "Draft"
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2430
+msgid "Upload failed. Please reload and try again."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2466
+msgid "Upload failed."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2509
+msgid "Sorry, you are not allowed to attach files to this post."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:2536
+#: wp-admin/includes/class-custom-background.php:525
+#: wp-admin/includes/class-custom-image-header.php:963
+msgid "The uploaded file is not a valid image. Please try again."
+msgstr ""
+
+#. translators: %s: URL that could not be embedded.
+#: wp-admin/includes/ajax-actions.php:3733
+msgid "%s failed to embed."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:3767
+msgid "This preview is unavailable in the editor."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:3896
+msgid "Could not log out user sessions. Please try again."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:3905
+msgid "You are now logged out everywhere else."
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/ajax-actions.php:3909
+msgid "%s has been logged out."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:3934
+msgid "Image could not be processed."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4110
+#: wp-admin/includes/ajax-actions.php:4235
+#: wp-admin/includes/ajax-actions.php:4330
+msgid "No theme specified."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4123
+#: wp-admin/theme-install.php:16
+#: wp-admin/update.php:286
+#: wp-admin/update.php:328
+#: wp-admin/update.php:366
+msgid "Sorry, you are not allowed to install themes on this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4166
+#: wp-admin/includes/ajax-actions.php:4298
+#: wp-admin/includes/ajax-actions.php:4362
+#: wp-admin/includes/ajax-actions.php:4462
+#: wp-admin/includes/ajax-actions.php:4589
+#: wp-admin/includes/ajax-actions.php:4658
+msgid "Unable to connect to the filesystem. Please confirm your credentials."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4249
+#: wp-admin/update.php:235
+#: wp-admin/update.php:258
+msgid "Sorry, you are not allowed to update themes for this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4309
+#: wp-admin/includes/class-theme-upgrader.php:63
+#: wp-admin/includes/class-theme-upgrader.php:100
+msgid "Theme update failed."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4342
+msgid "Sorry, you are not allowed to delete themes on this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4347
+#: wp-admin/includes/file.php:440
+#: wp-admin/includes/file.php:450
+#: wp-admin/theme-editor.php:70
+#: wp-admin/theme-editor.php:74
+#: wp-admin/themes.php:28
+#: wp-admin/themes.php:71
+msgid "The requested theme does not exist."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4380
+msgid "Theme could not be deleted."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4404
+#: wp-admin/includes/ajax-actions.php:4513
+#: wp-admin/includes/ajax-actions.php:4621
+msgid "No plugin specified."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4415
+#: wp-admin/plugin-install.php:19
+#: wp-admin/update.php:107
+#: wp-admin/update.php:176
+#: wp-admin/update.php:214
+msgid "Sorry, you are not allowed to install plugins on this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4528
+#: wp-admin/update.php:29
+#: wp-admin/update.php:57
+#: wp-admin/update.php:80
+msgid "Sorry, you are not allowed to update plugins for this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4600
+#: wp-admin/includes/class-plugin-upgrader.php:64
+#: wp-admin/includes/class-plugin-upgrader.php:91
+msgid "Plugin update failed."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4634
+#: wp-admin/plugins.php:269
+msgid "Sorry, you are not allowed to delete plugins for this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4643
+#: wp-admin/plugins.php:623
+msgid "You cannot delete a plugin while it is active on the main site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4674
+msgid "Plugin could not be deleted."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4710
+#: wp-admin/includes/ajax-actions.php:4762
+#: wp-admin/plugins.php:13
+msgid "Sorry, you are not allowed to manage plugins for this site."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4811
+#: wp-admin/plugin-editor.php:187
+#: wp-admin/theme-editor.php:194
+msgid "File edited successfully."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4825
+#: wp-admin/includes/ajax-actions.php:5015
+msgid "Missing request ID."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4831
+#: wp-admin/includes/ajax-actions.php:5021
+msgid "Invalid request ID."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4835
+#: wp-admin/includes/ajax-actions.php:5026
+msgid "Sorry, you are not allowed to perform this action."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4844
+#: wp-admin/includes/ajax-actions.php:5035
+msgid "Invalid request type."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4849
+msgid "A valid email address must be given."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4853
+msgid "Missing exporter index."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4859
+#: wp-admin/includes/ajax-actions.php:5051
+msgid "Missing page index."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4888
+msgid "An exporter has improperly used the registration filter."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4894
+msgid "Exporter index cannot be negative."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4898
+msgid "Exporter index is out of range."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:4902
+#: wp-admin/includes/ajax-actions.php:5090
+msgid "Page index cannot be less than one."
+msgstr ""
+
+#. translators: %s: Exporter array index.
+#: wp-admin/includes/ajax-actions.php:4912
+msgid "Expected an array describing the exporter at index %s."
+msgstr ""
+
+#. translators: %s: Exporter array index.
+#: wp-admin/includes/ajax-actions.php:4919
+msgid "Exporter array at index %s does not include a friendly name."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4928
+msgid "Exporter does not include a callback: %s."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4935
+msgid "Exporter callback is not a valid callback: %s."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4949
+msgid "Expected response as an array from exporter: %s."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4956
+msgid "Expected data in response array from exporter: %s."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4963
+msgid "Expected data array in response array from exporter: %s."
+msgstr ""
+
+#. translators: %s: Exporter friendly name.
+#: wp-admin/includes/ajax-actions.php:4970
+msgid "Expected done (boolean) in response array from exporter: %s."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5041
+msgid "Invalid email address in request."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5045
+msgid "Missing eraser index."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5082
+msgid "Eraser index cannot be less than one."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5086
+msgid "Eraser index is out of range."
+msgstr ""
+
+#. translators: %d: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5099
+msgid "Expected an array describing the eraser at index %d."
+msgstr ""
+
+#. translators: %d: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5104
+msgid "Eraser array at index %d does not include a friendly name."
+msgstr ""
+
+#. translators: %s: Eraser friendly name.
+#: wp-admin/includes/ajax-actions.php:5113
+msgid "Eraser does not include a callback: %s."
+msgstr ""
+
+#. translators: %s: Eraser friendly name.
+#: wp-admin/includes/ajax-actions.php:5123
+msgid "Eraser callback is not valid: %s."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5140
+msgid "Did not receive array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5151
+msgid "Expected items_removed key in response array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5162
+msgid "Expected items_retained key in response array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5173
+msgid "Expected messages key in response array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5184
+msgid "Expected messages key to reference an array in response array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: Eraser friendly name, 2: Eraser array index.
+#: wp-admin/includes/ajax-actions.php:5195
+msgid "Expected done flag in response array from %1$s eraser (index %2$d)."
+msgstr ""
+
+#. translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
+#: wp-admin/includes/ajax-actions.php:5248
+#: wp-admin/includes/ajax-actions.php:5281
+#: wp-admin/includes/ajax-actions.php:5314
+#: wp-admin/includes/ajax-actions.php:5364
+msgid "The Site Health check for %1$s has been replaced with %2$s."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5436
+msgid "Invalid data. No selected item."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5442
+msgid "Invalid data. Unknown state."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5447
+#: wp-admin/includes/ajax-actions.php:5472
+msgid "Invalid data. Unknown type."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5454
+msgid "Sorry, you are not allowed to modify plugins."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5464
+msgid "Sorry, you are not allowed to modify themes."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5476
+msgid "Invalid data. The item does not exist."
+msgstr ""
+
+#: wp-admin/includes/ajax-actions.php:5510
+msgid "Cannot send password reset, permission denied."
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/ajax-actions.php:5520
+msgid "A password reset link was emailed to %s."
+msgstr ""
+
+#: wp-admin/includes/bookmark.php:32
+#: wp-admin/includes/bookmark.php:379
+#: wp-admin/link-manager.php:12
+#: wp-admin/link-manager.php:92
+msgid "Sorry, you are not allowed to edit the links for this site."
+msgstr ""
+
+#: wp-admin/includes/bookmark.php:228
+msgid "Could not update link in the database."
+msgstr ""
+
+#: wp-admin/includes/bookmark.php:236
+msgid "Could not insert link into the database."
+msgstr ""
+
+#. translators: %s: A link to install the Link Manager plugin.
+#: wp-admin/includes/bookmark.php:356
+msgid "If you are looking to use the link manager, please install the <a href=\"%s\">Link Manager plugin</a>."
+msgstr ""
+
+#. translators: %s: A link to activate the Link Manager plugin.
+#: wp-admin/includes/bookmark.php:371
+msgid "Please activate the <a href=\"%s\">Link Manager plugin</a> to use the link manager."
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Number of the plugin, 3: Total number of plugins being updated.
+#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:33
+msgid "Updating Plugin %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:60
+#: wp-admin/includes/class-plugin-installer-skin.php:151
+#: wp-admin/includes/class-plugin-upgrader-skin.php:101
+msgid "Go to Plugins page"
+msgstr ""
+
+#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:65
+#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:66
+#: wp-admin/includes/class-language-pack-upgrader-skin.php:80
+msgid "Go to ClassicPress Updates page"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Number of the theme, 3: Total number of themes being updated.
+#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:34
+msgid "Updating Theme %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:61
+#: wp-admin/includes/class-theme-installer-skin.php:164
+#: wp-admin/includes/class-theme-upgrader-skin.php:127
+msgid "Go to Themes page"
+msgstr ""
+
+#: wp-admin/includes/class-bulk-upgrader-skin.php:41
+msgid "The update process is starting. This process may take a while on some hosts, so please be patient."
+msgstr ""
+
+#. translators: 1: Title of an update, 2: Error message.
+#: wp-admin/includes/class-bulk-upgrader-skin.php:43
+msgid "An error occurred while updating %1$s: %2$s"
+msgstr ""
+
+#. translators: %s: Title of an update.
+#: wp-admin/includes/class-bulk-upgrader-skin.php:45
+msgid "The update of %s failed."
+msgstr ""
+
+#. translators: %s: Title of an update.
+#: wp-admin/includes/class-bulk-upgrader-skin.php:47
+msgid "%s updated successfully."
+msgstr ""
+
+#: wp-admin/includes/class-bulk-upgrader-skin.php:48
+msgid "All updates have been completed."
+msgstr ""
+
+#: wp-admin/includes/class-bulk-upgrader-skin.php:157
+msgid "Show details."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:29
+msgid "ClassicPress is at the latest version."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:30
+msgid "Another update is currently in progress."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:31
+#: wp-admin/includes/class-language-pack-upgrader.php:115
+#: wp-admin/includes/class-plugin-upgrader.php:58
+#: wp-admin/includes/class-theme-upgrader.php:57
+msgid "Update package not available."
+msgstr ""
+
+#. translators: %s: Package URL.
+#: wp-admin/includes/class-core-upgrader.php:33
+#: wp-admin/includes/class-plugin-upgrader.php:60
+#: wp-admin/includes/class-theme-upgrader.php:59
+msgid "Downloading update from %s&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:34
+#: wp-admin/includes/class-language-pack-upgrader.php:118
+#: wp-admin/includes/class-plugin-upgrader.php:61
+#: wp-admin/includes/class-theme-upgrader.php:60
+msgid "Unpacking the update&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:35
+msgid "Could not copy files."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:36
+#: wp-admin/includes/file.php:1681
+#: wp-admin/includes/file.php:1822
+msgid "Could not copy files. You may have run out of disk space."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:37
+msgid "Attempting to roll back to previous version."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:38
+msgid "Due to an error during updating, ClassicPress has rolled back to your previous version."
+msgstr ""
+
+#: wp-admin/includes/class-core-upgrader.php:199
+#: wp-admin/includes/class-wp-upgrader.php:166
+#: wp-admin/includes/update-core.php:313
+msgid "The update cannot be installed because some files could not be copied. This is usually due to inconsistent file permissions."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:66
+#: wp-admin/menu.php:220
+msgid "Background"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:91
+msgid "You can customize the look of your site without touching any of your theme&#8217;s code by using a custom background. Your background can be an image or a color."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:92
+msgid "To use a background image, simply upload it or choose an image that has already been uploaded to your Media Library by clicking the &#8220;Choose Image&#8221; button. You can display a single instance of your image, or tile it to fill the screen. You can have your background fixed in place, so your site content moves on top of it, or you can have it scroll with your site."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:93
+msgid "You can also choose a background color by clicking the Select Color button and either typing in a legitimate HTML hex value, e.g. &#8220;#ff0000&#8221; for red, or by choosing a color using the color picker."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:94
+msgid "Do not forget to click on the Save Changes button when you are finished."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:100
+msgid "<a href=\"https://codex.wordpress.org/Appearance_Background_Screen\">Documentation on Custom Background</a>"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:101
+#: wp-admin/update-core.php:868
+msgid "<a href=\"https://forums.classicpress.net/c/support\">Support Forums</a>"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:233
+#: wp-admin/includes/theme.php:320
+msgid "Custom Background"
+msgstr ""
+
+#. translators: %s: URL to background image configuration in Customizer.
+#: wp-admin/includes/class-custom-background.php:241
+msgid "You can now manage and live-preview Custom Backgrounds in the <a href=\"%s\">Customizer</a>."
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-custom-background.php:254
+msgid "Background updated. <a href=\"%s\">Visit your site</a> to see how it looks."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:260
+#: wp-admin/includes/template.php:2318
+msgid "Background Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:306
+#: wp-admin/includes/class-custom-image-header.php:714
+msgid "Remove Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:310
+msgid "Remove Background Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:311
+msgid "This will remove the background image. You will not be able to restore any customizations."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:320
+#: wp-admin/includes/class-custom-background.php:324
+msgid "Restore Original Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:325
+msgid "This will restore the original background image. You will not be able to restore any customizations."
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:333
+#: wp-admin/includes/class-custom-image-header.php:578
+msgid "Select Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:336
+#: wp-admin/includes/class-custom-image-header.php:648
+msgid "Choose an image from your computer:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:340
+#: wp-admin/includes/class-custom-image-header.php:652
+#: wp-admin/includes/class-wp-theme-install-list-table.php:62
+#: wp-admin/includes/media.php:2206
+#: wp-admin/includes/media.php:2210
+msgid "Upload"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:343
+#: wp-admin/includes/class-custom-image-header.php:665
+msgid "Or choose an image from your media library:"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:345
+msgid "Choose a Background Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:346
+msgid "Set as background"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:346
+#: wp-admin/includes/class-custom-image-header.php:669
+#: wp-admin/options-general.php:322
+msgid "Choose Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:355
+msgid "Display Options"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:372
+msgid "Top Left"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:376
+msgid "Top"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:380
+msgid "Top Right"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:386
+#: wp-admin/includes/media.php:1152
+#: wp-admin/includes/media.php:2913
+msgid "Left"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:390
+#: wp-admin/includes/media.php:1153
+#: wp-admin/includes/media.php:2915
+msgid "Center"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:394
+#: wp-admin/includes/media.php:1154
+#: wp-admin/includes/media.php:2917
+msgid "Right"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:400
+msgid "Bottom Left"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:404
+msgid "Bottom"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:408
+msgid "Bottom Right"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:415
+#: wp-admin/includes/class-custom-background.php:419
+msgid "Image Position"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:439
+#: wp-admin/includes/class-custom-background.php:443
+msgid "Image Size"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:447
+msgctxt "Original Size"
+msgid "Original"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:448
+msgid "Fit to Screen"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:449
+msgid "Fill Screen"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:455
+#: wp-admin/includes/class-custom-background.php:459
+msgctxt "Background Repeat"
+msgid "Repeat"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:463
+msgid "Repeat Background Image"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:468
+#: wp-admin/includes/class-custom-background.php:472
+msgctxt "Background Scroll"
+msgid "Scroll"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:476
+msgid "Scroll with Page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-custom-background.php:481
+#: wp-admin/includes/class-custom-background.php:485
+msgid "Background Color"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:630
+#: wp-admin/includes/image-edit.php:288
+#: wp-admin/includes/media.php:1194
+msgid "Thumbnail"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:631
+#: wp-admin/includes/media.php:1195
+msgid "Medium"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:632
+#: wp-admin/includes/media.php:1196
+msgid "Large"
+msgstr ""
+
+#: wp-admin/includes/class-custom-background.php:633
+#: wp-admin/includes/media.php:1197
+msgid "Full Size"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:74
+#: wp-admin/menu.php:215
+msgid "Header"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:102
+msgid "This screen is used to customize the header section of your theme."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:103
+msgid "You can choose from the theme&#8217;s default header images, or use one of your own. You can also customize how your Site Title and Tagline are displayed."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:110
+#: wp-admin/includes/class-custom-image-header.php:531
+#: wp-admin/includes/template.php:2290
+#: wp-admin/includes/template.php:2297
+msgid "Header Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:112
+msgid "You can set a custom image header for your site. Simply upload the image and crop it, and the new header will go live immediately. Alternatively, you can use an image that has already been uploaded to your Media Library by clicking the &#8220;Choose Image&#8221; button."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:113
+msgid "Some themes come with additional header images bundled. If you see multiple images displayed, select the one you would like and click the &#8220;Save Changes&#8221; button."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:114
+msgid "If your theme has more than one default header image, or you have uploaded more than one custom header image, you have the option of having ClassicPress display a randomly different image on each page of your site. Click the &#8220;Random&#8221; radio button next to the Uploaded Images or Default Images section to enable this feature."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:115
+msgid "If you do not want a header image to be displayed on your site at all, click the &#8220;Remove Header Image&#8221; button at the bottom of the Header Image section of this page. If you want to re-enable the header image later, you just have to select one of the other image options and click &#8220;Save Changes&#8221;."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:122
+#: wp-admin/includes/class-custom-image-header.php:744
+#: wp-admin/includes/class-custom-image-header.php:749
+msgid "Header Text"
+msgstr ""
+
+#. translators: %s: URL to General Settings screen.
+#: wp-admin/includes/class-custom-image-header.php:126
+msgid "For most themes, the header text is your Site Title and Tagline, as defined in the <a href=\"%s\">General Settings</a> section."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:130
+msgid "In the Header Text section of this page, you can choose whether to display this text or hide it. You can also choose a color for the text by clicking the Select Color button and either typing in a legitimate HTML hex value, e.g. &#8220;#ff0000&#8221; for red, or by choosing a color using the color picker."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:131
+msgid "Do not forget to click &#8220;Save Changes&#8221; when you are done!"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:137
+msgid "<a href=\"https://codex.wordpress.org/Appearance_Header_Screen\">Documentation on Custom Header</a>"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:317
+msgid "<strong>Random:</strong> Show a different image on each page."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:504
+#: wp-admin/includes/theme.php:322
+msgid "Custom Header"
+msgstr ""
+
+#. translators: %s: URL to header image configuration in Customizer.
+#: wp-admin/includes/class-custom-image-header.php:512
+msgid "You can now manage and live-preview Custom Header in the <a href=\"%s\">Customizer</a>."
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-custom-image-header.php:525
+msgid "Header updated. <a href=\"%s\">Visit your site</a> to see how it looks."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:580
+msgid "You can select an image to be shown at the top of your site by uploading from your computer or choosing from your media library. After selecting an image you will be able to crop it."
+msgstr ""
+
+#. translators: 1: Image width in pixels, 2: Image height in pixels.
+#: wp-admin/includes/class-custom-image-header.php:587
+msgid "Images of exactly <strong>%1$d &times; %2$d pixels</strong> will be used as-is."
+msgstr ""
+
+#. translators: %s: Size in pixels.
+#: wp-admin/includes/class-custom-image-header.php:595
+msgid "Images should be at least %s wide."
+msgstr ""
+
+#. translators: %d: Custom header width.
+#. translators: %d: Custom header height.
+#: wp-admin/includes/class-custom-image-header.php:598
+#: wp-admin/includes/class-custom-image-header.php:610
+#: wp-admin/includes/class-custom-image-header.php:626
+#: wp-admin/includes/class-custom-image-header.php:638
+msgid "%d pixels"
+msgstr ""
+
+#. translators: %s: Size in pixels.
+#: wp-admin/includes/class-custom-image-header.php:607
+msgid "Images should be at least %s tall."
+msgstr ""
+
+#. translators: %s: Size in pixels.
+#: wp-admin/includes/class-custom-image-header.php:623
+msgid "Suggested width is %s."
+msgstr ""
+
+#. translators: %s: Size in pixels.
+#: wp-admin/includes/class-custom-image-header.php:635
+msgid "Suggested height is %s."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:668
+msgid "Choose a Custom Header"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:669
+msgid "Set as header"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:684
+msgid "Uploaded Images"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:686
+msgid "You can choose one of your previously uploaded headers, or show a random one."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:697
+msgid "Default Images"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:700
+msgid "If you don&lsquo;t want to upload your own image, you can use one of these cool headers, or show a random one."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:702
+msgid "You can use one of these cool headers or show a random one on each page."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:716
+msgid "This will remove the header image. You will not be able to restore any customizations."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:717
+msgid "Remove Header Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:732
+msgid "Reset Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:734
+msgid "This will restore the original header image. You will not be able to restore any customizations."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:735
+msgid "Restore Original Header Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:752
+msgid "Show header text with your image."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:758
+msgid "Text Color"
+msgstr ""
+
+#. translators: %s: Default text color.
+#: wp-admin/includes/class-custom-image-header.php:780
+msgctxt "color"
+msgid "Default: %s"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:819
+#: wp-admin/includes/class-custom-image-header.php:1005
+msgid "The active theme does not support uploading a custom header image."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:898
+#: wp-admin/includes/class-custom-image-header.php:1057
+#: wp-admin/includes/class-custom-image-header.php:1400
+msgid "Image could not be processed. Please go back and try again."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:898
+#: wp-admin/includes/class-custom-image-header.php:1057
+msgid "Image Processing Error"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:913
+msgid "Crop Header Image"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:916
+msgid "Choose the part of the image you want to use as your header."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:917
+msgid "You need JavaScript to choose a part of the image."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:935
+msgid "Crop and Publish"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:941
+msgid "Skip Cropping, Publish Image as Is"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:969
+msgid "Image Upload Error"
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:1016
+msgid "The active theme does not support a flexible sized header image."
+msgstr ""
+
+#: wp-admin/includes/class-custom-image-header.php:1105
+msgid "Sorry, you are not allowed to customize headers."
+msgstr ""
+
+#: wp-admin/includes/class-file-upload-upgrader.php:57
+#: wp-admin/includes/class-file-upload-upgrader.php:120
+#: wp-admin/includes/class-file-upload-upgrader.php:136
+msgid "Please select a file"
+msgstr ""
+
+#: wp-admin/includes/class-file-upload-upgrader.php:92
+#: wp-admin/includes/file.php:1636
+#: wp-admin/includes/file.php:1791
+msgid "Incompatible Archive."
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader-skin.php:31
+#: wp-admin/update-core.php:667
+#: wp-admin/update-core.php:1073
+msgid "Update Translations"
+msgstr ""
+
+#. translators: 1: Project name (plugin, theme, or ClassicPress), 2: Language.
+#: wp-admin/includes/class-language-pack-upgrader-skin.php:51
+#: wp-admin/includes/class-wp-automatic-updater.php:437
+msgid "Updating translations for %1$s (%2$s)&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:113
+msgid "Some of your translations need updating. Sit tight for a few more seconds while they are updated as well."
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:114
+#: wp-admin/update-core.php:656
+msgid "Your translations are all up to date."
+msgstr ""
+
+#. translators: %s: Package URL.
+#: wp-admin/includes/class-language-pack-upgrader.php:117
+msgid "Downloading translation from %s&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:119
+msgid "Translation update failed."
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:120
+msgid "Translation updated successfully."
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:121
+msgid "Removing the old version of the translation&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-language-pack-upgrader.php:122
+msgid "Could not remove the old translation."
+msgstr ""
+
+#. translators: 1: .po, 2: .mo
+#: wp-admin/includes/class-language-pack-upgrader.php:352
+msgid "The language pack is missing either the %1$s or %2$s files."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:104
+msgid "Activate Plugin &amp; Run Importer"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:110
+msgid "Activate Plugin &amp; Go to Press This"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:116
+#: wp-admin/includes/class-plugin-upgrader-skin.php:96
+msgid "Activate Plugin"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:124
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:581
+#: wp-admin/includes/class-wp-plugins-list-table.php:599
+#: wp-admin/includes/class-wp-plugins-list-table.php:806
+#: wp-admin/js/updates.js:755
+msgid "Network Activate"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:133
+msgid "Go to Importers"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:139
+#: wp-admin/includes/class-plugin-installer-skin.php:145
+msgid "Go to Plugin Installer"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:211
+msgid "This plugin is already installed."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:216
+msgid "Plugin name"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:217
+#: wp-admin/includes/class-theme-installer-skin.php:240
+#: wp-admin/includes/class-wp-debug-data.php:71
+#: wp-admin/includes/class-wp-debug-data.php:1095
+#: wp-admin/includes/class-wp-debug-data.php:1190
+msgid "Version"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:219
+#: wp-admin/includes/class-theme-installer-skin.php:242
+msgid "Required WordPress version"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:220
+#: wp-admin/includes/class-theme-installer-skin.php:243
+msgid "Required PHP version"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:224
+msgctxt "plugin"
+msgid "Current"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:225
+msgctxt "plugin"
+msgid "Uploaded"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:259
+msgid "The plugin cannot be updated due to the following:"
+msgstr ""
+
+#. translators: 1: Current PHP version, 2: Version required by the uploaded plugin.
+#: wp-admin/includes/class-plugin-installer-skin.php:268
+#: wp-admin/includes/class-plugin-upgrader.php:449
+msgid "The PHP version on your server is %1$s, however the uploaded plugin requires %2$s."
+msgstr ""
+
+#. translators: 1: Current WordPress version, 2: Version required by the uploaded plugin.
+#. translators: 1: Current ClassicPress version, 2: Version required by the uploaded plugin.
+#: wp-admin/includes/class-plugin-installer-skin.php:280
+#: wp-admin/includes/class-plugin-upgrader.php:460
+msgid "Your ClassicPress version is %1$s, however the uploaded plugin requires %2$s."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/class-plugin-installer-skin.php:295
+msgid "You are uploading an older version of a current plugin. You can continue to install the older version, but be sure to <a href=\"%s\">back up your database and files</a> first."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:296
+#: wp-admin/includes/class-plugin-installer-skin.php:302
+#: wp-admin/includes/class-theme-installer-skin.php:331
+#: wp-admin/includes/class-theme-installer-skin.php:337
+msgid "https://wordpress.org/documentation/article/wordpress-backups/"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/class-plugin-installer-skin.php:301
+msgid "You are updating a plugin. Be sure to <a href=\"%s\">back up your database and files</a> first."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:313
+msgctxt "plugin"
+msgid "Replace current with uploaded"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:324
+#: wp-admin/includes/class-theme-installer-skin.php:359
+msgid "Cancel and go back"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-installer-skin.php:342
+#: wp-admin/includes/class-theme-installer-skin.php:377
+msgid "The uploaded file has expired. Please go back and upload it again."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader-skin.php:62
+#: wp-admin/update.php:63
+msgid "Update Plugin"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader-skin.php:85
+#: wp-admin/update-core.php:1005
+#: wp-admin/update-core.php:1046
+msgid "Update progress"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:57
+msgid "The plugin is at the latest version."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:62
+msgid "Removing the old version of the plugin&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:63
+msgid "Could not remove the old plugin."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:65
+#: wp-admin/includes/class-plugin-upgrader.php:92
+msgid "Plugin updated successfully."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:66
+msgid "Plugins updated successfully."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:75
+#: wp-admin/includes/class-theme-upgrader.php:73
+msgid "Installation package not available."
+msgstr ""
+
+#. translators: %s: Package URL.
+#: wp-admin/includes/class-plugin-upgrader.php:77
+#: wp-admin/includes/class-theme-upgrader.php:75
+msgid "Downloading installation package from %s&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:78
+#: wp-admin/includes/class-theme-upgrader.php:76
+msgid "Unpacking the package&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:79
+msgid "Installing the plugin&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:80
+msgid "Removing the current plugin&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:81
+msgid "Could not remove the current plugin."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:82
+msgid "The plugin contains no files."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:83
+msgid "Plugin installation failed."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:84
+msgid "Plugin installed successfully."
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Plugin version.
+#: wp-admin/includes/class-plugin-upgrader.php:86
+msgid "Successfully installed the plugin <strong>%1$s %2$s</strong>."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:90
+msgid "Updating the plugin&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:96
+msgid "Downgrading the plugin&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:97
+msgid "Plugin downgrade failed."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:98
+msgid "Plugin downgraded successfully."
+msgstr ""
+
+#: wp-admin/includes/class-plugin-upgrader.php:440
+msgid "No valid plugins were found."
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:131
+#: wp-admin/includes/class-theme-upgrader-skin.php:103
+#: wp-admin/includes/class-wp-themes-list-table.php:222
+#: wp-admin/includes/theme.php:1036
+#: wp-admin/includes/theme.php:1038
+#: wp-admin/theme-install.php:389
+#: wp-admin/themes.php:562
+#: wp-admin/themes.php:571
+#: wp-admin/themes.php:922
+#: wp-admin/themes.php:930
+#: wp-admin/themes.php:1153
+#: wp-admin/themes.php:1162
+#: wp-admin/js/updates.js:1430
+msgid "Live Preview"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Theme name.
+#: wp-admin/includes/class-theme-installer-skin.php:133
+#: wp-admin/includes/class-theme-upgrader-skin.php:105
+msgid "Live Preview &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:141
+#: wp-admin/includes/class-theme-upgrader-skin.php:113
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:568
+#: wp-admin/includes/class-wp-plugins-list-table.php:599
+#: wp-admin/includes/class-wp-plugins-list-table.php:867
+#: wp-admin/includes/class-wp-themes-list-table.php:215
+#: wp-admin/includes/theme.php:1032
+#: wp-admin/theme-install.php:368
+#: wp-admin/theme-install.php:443
+#: wp-admin/themes.php:556
+#: wp-admin/themes.php:916
+#: wp-admin/themes.php:1151
+#: wp-admin/js/updates.js:766
+#: wp-admin/js/updates.js:1419
+msgid "Activate"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Theme name.
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-theme-installer-skin.php:143
+#: wp-admin/includes/class-theme-upgrader-skin.php:115
+#: wp-admin/includes/class-wp-themes-list-table.php:214
+msgctxt "theme"
+msgid "Activate &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:150
+#: wp-admin/js/updates.js:1408
+msgid "Network Enable"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:158
+msgid "Go to Theme Installer"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:224
+msgid "This theme is already installed."
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:239
+msgid "Theme name"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:244
+#: wp-admin/includes/class-wp-debug-data.php:1109
+msgid "Parent theme"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:248
+msgctxt "theme"
+msgid "Active"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:248
+msgctxt "theme"
+msgid "Uploaded"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:270
+msgid "(not found)"
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:294
+msgid "The theme cannot be updated due to the following:"
+msgstr ""
+
+#. translators: 1: Current PHP version, 2: Version required by the uploaded theme.
+#: wp-admin/includes/class-theme-installer-skin.php:303
+#: wp-admin/includes/class-theme-upgrader.php:608
+msgid "The PHP version on your server is %1$s, however the uploaded theme requires %2$s."
+msgstr ""
+
+#. translators: 1: Current WordPress version, 2: Version required by the uploaded theme.
+#: wp-admin/includes/class-theme-installer-skin.php:315
+#: wp-admin/includes/class-theme-upgrader.php:618
+msgid "Your ClassicPress version is %1$s, however the uploaded theme requires %2$s."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/class-theme-installer-skin.php:330
+msgid "You are uploading an older version of the active theme. You can continue to install the older version, but be sure to <a href=\"%s\">back up your database and files</a> first."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/class-theme-installer-skin.php:336
+msgid "You are updating a theme. Be sure to <a href=\"%s\">back up your database and files</a> first."
+msgstr ""
+
+#: wp-admin/includes/class-theme-installer-skin.php:348
+msgctxt "theme"
+msgid "Replace active with uploaded"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader-skin.php:44
+#: wp-admin/update.php:243
+msgid "Update Theme"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Theme name.
+#: wp-admin/includes/class-theme-upgrader-skin.php:94
+msgid "Customize &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:56
+msgid "The theme is at the latest version."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:61
+#: wp-admin/includes/class-theme-upgrader.php:78
+msgid "Removing the old version of the theme&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:62
+#: wp-admin/includes/class-theme-upgrader.php:79
+msgid "Could not remove the old theme."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:64
+#: wp-admin/includes/class-theme-upgrader.php:101
+msgid "Theme updated successfully."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:77
+msgid "Installing the theme&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:80
+msgid "The theme contains no files."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:81
+msgid "Theme installation failed."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:82
+msgid "Theme installed successfully."
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme version.
+#: wp-admin/includes/class-theme-upgrader.php:84
+msgid "Successfully installed the theme <strong>%1$s %2$s</strong>."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:85
+msgid "This theme requires a parent theme. Checking if it is installed&#8230;"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme version.
+#: wp-admin/includes/class-theme-upgrader.php:87
+msgid "Preparing to install <strong>%1$s %2$s</strong>&#8230;"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme version.
+#: wp-admin/includes/class-theme-upgrader.php:89
+msgid "The parent theme, <strong>%1$s %2$s</strong>, is currently installed."
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme version.
+#: wp-admin/includes/class-theme-upgrader.php:91
+msgid "Successfully installed the parent theme, <strong>%1$s %2$s</strong>."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-theme-upgrader.php:93
+msgid "<strong>The parent theme could not be found.</strong> You will need to install the parent theme, %s, before you can use this child theme."
+msgstr ""
+
+#. translators: %s: Theme error.
+#: wp-admin/includes/class-theme-upgrader.php:95
+msgid "The active theme has the following error: \"%s\"."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:99
+msgid "Updating the theme&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:105
+msgid "Downgrading the theme&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:106
+msgid "Theme downgrade failed."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:107
+msgid "Theme downgraded successfully."
+msgstr ""
+
+#. translators: %s: style.css
+#: wp-admin/includes/class-theme-upgrader.php:538
+msgid "The theme is missing the %s stylesheet."
+msgstr ""
+
+#. translators: %s: style.css
+#: wp-admin/includes/class-theme-upgrader.php:564
+msgid "The %s stylesheet does not contain a valid theme header."
+msgstr ""
+
+#. translators: 1: templates/index.html, 2: index.php, 3: Documentation URL, 4: Template, 5: style.css
+#: wp-admin/includes/class-theme-upgrader.php:586
+msgid "Template is missing. Standalone themes need to have a %1$s or %2$s template file. <a href=\"%3$s\">Child themes</a> need to have a %4$s header in the %5$s stylesheet."
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:589
+#: wp-admin/includes/class-wp-themes-list-table.php:285
+#: wp-admin/theme-editor.php:44
+#: wp-admin/theme-editor.php:376
+#: wp-admin/update-core.php:504
+msgid "https://developer.wordpress.org/themes/advanced-topics/child-themes/"
+msgstr ""
+
+#: wp-admin/includes/class-theme-upgrader.php:601
+#: wp-admin/theme-install.php:319
+#: wp-admin/theme-install.php:524
+msgid "FSE themes don't work with ClassicPress."
+msgstr ""
+
+#. translators: %s: Title of an invalid menu item.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:108
+msgid "%s (Invalid)"
+msgstr ""
+
+#. translators: %s: Title of a menu item in draft status.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:112
+msgid "%s (Pending)"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:129
+msgid "sub item"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:147
+#: wp-admin/includes/template.php:1309
+msgid "Move up"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:164
+#: wp-admin/includes/template.php:1322
+msgid "Move down"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:183
+msgid "Move menu item"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:185
+#: wp-admin/includes/class-walker-nav-menu-edit.php:254
+msgid "Move"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:202
+msgid "Navigation Label"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:208
+#: wp-admin/includes/nav-menu.php:1126
+msgid "Title Attribute"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:215
+msgid "Open link in a new tab"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:220
+msgid "CSS Classes (optional)"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:234
+msgid "The description will be displayed in the menu if the active theme supports it."
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:255
+msgid "Up one"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:256
+msgid "Down one"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:259
+msgid "To the top"
+msgstr ""
+
+#. translators: %s: Link to menu item's original object.
+#: wp-admin/includes/class-walker-nav-menu-edit.php:267
+msgid "Original: %s"
+msgstr ""
+
+#: wp-admin/includes/class-walker-nav-menu-edit.php:286
+#: wp-admin/includes/class-wp-users-list-table.php:276
+#: wp-admin/includes/class-wp-users-list-table.php:487
+msgid "Remove"
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:29
+msgid "Created"
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:30
+msgid "Last Used"
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:31
+msgid "Last IP"
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:32
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:118
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:238
+msgid "Revoke"
+msgstr ""
+
+#. translators: %s: the application password's given name.
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:117
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:237
+msgid "Revoke \"%s\""
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:156
+msgid "Revoke all application passwords"
+msgstr ""
+
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:225
+msgid "Just now"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-application-passwords-list-table.php:258
+#: wp-admin/includes/class-wp-comments-list-table.php:882
+#: wp-admin/includes/class-wp-list-table.php:650
+#: wp-admin/includes/class-wp-list-table.php:1594
+#: wp-admin/includes/update.php:919
+msgid "Show more details"
+msgstr ""
+
+#. translators: %s: The "$dir" argument.
+#: wp-admin/includes/class-wp-automatic-updater.php:81
+msgid "The \"%s\" argument must be a non-empty string."
+msgstr ""
+
+#. translators: %s: WordPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:404
+msgid "Updating to ClassicPress %s"
+msgstr ""
+
+#. translators: %s: WordPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:406
+msgid "ClassicPress %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-automatic-updater.php:418
+msgid "Updating theme: %s"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-automatic-updater.php:430
+msgid "Updating plugin: %s"
+msgstr ""
+
+#. translators: %s: Project name (plugin, theme, or WordPress).
+#: wp-admin/includes/class-wp-automatic-updater.php:435
+msgid "Translations for %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:462
+#: wp-admin/includes/class-wp-upgrader.php:151
+#: wp-admin/includes/file.php:1558
+#: wp-admin/includes/plugin.php:948
+#: wp-admin/includes/theme.php:62
+msgid "Could not access filesystem."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:477
+#: wp-admin/js/updates.js:826
+#: wp-admin/js/updates.js:1495
+msgid "Installation failed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:480
+msgid "ClassicPress updated successfully."
+msgstr ""
+
+#. translators: Site updated notification email subject. 1: Site title, 2: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:768
+msgid "[%1$s] Your site has updated to ClassicPress %2$s"
+msgstr ""
+
+#. translators: Update available notification email subject. 1: Site title, 2: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:774
+msgid "[%1$s] ClassicPress %2$s is available. Please update!"
+msgstr ""
+
+#. translators: Site down notification email subject. 1: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:779
+msgid "[%1$s] URGENT: Your site may be down due to a failed update"
+msgstr ""
+
+#. translators: 1: Home URL, 2: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:796
+msgid "Howdy! Your site at %1$s has been updated automatically to ClassicPress %2$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:802
+msgid "No further action is needed on your part."
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:808
+msgid "For more on version %s, see the About ClassicPress screen:"
+msgstr ""
+
+#. translators: %s: ClassicPress latest version.
+#: wp-admin/includes/class-wp-automatic-updater.php:813
+msgid "ClassicPress %s is also now available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:814
+#: wp-admin/includes/class-wp-automatic-updater.php:837
+msgid "Updating is easy and only takes a few moments:"
+msgstr ""
+
+#. translators: 1: Home URL, 2: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:824
+msgid "Please update your site at %1$s to ClassicPress %2$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:834
+msgid "An attempt was made, but your site could not be updated automatically."
+msgstr ""
+
+#. translators: 1: Home URL, 2: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:845
+msgid "Your site at %1$s experienced a critical failure while trying to update ClassicPress to version %2$s."
+msgstr ""
+
+#. translators: 1: Home URL, 2: ClassicPress latest version.
+#: wp-admin/includes/class-wp-automatic-updater.php:852
+msgid "Your site at %1$s experienced a critical failure while trying to update to the latest version of ClassicPress, %2$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:858
+msgid "This means your site may be offline or broken. Don't panic; this can be fixed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:860
+msgid "Please check out your site now. It's possible that everything is working. If it says you need to update, you should do so:"
+msgstr ""
+
+#. translators: %s: Support email address.
+#: wp-admin/includes/class-wp-automatic-updater.php:870
+msgid "The ClassicPress team is willing to help you. Forward this email to %s and the team will work with you to make sure your site is working."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:875
+#: wp-admin/includes/class-wp-automatic-updater.php:1309
+msgid "If you experience any issues or need support, the volunteers in the ClassicPress.net support forums may be able to help."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:876
+#: wp-admin/includes/plugin-install.php:186
+#: wp-admin/includes/theme.php:551
+#: wp-admin/includes/theme.php:566
+#: wp-admin/includes/translation-install.php:85
+#: wp-admin/includes/translation-install.php:97
+#: wp-admin/theme-install.php:65
+msgid "https://wordpress.org/support/forums/"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:881
+#: wp-admin/update-core.php:840
+msgid "Keeping your site updated is important for security. It also makes the internet a safer place for you and your readers."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:885
+msgid "Reach out to ClassicPress Core developers to ensure you'll never have this problem again."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:890
+msgid "You also have some plugins or themes with updates available. Update them now:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:894
+#: wp-admin/includes/class-wp-automatic-updater.php:1311
+msgid "The ClassicPress Team"
+msgstr ""
+
+#. translators: %s: WordPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:899
+msgid "Your site was running version %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:900
+msgid "Some data that describes the error your site encountered has been put together."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:901
+msgid "Your hosting company, support forum volunteers, or a friendly developer may be able to use this information to help you:"
+msgstr ""
+
+#. translators: %s: Error code.
+#: wp-admin/includes/class-wp-automatic-updater.php:918
+msgid "Error code: %s"
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1090
+msgid "[%s] Some plugins and themes have automatically updated"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1093
+msgid "Howdy! Some plugins and themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1098
+msgid "[%s] Some plugins were automatically updated"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1101
+msgid "Howdy! Some plugins have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1106
+msgid "[%s] Some themes were automatically updated"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1109
+msgid "Howdy! Some themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1119
+msgid "[%s] Some plugins and themes have failed to update"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1122
+msgid "Howdy! Plugins and themes failed to update on your site at %s."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1127
+msgid "[%s] Some plugins have failed to update"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1130
+msgid "Howdy! Plugins failed to update on your site at %s."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1135
+msgid "[%s] Some themes have failed to update"
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1138
+msgid "Howdy! Themes failed to update on your site at %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1148
+msgid "Please check your site now. It’s possible that everything is working. If there are updates available, you should update."
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1153
+msgid "These plugins failed to update:"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Current version number, 3: New version number, 4: Plugin URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1166
+#: wp-admin/includes/class-wp-automatic-updater.php:1238
+msgid "- %1$s (from version %2$s to %3$s)%4$s"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Version number, 3: Plugin URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1175
+#: wp-admin/includes/class-wp-automatic-updater.php:1247
+msgid "- %1$s version %2$s%3$s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1192
+msgid "These themes failed to update:"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Current version number, 3: New version number.
+#: wp-admin/includes/class-wp-automatic-updater.php:1198
+#: wp-admin/includes/class-wp-automatic-updater.php:1269
+msgid "- %1$s (from version %2$s to %3$s)"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Version number.
+#: wp-admin/includes/class-wp-automatic-updater.php:1206
+#: wp-admin/includes/class-wp-automatic-updater.php:1277
+msgid "- %1$s version %2$s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1225
+msgid "These plugins are now up to date:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1263
+msgid "These themes are now up to date:"
+msgstr ""
+
+#. translators: %s: Plugins screen URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1293
+msgid "To manage plugins on your site, visit the Plugins page: %s"
+msgstr ""
+
+#. translators: %s: Themes screen URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1302
+msgid "To manage themes on your site, visit the Themes page: %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1310
+msgid "https://forums.classicpress.net/c/support/"
+msgstr ""
+
+#. translators: %s: Network home URL.
+#: wp-admin/includes/class-wp-automatic-updater.php:1368
+msgid "ClassicPress site: %s"
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:1376
+msgid "SUCCESS: ClassicPress was successfully updated to %s"
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/class-wp-automatic-updater.php:1379
+msgid "FAILED: ClassicPress failed to update to %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1396
+msgid "The following plugins were successfully updated:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1397
+msgid "The following themes were successfully updated:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1398
+msgid "The following translations were successfully updated:"
+msgstr ""
+
+#. translators: %s: Name of plugin / theme / translation.
+#: wp-admin/includes/class-wp-automatic-updater.php:1404
+msgid "SUCCESS: %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1411
+msgid "The following plugins failed to update:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1412
+msgid "The following themes failed to update:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1413
+msgid "The following translations failed to update:"
+msgstr ""
+
+#. translators: %s: Name of plugin / theme / translation.
+#: wp-admin/includes/class-wp-automatic-updater.php:1421
+msgid "FAILED: %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1438
+msgid ""
+"BETA TESTING?\n"
+"=============\n"
+"\n"
+"This debugging email is sent when you are using a development version of ClassicPress.\n"
+"\n"
+"If you think these failures might be due to a bug in ClassicPress, could you report it?\n"
+" * Open a thread in the support forums: https://wordpress.org/support/forum/alphabeta\n"
+" * Or, if you're comfortable writing a bug report: https://core.trac.wordpress.org/\n"
+"\n"
+"Thanks! -- The ClassicPress Team"
+msgstr ""
+
+#. translators: Background update failed notification email subject. %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1454
+msgid "[%s] Background Update Failed"
+msgstr ""
+
+#. translators: Background update finished notification email subject. %s: Site title.
+#: wp-admin/includes/class-wp-automatic-updater.php:1457
+msgid "[%s] Background Update Finished"
+msgstr ""
+
+#: wp-admin/includes/class-wp-automatic-updater.php:1461
+msgid ""
+"UPDATE LOG\n"
+"=========="
+msgstr ""
+
+#. translators: 1: Error code, 2: Error message.
+#: wp-admin/includes/class-wp-automatic-updater.php:1496
+msgid "Rollback Error: [%1$s] %2$s"
+msgstr ""
+
+#. translators: 1: Error code, 2: Error message.
+#: wp-admin/includes/class-wp-automatic-updater.php:1499
+msgid "Error: [%1$s] %2$s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:219
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:221
+msgid "No comments found in Trash."
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:223
+msgid "No comments found."
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:240
+msgctxt "comments"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:247
+msgctxt "comments"
+msgid "Mine <span class=\"count\">(%s)</span>"
+msgid_plural "Mine <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:254
+msgctxt "comments"
+msgid "Pending <span class=\"count\">(%s)</span>"
+msgid_plural "Pending <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:261
+msgctxt "comments"
+msgid "Approved <span class=\"count\">(%s)</span>"
+msgid_plural "Approved <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:268
+msgctxt "comments"
+msgid "Spam <span class=\"count\">(%s)</span>"
+msgid_plural "Spam <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-comments-list-table.php:275
+msgctxt "comments"
+msgid "Trash <span class=\"count\">(%s)</span>"
+msgid_plural "Trash <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:360
+#: wp-admin/includes/class-wp-comments-list-table.php:729
+#: wp-admin/includes/class-wp-comments-list-table.php:754
+#: wp-admin/includes/dashboard.php:752
+msgid "Unapprove"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:364
+#: wp-admin/includes/class-wp-comments-list-table.php:737
+#: wp-admin/includes/class-wp-comments-list-table.php:746
+#: wp-admin/includes/dashboard.php:744
+msgid "Approve"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:372
+#: wp-admin/includes/class-wp-comments-list-table.php:783
+#: wp-admin/includes/class-wp-media-list-table.php:184
+#: wp-admin/includes/class-wp-media-list-table.php:821
+#: wp-admin/includes/class-wp-posts-list-table.php:438
+#: wp-admin/includes/class-wp-posts-list-table.php:1468
+msgid "Restore"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:374
+msgctxt "comment"
+msgid "Not spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:378
+#: wp-admin/includes/class-wp-media-list-table.php:185
+#: wp-admin/includes/class-wp-media-list-table.php:190
+#: wp-admin/includes/class-wp-posts-list-table.php:446
+#: wp-admin/includes/meta-boxes.php:366
+#: wp-admin/includes/meta-boxes.php:475
+msgid "Delete permanently"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:418
+#: wp-admin/includes/class-wp-links-list-table.php:120
+#: wp-admin/includes/class-wp-media-list-table.php:217
+#: wp-admin/includes/class-wp-posts-list-table.php:600
+msgid "Filter"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:426
+msgid "Empty Spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:426
+#: wp-admin/includes/class-wp-media-list-table.php:222
+#: wp-admin/includes/class-wp-posts-list-table.php:607
+msgid "Empty Trash"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:470
+#: wp-admin/includes/class-wp-post-comments-list-table.php:26
+msgctxt "column name"
+msgid "Comment"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:477
+msgctxt "column name"
+msgid "Submitted on"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:502
+#: wp-admin/includes/class-wp-posts-list-table.php:1894
+msgid "Pings"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-comments-list-table.php:510
+msgid "Filter by comment type"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:515
+msgid "All comment types"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:728
+#: wp-admin/includes/class-wp-comments-list-table.php:753
+#: wp-admin/includes/dashboard.php:751
+msgid "Unapprove this comment"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:736
+#: wp-admin/includes/class-wp-comments-list-table.php:745
+#: wp-admin/includes/dashboard.php:743
+msgid "Approve this comment"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:763
+#: wp-admin/includes/dashboard.php:774
+msgid "Mark this comment as spam"
+msgstr ""
+
+#. translators: "Mark as spam" link.
+#: wp-admin/includes/class-wp-comments-list-table.php:765
+#: wp-admin/includes/dashboard.php:776
+msgctxt "verb"
+msgid "Spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:772
+msgid "Restore this comment from the spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:773
+msgctxt "comment"
+msgid "Not Spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:782
+msgid "Restore this comment from the Trash"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:792
+#: wp-admin/includes/dashboard.php:784
+msgid "Delete this comment permanently"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:800
+#: wp-admin/includes/dashboard.php:792
+msgid "Move this comment to the Trash"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:801
+#: wp-admin/includes/class-wp-media-list-table.php:769
+#: wp-admin/includes/class-wp-media-list-table.php:829
+#: wp-admin/includes/class-wp-posts-list-table.php:1476
+#: wp-admin/includes/dashboard.php:793
+msgctxt "verb"
+msgid "Trash"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:809
+#: wp-admin/includes/dashboard.php:758
+msgid "Edit this comment"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:821
+msgid "Quick edit this comment inline"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:822
+#: wp-admin/includes/class-wp-posts-list-table.php:1457
+#: wp-admin/includes/class-wp-terms-list-table.php:483
+msgid "Quick&nbsp;Edit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:831
+#: wp-admin/includes/dashboard.php:766
+msgid "Reply to this comment"
+msgstr ""
+
+#: wp-admin/includes/class-wp-comments-list-table.php:832
+#: wp-admin/includes/dashboard.php:767
+#: wp-admin/js/edit-comments.js:372
+#: wp-admin/js/edit-comments.js:1014
+msgid "Reply"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-comments-list-table.php:902
+msgid "Select comment"
+msgstr ""
+
+#. translators: %s: Latest ClassicPress version number.
+#. translators: %s: Latest plugin version number.
+#. translators: %s: Latest theme version number.
+#: wp-admin/includes/class-wp-debug-data.php:57
+#: wp-admin/includes/class-wp-debug-data.php:971
+#: wp-admin/includes/class-wp-debug-data.php:1061
+#: wp-admin/includes/class-wp-debug-data.php:1173
+#: wp-admin/includes/class-wp-debug-data.php:1293
+msgid "(Latest version: %s)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:68
+#: wp-admin/includes/class-wp-debug-data.php:73
+#: wp-admin/includes/class-wp-privacy-policy-content.php:670
+#: wp-admin/includes/media.php:531
+#: wp-admin/includes/template.php:2012
+#: wp-admin/install.php:77
+#: wp-admin/maint/repair.php:24
+#: wp-admin/setup-config.php:115
+#: wp-admin/upgrade.php:69
+msgid "ClassicPress"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:76
+#: wp-admin/options-general.php:367
+msgid "Site Language"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:80
+msgid "User Language"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:84
+#: wp-admin/options-general.php:425
+msgid "Timezone"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:88
+msgid "Home URL"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:93
+msgid "Site URL"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-debug-data.php:98
+#: wp-admin/options-permalink.php:330
+#: wp-admin/options-permalink.php:336
+msgid "Permalink structure"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:99
+msgid "No permalink structure set"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:103
+msgid "Is this site using HTTPS?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:104
+#: wp-admin/includes/class-wp-debug-data.php:109
+#: wp-admin/includes/class-wp-debug-data.php:114
+#: wp-admin/includes/class-wp-debug-data.php:119
+#: wp-admin/includes/class-wp-debug-data.php:774
+#: wp-admin/includes/class-wp-debug-data.php:783
+#: wp-admin/includes/class-wp-debug-data.php:792
+#: wp-admin/includes/class-wp-links-list-table.php:264
+msgid "Yes"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:104
+#: wp-admin/includes/class-wp-debug-data.php:109
+#: wp-admin/includes/class-wp-debug-data.php:114
+#: wp-admin/includes/class-wp-debug-data.php:119
+#: wp-admin/includes/class-wp-debug-data.php:774
+#: wp-admin/includes/class-wp-debug-data.php:783
+#: wp-admin/includes/class-wp-debug-data.php:792
+#: wp-admin/includes/class-wp-links-list-table.php:266
+msgid "No"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:108
+msgid "Is this a multisite?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:113
+msgid "Can anyone register on this site?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:118
+msgid "Is this site discouraging search engines?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:123
+msgid "Default comment status"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:124
+msgctxt "comment status"
+msgid "Open"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:124
+msgctxt "comment status"
+msgid "Closed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:128
+msgid "Environment type"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:137
+msgid "Directories and Sizes"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:143
+msgid "Drop-ins"
+msgstr ""
+
+#. translators: %s: wp-content directory name.
+#: wp-admin/includes/class-wp-debug-data.php:147
+#: wp-admin/includes/class-wp-plugins-list-table.php:666
+msgid "Drop-ins are single files, found in the %s directory, that replace or enhance ClassicPress features in ways that are not possible for traditional plugins."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:154
+#: wp-admin/includes/theme.php:817
+#: wp-admin/themes.php:971
+msgid "Active Theme"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:159
+msgid "Parent Theme"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:164
+msgid "Inactive Themes"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:170
+msgid "Must Use Plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:176
+msgid "Active Plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:182
+msgid "Inactive Plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:188
+msgid "Media Handling"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:193
+msgid "Server"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:194
+msgid "The options shown below relate to your server setup. If changes are required, you may need your web host&#8217;s assistance."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:199
+msgid "Database"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:204
+#: wp-admin/includes/class-wp-debug-data.php:214
+#: wp-admin/includes/class-wp-debug-data.php:223
+#: wp-admin/includes/class-wp-debug-data.php:232
+#: wp-admin/includes/class-wp-debug-data.php:283
+#: wp-admin/includes/class-wp-debug-data.php:288
+#: wp-admin/includes/class-wp-debug-data.php:298
+#: wp-admin/includes/class-wp-debug-data.php:303
+#: wp-admin/includes/class-wp-debug-data.php:532
+#: wp-admin/includes/class-wp-debug-data.php:1150
+#: wp-admin/includes/class-wp-debug-data.php:1236
+msgid "Disabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:209
+#: wp-admin/includes/class-wp-debug-data.php:214
+#: wp-admin/includes/class-wp-debug-data.php:223
+#: wp-admin/includes/class-wp-debug-data.php:232
+#: wp-admin/includes/class-wp-debug-data.php:283
+#: wp-admin/includes/class-wp-debug-data.php:288
+#: wp-admin/includes/class-wp-debug-data.php:298
+#: wp-admin/includes/class-wp-debug-data.php:303
+#: wp-admin/includes/class-wp-debug-data.php:532
+#: wp-admin/includes/class-wp-debug-data.php:1148
+#: wp-admin/includes/class-wp-debug-data.php:1234
+msgid "Enabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:217
+#: wp-admin/includes/class-wp-debug-data.php:226
+#: wp-admin/includes/class-wp-debug-data.php:235
+#: wp-admin/includes/class-wp-debug-data.php:243
+#: wp-admin/includes/class-wp-debug-data.php:257
+#: wp-admin/includes/class-wp-debug-data.php:262
+#: wp-admin/includes/class-wp-debug-data.php:328
+#: wp-admin/includes/class-wp-debug-data.php:333
+#: wp-admin/includes/class-wp-debug-data.php:1105
+#: wp-admin/includes/class-wp-debug-data.php:1200
+msgid "Undefined"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:247
+msgid "ClassicPress Constants"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:248
+msgid "These settings alter where and how parts of ClassicPress are loaded."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:346
+msgid "Filesystem Permissions"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:347
+msgid "Shows whether ClassicPress is able to write to the directories it needs access to."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:350
+msgid "The main ClassicPress directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:351
+#: wp-admin/includes/class-wp-debug-data.php:356
+#: wp-admin/includes/class-wp-debug-data.php:361
+#: wp-admin/includes/class-wp-debug-data.php:366
+#: wp-admin/includes/class-wp-debug-data.php:371
+#: wp-admin/includes/class-wp-debug-data.php:1360
+msgid "Writable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:351
+#: wp-admin/includes/class-wp-debug-data.php:356
+#: wp-admin/includes/class-wp-debug-data.php:361
+#: wp-admin/includes/class-wp-debug-data.php:366
+#: wp-admin/includes/class-wp-debug-data.php:371
+#: wp-admin/includes/class-wp-debug-data.php:1360
+msgid "Not writable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:355
+msgid "The wp-content directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:360
+msgid "The uploads directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:365
+msgid "The plugins directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:370
+msgid "The themes directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:394
+msgid "Site count"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:399
+msgid "Network count"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:405
+msgid "User count"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:415
+msgid "ClassicPress directory location"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:419
+msgid "ClassicPress directory size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:424
+msgid "Uploads directory location"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:428
+msgid "Uploads directory size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:433
+msgid "Themes directory location"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:437
+msgid "Themes directory size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:442
+msgid "Plugins directory location"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:446
+msgid "Plugins directory size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:451
+msgid "Database size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:456
+msgid "Total installation size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:470
+#: wp-admin/includes/class-wp-debug-data.php:492
+#: wp-admin/includes/class-wp-debug-data.php:509
+#: wp-admin/includes/class-wp-debug-data.php:1649
+msgid "Not available"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:482
+msgid "Active editor"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:496
+msgid "ImageMagick version number"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:501
+msgid "ImageMagick version string"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:508
+msgid "Imagick version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:514
+msgid "File upload settings"
+msgstr ""
+
+#. translators: %s: ini_get()
+#: wp-admin/includes/class-wp-debug-data.php:517
+#: wp-admin/includes/class-wp-debug-data.php:709
+msgid "Unable to determine some settings, as the %s function has been disabled."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:531
+#: wp-admin/includes/class-wp-site-health.php:2534
+msgid "File uploads"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:536
+msgid "Max size of post data allowed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:540
+msgid "Max size of an uploaded file"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:544
+msgid "Max effective file size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:548
+msgid "Max number of files allowed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:576
+msgid "Imagick Resource Limits"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:588
+msgid "ImageMagick supported file formats"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:589
+msgid "Unable to determine"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:602
+msgid "GD version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:629
+msgid "GD supported file formats"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:645
+msgid "Unable to determine if Ghostscript is installed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:650
+msgid "Ghostscript version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:669
+msgid "(Supports 64bit values)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:669
+msgid "(Does not support 64bit values)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:683
+msgid "Server architecture"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:684
+msgid "Unable to determine server architecture"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:688
+msgid "Web server"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:689
+msgid "Unable to determine what web server software is used"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:693
+msgid "PHP version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:698
+msgid "PHP SAPI"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:699
+msgid "Unable to determine PHP SAPI"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:706
+msgid "Server settings"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:716
+msgid "PHP max input variables"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:720
+msgid "PHP time limit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:726
+#: wp-admin/includes/class-wp-debug-data.php:735
+msgid "PHP memory limit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:730
+msgid "PHP memory limit (only for admin screens)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:741
+msgid "Max input time"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:745
+msgid "Upload max filesize"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:749
+msgid "PHP post max size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:758
+#: wp-admin/includes/class-wp-debug-data.php:763
+msgid "cURL version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:773
+msgid "Is SUHOSIN installed?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:782
+msgid "Is the Imagick library available?"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:791
+msgid "Are pretty permalinks supported?"
+msgstr ""
+
+#. translators: %s: .htaccess
+#: wp-admin/includes/class-wp-debug-data.php:807
+msgid "Custom rules have been added to your %s file."
+msgstr ""
+
+#. translators: %s: .htaccess
+#: wp-admin/includes/class-wp-debug-data.php:810
+msgid "Your %s file contains only core ClassicPress features."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:814
+msgid ".htaccess rules"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:834
+msgid "Extension"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:839
+msgid "Server version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:844
+msgid "Client version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:849
+#: wp-admin/setup-config.php:169
+msgid "Database username"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:855
+#: wp-admin/setup-config.php:171
+msgid "Database host"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:861
+#: wp-admin/setup-config.php:168
+msgid "Database name"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:867
+msgid "Table prefix"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:873
+msgid "Database charset"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:879
+msgid "Database collation"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:885
+msgid "Max allowed packet size"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:890
+msgid "Max connections number"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:901
+#: wp-admin/includes/class-wp-debug-data.php:948
+#: wp-admin/includes/class-wp-debug-data.php:1270
+msgid "No version or author information is available."
+msgstr ""
+
+#. translators: 1: Plugin version number. 2: Plugin author name.
+#. translators: 1: Theme version number. 2: Theme author name.
+#: wp-admin/includes/class-wp-debug-data.php:906
+#: wp-admin/includes/class-wp-debug-data.php:953
+#: wp-admin/includes/class-wp-debug-data.php:1275
+msgid "Version %1$s by %2$s"
+msgstr ""
+
+#. translators: %s: Plugin author name.
+#. translators: %s: Theme author name.
+#. translators: %s: Plugin author.
+#. translators: %s: Theme author.
+#. translators: %s: Theme author link.
+#: wp-admin/includes/class-wp-debug-data.php:911
+#: wp-admin/includes/class-wp-debug-data.php:958
+#: wp-admin/includes/class-wp-debug-data.php:1280
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:500
+#: wp-admin/includes/class-wp-plugins-list-table.php:1060
+#: wp-admin/includes/class-wp-theme-install-list-table.php:370
+#: wp-admin/includes/class-wp-theme-install-list-table.php:502
+#: wp-admin/includes/class-wp-themes-list-table.php:262
+#: wp-admin/includes/theme.php:828
+#: wp-admin/theme-install.php:352
+#: wp-admin/theme-install.php:464
+#: wp-admin/themes.php:529
+#: wp-admin/themes.php:888
+#: wp-admin/themes.php:982
+msgid "By %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1007
+#: wp-admin/includes/class-wp-debug-data.php:1322
+#: wp-admin/includes/class-wp-plugins-list-table.php:1168
+#: wp-admin/themes.php:700
+#: wp-admin/js/updates.js:2982
+msgid "Auto-updates enabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1009
+#: wp-admin/includes/class-wp-debug-data.php:1324
+#: wp-admin/includes/class-wp-plugins-list-table.php:1170
+#: wp-admin/themes.php:698
+#: wp-admin/js/updates.js:2993
+msgid "Auto-updates disabled"
+msgstr ""
+
+#. translators: 1: Theme name. 2: Theme slug.
+#: wp-admin/includes/class-wp-debug-data.php:1070
+#: wp-admin/includes/class-wp-debug-data.php:1089
+#: wp-admin/includes/class-wp-debug-data.php:1184
+#: wp-admin/includes/class-wp-debug-data.php:1345
+msgid "%1$s (%2$s)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1104
+#: wp-admin/includes/class-wp-debug-data.php:1199
+msgid "Author website"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1114
+msgid "Theme features"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1118
+#: wp-admin/includes/class-wp-debug-data.php:1204
+msgid "Theme directory location"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1157
+#: wp-admin/plugins.php:574
+#: wp-admin/themes.php:197
+msgid "Auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1243
+msgid "Auto-update"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1359
+msgid "The must use plugins directory"
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1614
+msgid "The size cannot be calculated. The directory is not accessible. Usually caused by invalid permissions."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1621
+msgid "The directory size calculation has timed out. Usually caused by a very large number of sub-directories and files."
+msgstr ""
+
+#: wp-admin/includes/class-wp-debug-data.php:1665
+msgid "Total size is not available. Some errors were encountered when determining the size of your installation."
+msgstr ""
+
+#. translators: 1: Folder to locate, 2: Folder to start searching from.
+#: wp-admin/includes/class-wp-filesystem-base.php:266
+msgid "Looking for %1$s in %2$s"
+msgstr ""
+
+#. translators: %s: Directory name.
+#: wp-admin/includes/class-wp-filesystem-base.php:295
+msgid "Changing to %s"
+msgstr ""
+
+#. translators: %s: Directory name.
+#: wp-admin/includes/class-wp-filesystem-base.php:313
+msgid "Found %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:37
+msgid "The ftp PHP extension is not available"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:53
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:49
+msgid "FTP hostname is required"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:60
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:56
+msgid "FTP username is required"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:66
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:62
+msgid "FTP password is required"
+msgstr ""
+
+#. translators: %s: hostname:port
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:97
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:87
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:100
+msgid "Failed to connect to FTP Server %s"
+msgstr ""
+
+#. translators: %s: Username.
+#: wp-admin/includes/class-wp-filesystem-ftpext.php:110
+#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:113
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:145
+msgid "Username/Password incorrect for %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:69
+msgid "The ssh2 PHP extension is not available"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:81
+msgid "SSH2 hostname is required"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:95
+msgid "SSH2 username is required"
+msgstr ""
+
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:105
+msgid "SSH2 password is required"
+msgstr ""
+
+#. translators: %s: hostname:port
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:131
+msgid "Failed to connect to SSH2 Server %s"
+msgstr ""
+
+#. translators: %s: Username.
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:158
+msgid "Public and Private keys incorrect for %s"
+msgstr ""
+
+#. translators: %s: hostname:port
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:174
+msgid "Failed to initialize a SFTP subsystem session with the SSH2 Server %s"
+msgstr ""
+
+#. translators: %s: Command.
+#: wp-admin/includes/class-wp-filesystem-ssh2.php:226
+msgid "Unable to perform command: %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-links-list-table.php:79
+msgid "No links found."
+msgstr ""
+
+#: wp-admin/includes/class-wp-links-list-table.php:135
+msgid "Relationship"
+msgstr ""
+
+#: wp-admin/includes/class-wp-links-list-table.php:136
+msgid "Visible"
+msgstr ""
+
+#: wp-admin/includes/class-wp-links-list-table.php:137
+#: wp-admin/includes/meta-boxes.php:1503
+msgid "Rating"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Link name.
+#. translators: Hidden accessibility text. %s: Attachment title.
+#. translators: Hidden accessibility text. %s: Plugin name.
+#. translators: %s: Post title.
+#. translators: Hidden accessibility text. %s: Taxonomy term name.
+#. translators: Hidden accessibility text. %s: User login.
+#. translators: %s: Plugin name.
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-links-list-table.php:180
+#: wp-admin/includes/class-wp-media-list-table.php:417
+#: wp-admin/includes/class-wp-plugins-list-table.php:989
+#: wp-admin/includes/class-wp-posts-list-table.php:1018
+#: wp-admin/includes/class-wp-terms-list-table.php:363
+#: wp-admin/includes/class-wp-users-list-table.php:530
+#: wp-admin/update-core.php:431
+#: wp-admin/update-core.php:605
+msgid "Select %s"
+msgstr ""
+
+#. translators: %s: Link name.
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#. translators: %s: Taxonomy term name.
+#: wp-admin/includes/class-wp-links-list-table.php:200
+#: wp-admin/includes/class-wp-media-list-table.php:757
+#: wp-admin/includes/class-wp-media-list-table.php:809
+#: wp-admin/includes/class-wp-posts-list-table.php:1449
+#: wp-admin/includes/class-wp-terms-list-table.php:476
+#: wp-admin/includes/dashboard.php:676
+#: wp-admin/includes/dashboard.php:1046
+msgid "Edit &#8220;%s&#8221;"
+msgstr ""
+
+#. translators: %s: Link name.
+#: wp-admin/includes/class-wp-links-list-table.php:342
+#: wp-admin/includes/meta-boxes.php:1150
+msgid ""
+"You are about to delete this link '%s'\n"
+"  'Cancel' to stop, 'OK' to delete."
+msgstr ""
+
+#: wp-admin/includes/class-wp-list-table.php:169
+#: wp-admin/includes/class-wp-screen.php:1327
+msgid "Compact view"
+msgstr ""
+
+#: wp-admin/includes/class-wp-list-table.php:170
+#: wp-admin/includes/class-wp-screen.php:1331
+msgid "Extended view"
+msgstr ""
+
+#. translators: %s: The $link_data argument.
+#: wp-admin/includes/class-wp-list-table.php:398
+msgid "The %s argument must be an array."
+msgstr ""
+
+#. translators: %1$s: The argument name. %2$s: The view name.
+#: wp-admin/includes/class-wp-list-table.php:415
+#: wp-admin/includes/class-wp-list-table.php:430
+msgid "The %1$s argument must be a non-empty string for %2$s."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:565
+msgid "Select bulk action"
+msgstr ""
+
+#: wp-admin/includes/class-wp-list-table.php:589
+#: wp-admin/includes/class-wp-screen.php:1090
+msgid "Apply"
+msgstr ""
+
+#: wp-admin/includes/class-wp-list-table.php:733
+#: wp-admin/includes/media.php:2783
+msgid "All dates"
+msgstr ""
+
+#. translators: 1: Month name, 2: 4-digit year.
+#: wp-admin/includes/class-wp-list-table.php:748
+msgid "%1$s %2$d"
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-list-table.php:805
+msgid "%s comment"
+msgid_plural "%s comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-list-table.php:811
+msgid "%s approved comment"
+msgid_plural "%s approved comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/includes/class-wp-list-table.php:817
+msgid "%s pending comment"
+msgid_plural "%s pending comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:839
+#: wp-admin/includes/class-wp-list-table.php:873
+#: wp-admin/includes/class-wp-list-table.php:900
+msgid "No comments"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:871
+msgid "No approved comments"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:898
+msgid "No pending comments"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1026
+msgid "First page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1038
+#: wp-admin/includes/nav-menu.php:462
+#: wp-admin/includes/nav-menu.php:764
+msgid "Previous page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1047
+#: wp-admin/includes/class-wp-list-table.php:1054
+msgid "Current Page"
+msgstr ""
+
+#. translators: 1: Current page, 2: Total pages.
+#: wp-admin/includes/class-wp-list-table.php:1063
+msgctxt "paging"
+msgid "%1$s of %2$s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1075
+#: wp-admin/includes/nav-menu.php:463
+#: wp-admin/includes/nav-menu.php:765
+msgid "Next page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1087
+msgid "Last page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-list-table.php:1325
+#: wp-admin/includes/nav-menu.php:678
+#: wp-admin/includes/nav-menu.php:915
+#: wp-admin/update-core.php:335
+#: wp-admin/update-core.php:463
+#: wp-admin/update-core.php:515
+#: wp-admin/update-core.php:637
+msgid "Select All"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:43
+msgid "List view"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:44
+msgid "Grid view"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:134
+msgid "All media items"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:157
+msgctxt "media items"
+msgid "Unattached"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:162
+msgctxt "media items"
+msgid "Mine"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:169
+msgctxt "attachment filter"
+msgid "Trash"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:194
+#: wp-admin/includes/class-wp-media-list-table.php:611
+#: wp-admin/includes/class-wp-media-list-table.php:800
+msgid "Attach"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:259
+msgid "No media files found in Trash."
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:261
+msgid "No media files found."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-media-list-table.php:284
+msgid "Filter by type"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-media-list-table.php:315
+#: wp-admin/includes/class-wp-theme-install-list-table.php:58
+#: wp-admin/includes/nav-menu.php:523
+#: wp-admin/includes/nav-menu.php:589
+#: wp-admin/includes/nav-menu.php:594
+#: wp-admin/includes/nav-menu.php:825
+#: wp-admin/includes/nav-menu.php:890
+#: wp-admin/includes/nav-menu.php:895
+#: wp-admin/includes/template.php:1927
+#: wp-admin/includes/template.php:1932
+#: wp-admin/includes/theme-install.php:139
+msgid "Search"
+msgstr ""
+
+#. translators: Column name.
+#: wp-admin/includes/class-wp-media-list-table.php:329
+msgctxt "column name"
+msgid "File"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:360
+msgctxt "column name"
+msgid "Uploaded to"
+msgstr ""
+
+#. translators: Column name.
+#: wp-admin/includes/class-wp-media-list-table.php:373
+msgctxt "column name"
+msgid "Date"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#. translators: %s: Taxonomy term name.
+#: wp-admin/includes/class-wp-media-list-table.php:455
+#: wp-admin/includes/class-wp-posts-list-table.php:1116
+#: wp-admin/includes/class-wp-terms-list-table.php:410
+msgid "&#8220;%s&#8221; (Edit)"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-media-list-table.php:481
+#: wp-admin/includes/media.php:1636
+#: wp-admin/includes/media.php:3289
+msgid "File name:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:530
+#: wp-admin/includes/class-wp-posts-list-table.php:1163
+msgid "Unpublished"
+msgstr ""
+
+#. translators: %s: Human-readable time difference.
+#: wp-admin/includes/class-wp-media-list-table.php:537
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:736
+#: wp-admin/includes/class-wp-privacy-requests-table.php:475
+#: wp-admin/includes/plugin-install.php:692
+#: wp-admin/includes/revision.php:250
+#: wp-admin/includes/revision.php:293
+msgid "%s ago"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:580
+msgid "(Private post)"
+msgstr ""
+
+#. translators: %s: Title of the post the attachment is attached to.
+#: wp-admin/includes/class-wp-media-list-table.php:596
+msgid "Detach from &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:597
+msgid "Detach"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:601
+msgid "(Unattached)"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#: wp-admin/includes/class-wp-media-list-table.php:610
+#: wp-admin/includes/class-wp-media-list-table.php:799
+msgid "Attach &#8220;%s&#8221; to existing content"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#: wp-admin/includes/class-wp-media-list-table.php:768
+#: wp-admin/includes/class-wp-media-list-table.php:828
+#: wp-admin/includes/class-wp-posts-list-table.php:1475
+msgid "Move &#8220;%s&#8221; to the Trash"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#: wp-admin/includes/class-wp-media-list-table.php:778
+#: wp-admin/includes/class-wp-media-list-table.php:840
+#: wp-admin/includes/class-wp-posts-list-table.php:1485
+msgid "Delete &#8220;%s&#8221; permanently"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#: wp-admin/includes/class-wp-media-list-table.php:789
+#: wp-admin/includes/class-wp-media-list-table.php:852
+#: wp-admin/includes/class-wp-posts-list-table.php:1508
+msgid "View &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:790
+#: wp-admin/includes/class-wp-media-list-table.php:853
+#: wp-admin/includes/class-wp-posts-list-table.php:1509
+#: wp-admin/includes/class-wp-terms-list-table.php:503
+#: wp-admin/includes/class-wp-users-list-table.php:498
+#: wp-admin/includes/dashboard.php:801
+msgid "View"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#. translators: %s: Post title.
+#: wp-admin/includes/class-wp-media-list-table.php:820
+#: wp-admin/includes/class-wp-posts-list-table.php:1467
+msgid "Restore &#8220;%s&#8221; from the Trash"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#: wp-admin/includes/class-wp-media-list-table.php:861
+msgid "Copy &#8220;%s&#8221; URL to clipboard"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:862
+msgid "Copy URL"
+msgstr ""
+
+#. translators: %s: Attachment title.
+#: wp-admin/includes/class-wp-media-list-table.php:870
+msgid "Download &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-media-list-table.php:871
+#: wp-admin/includes/media.php:3286
+msgid "Download file"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:105
+#: wp-admin/includes/class-wp-theme-install-list-table.php:60
+#: wp-admin/includes/file.php:32
+#: wp-admin/js/updates.js:2575
+msgid "Search Results"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:108
+msgctxt "Plugin Installer"
+msgid "Popular"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:109
+msgctxt "Plugin Installer"
+msgid "Categories"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:114
+#: wp-admin/plugin-install.php:147
+#: wp-admin/update.php:188
+msgid "Upload Plugin"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:256
+#: wp-admin/includes/class-wp-theme-install-list-table.php:158
+#: wp-admin/setup-config.php:288
+#: wp-admin/theme-install.php:67
+msgid "Try Again"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:259
+#: wp-admin/js/updates.js:2684
+msgid "No plugins found. Try a different search."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:442
+msgctxt "Plugin installer group title"
+msgid "Performance"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:443
+msgctxt "Plugin installer group title"
+msgid "Social"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:444
+msgctxt "Plugin installer group title"
+msgid "Tools"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:531
+#: wp-admin/includes/plugin-install.php:895
+msgctxt "plugin"
+msgid "Cannot Install"
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:546
+#: wp-admin/includes/update.php:528
+#: wp-admin/js/updates.js:2138
+msgctxt "plugin"
+msgid "Update %s now"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:548
+#: wp-admin/js/updates.js:644
+msgid "Update Now"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:553
+#: wp-admin/includes/plugin-install.php:907
+msgctxt "plugin"
+msgid "Cannot Update"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:564
+msgctxt "plugin"
+msgid "Active"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:570
+#: wp-admin/includes/class-wp-plugins-list-table.php:866
+#: wp-admin/js/updates.js:762
+msgctxt "plugin"
+msgid "Activate %s"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:583
+#: wp-admin/includes/class-wp-plugins-list-table.php:805
+#: wp-admin/js/updates.js:751
+msgctxt "plugin"
+msgid "Network Activate %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:596
+#: wp-admin/includes/class-wp-plugins-list-table.php:811
+#: wp-admin/includes/class-wp-plugins-list-table.php:872
+msgctxt "plugin"
+msgid "Cannot Activate"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:602
+msgctxt "plugin"
+msgid "Installed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:620
+msgid "More Details"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:652
+#: wp-admin/includes/class-wp-plugins-list-table.php:1273
+msgid "This plugin does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#. translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:656
+#: wp-admin/includes/class-wp-plugins-list-table.php:1277
+#: wp-admin/includes/theme.php:869
+#: wp-admin/includes/theme.php:946
+#: wp-admin/includes/update.php:732
+#: wp-admin/theme-install.php:297
+#: wp-admin/theme-install.php:502
+#: wp-admin/themes.php:418
+#: wp-admin/themes.php:478
+#: wp-admin/themes.php:769
+#: wp-admin/themes.php:833
+#: wp-admin/themes.php:994
+#: wp-admin/themes.php:1061
+#: wp-admin/update-core.php:541
+msgid "<a href=\"%1$s\">Please update ClassicPress</a>, and then <a href=\"%2$s\">learn more about updating PHP</a>."
+msgstr ""
+
+#. translators: %s: URL to WordPress Updates screen.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:664
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:680
+#: wp-admin/includes/class-wp-plugins-list-table.php:1285
+#: wp-admin/includes/class-wp-plugins-list-table.php:1301
+#: wp-admin/includes/theme.php:877
+#: wp-admin/includes/theme.php:899
+#: wp-admin/includes/theme.php:954
+#: wp-admin/includes/theme.php:972
+#: wp-admin/includes/update.php:740
+#: wp-admin/includes/update.php:760
+#: wp-admin/theme-install.php:305
+#: wp-admin/theme-install.php:327
+#: wp-admin/theme-install.php:510
+#: wp-admin/theme-install.php:532
+#: wp-admin/themes.php:426
+#: wp-admin/themes.php:446
+#: wp-admin/themes.php:486
+#: wp-admin/themes.php:502
+#: wp-admin/themes.php:777
+#: wp-admin/themes.php:799
+#: wp-admin/themes.php:841
+#: wp-admin/themes.php:859
+#: wp-admin/themes.php:1002
+#: wp-admin/themes.php:1020
+#: wp-admin/themes.php:1069
+#: wp-admin/themes.php:1091
+#: wp-admin/update-core.php:554
+#: wp-admin/update-core.php:575
+msgid "<a href=\"%s\">Please update ClassicPress</a>."
+msgstr ""
+
+#. translators: %s: URL to Update PHP page.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:670
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:689
+#: wp-admin/includes/class-wp-plugins-list-table.php:1291
+#: wp-admin/includes/class-wp-plugins-list-table.php:1310
+#: wp-admin/includes/plugin.php:1148
+#: wp-admin/includes/theme.php:883
+#: wp-admin/includes/theme.php:914
+#: wp-admin/includes/theme.php:960
+#: wp-admin/includes/theme.php:983
+#: wp-admin/includes/update-core.php:357
+#: wp-admin/includes/update.php:746
+#: wp-admin/includes/update.php:773
+#: wp-admin/install.php:253
+#: wp-admin/theme-install.php:311
+#: wp-admin/theme-install.php:338
+#: wp-admin/theme-install.php:516
+#: wp-admin/theme-install.php:543
+#: wp-admin/themes.php:432
+#: wp-admin/themes.php:459
+#: wp-admin/themes.php:492
+#: wp-admin/themes.php:511
+#: wp-admin/themes.php:783
+#: wp-admin/themes.php:814
+#: wp-admin/themes.php:847
+#: wp-admin/themes.php:870
+#: wp-admin/themes.php:1008
+#: wp-admin/themes.php:1031
+#: wp-admin/themes.php:1075
+#: wp-admin/themes.php:1106
+#: wp-admin/update-core.php:560
+#: wp-admin/update-core.php:584
+#: wp-admin/upgrade.php:87
+msgid "<a href=\"%s\">Learn more about updating PHP</a>."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:676
+#: wp-admin/includes/class-wp-plugins-list-table.php:1297
+msgid "This plugin does not work with your version of ClassicPress."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:685
+#: wp-admin/includes/class-wp-plugins-list-table.php:1306
+msgid "This plugin does not work with your version of PHP."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:733
+#: wp-admin/includes/plugin-install.php:689
+msgid "Last Updated:"
+msgstr ""
+
+#. translators: %s: Number of millions.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:745
+#: wp-admin/includes/plugin-install.php:720
+msgctxt "Active plugin installations"
+msgid "%s+ Million"
+msgid_plural "%s+ Million"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:749
+#: wp-admin/includes/plugin-install.php:724
+msgctxt "Active plugin installations"
+msgid "Less Than 10"
+msgstr ""
+
+#. translators: %s: Number of installations.
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:754
+msgid "%s Active Installations"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:760
+msgid "Untested with your version of ClassicPress"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:762
+msgid "<strong>Incompatible</strong> with your version of ClassicPress"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugin-install-list-table.php:764
+msgid "<strong>Compatible</strong> with your version of ClassicPress"
+msgstr ""
+
+#. translators: %s: Plugin search term.
+#: wp-admin/includes/class-wp-plugins-list-table.php:409
+msgid "No plugins found for: %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:413
+msgid "Search for plugins in the ClassicPress Plugin Directory."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:416
+msgid "No plugins found."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:418
+#: wp-admin/plugin-editor.php:32
+#: wp-admin/js/updates.js:1061
+msgid "No plugins are currently available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:446
+msgid "Search installed plugins..."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:461
+msgid "Plugin"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:466
+msgid "Automatic Updates"
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:496
+msgctxt "plugins"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:505
+msgid "Active <span class=\"count\">(%s)</span>"
+msgid_plural "Active <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:513
+msgid "Recently Active <span class=\"count\">(%s)</span>"
+msgid_plural "Recently Active <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:521
+msgid "Inactive <span class=\"count\">(%s)</span>"
+msgid_plural "Inactive <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:529
+msgid "Must-Use <span class=\"count\">(%s)</span>"
+msgid_plural "Must-Use <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:537
+msgid "Drop-in <span class=\"count\">(%s)</span>"
+msgid_plural "Drop-ins <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:545
+msgid "Paused <span class=\"count\">(%s)</span>"
+msgid_plural "Paused <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:553
+msgid "Update Available <span class=\"count\">(%s)</span>"
+msgid_plural "Update Available <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:561
+msgid "Auto-updates Enabled <span class=\"count\">(%s)</span>"
+msgid_plural "Auto-updates Enabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/class-wp-plugins-list-table.php:569
+msgid "Auto-updates Disabled <span class=\"count\">(%s)</span>"
+msgid_plural "Auto-updates Disabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:603
+#: wp-admin/includes/class-wp-plugins-list-table.php:794
+msgid "Network Deactivate"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:603
+#: wp-admin/includes/class-wp-plugins-list-table.php:844
+msgid "Deactivate"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:617
+msgid "Enable Auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:620
+msgid "Disable Auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:656
+msgid "Clear List"
+msgstr ""
+
+#. translators: %s: mu-plugins directory name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:660
+msgid "Files in the %s directory are executed automatically."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:764
+msgid "Inactive:"
+msgstr ""
+
+#. translators: 1: Drop-in constant name, 2: wp-config.php
+#: wp-admin/includes/class-wp-plugins-list-table.php:767
+msgid "Requires %1$s in %2$s file."
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:793
+msgctxt "plugin"
+msgid "Network Deactivate %s"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:822
+#: wp-admin/includes/class-wp-plugins-list-table.php:883
+msgctxt "plugin"
+msgid "Delete %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:830
+msgid "Network Active"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:834
+msgid "Network Only"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:843
+msgctxt "plugin"
+msgid "Deactivate %s"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:854
+msgctxt "plugin"
+msgid "Resume %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:855
+#: wp-admin/themes.php:631
+msgid "Resume"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:1076
+msgid "View details"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-plugins-list-table.php:1080
+msgid "Visit plugin site for %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:1086
+msgid "Visit plugin site"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:1143
+msgid "This plugin failed to load properly and is paused during recovery mode."
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:1179
+#: wp-admin/themes.php:703
+#: wp-admin/js/updates.js:2980
+msgid "Disable auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-plugins-list-table.php:1183
+#: wp-admin/themes.php:707
+#: wp-admin/js/updates.js:2991
+msgid "Enable auto-updates"
+msgstr ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/includes/class-wp-posts-list-table.php:324
+msgctxt "posts"
+msgid "Mine <span class=\"count\">(%s)</span>"
+msgid_plural "Mine <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/includes/class-wp-posts-list-table.php:345
+msgctxt "posts"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/includes/class-wp-posts-list-table.php:404
+msgctxt "posts"
+msgid "Sticky <span class=\"count\">(%s)</span>"
+msgid_plural "Sticky <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-posts-list-table.php:540
+msgid "Filter by post format"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:544
+msgid "All formats"
+msgstr ""
+
+#. translators: Posts screen column name.
+#: wp-admin/includes/class-wp-posts-list-table.php:664
+msgctxt "column name"
+msgid "Title"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Post title.
+#: wp-admin/includes/class-wp-posts-list-table.php:1028
+msgid "&#8220;%s&#8221; is locked"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/class-wp-posts-list-table.php:1097
+#: wp-admin/includes/misc.php:1205
+msgid "%s is currently editing"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1183
+msgid "Missed schedule"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1188
+msgid "Last Modified"
+msgstr ""
+
+#. translators: %s: Post title.
+#. translators: %s: Taxonomy term name.
+#: wp-admin/includes/class-wp-posts-list-table.php:1456
+#: wp-admin/includes/class-wp-terms-list-table.php:482
+msgid "Quick edit &#8220;%s&#8221; inline"
+msgstr ""
+
+#. translators: %s: Post title.
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-posts-list-table.php:1499
+#: wp-admin/includes/class-wp-theme-install-list-table.php:282
+msgid "Preview &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1624
+msgid "Bulk Edit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1624
+#: wp-admin/includes/class-wp-terms-list-table.php:662
+msgid "Quick Edit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1684
+#: wp-admin/includes/class-wp-posts-list-table.php:1787
+#: wp-admin/includes/class-wp-posts-list-table.php:1826
+#: wp-admin/includes/class-wp-posts-list-table.php:1883
+#: wp-admin/includes/class-wp-posts-list-table.php:1896
+#: wp-admin/includes/class-wp-posts-list-table.php:1940
+#: wp-admin/includes/class-wp-posts-list-table.php:1963
+#: wp-admin/includes/class-wp-posts-list-table.php:1988
+msgid "&mdash; No Change &mdash;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1720
+#: wp-admin/includes/file.php:2431
+#: wp-admin/install.php:137
+#: wp-admin/install.php:438
+#: wp-admin/options-writing.php:172
+#: wp-admin/setup-config.php:235
+#: wp-admin/user-new.php:582
+msgid "Password"
+msgstr ""
+
+#. translators: Between password field and private checkbox on post quick edit interface.
+#: wp-admin/includes/class-wp-posts-list-table.php:1727
+msgid "&ndash;OR&ndash;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1732
+#: wp-admin/includes/class-wp-posts-list-table.php:1947
+#: wp-admin/includes/meta-boxes.php:180
+#: wp-admin/includes/meta-boxes.php:220
+#: wp-admin/js/post.js:906
+msgid "Private"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1775
+#: wp-admin/includes/meta-boxes.php:1039
+msgid "Parent"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1781
+msgid "Main Page (no parent)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1812
+#: wp-admin/includes/media.php:1412
+#: wp-admin/includes/media.php:2516
+#: wp-admin/includes/meta-boxes.php:1080
+msgid "Order"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1823
+#: wp-admin/includes/meta-boxes.php:1048
+msgid "Template"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1830
+#: wp-admin/includes/meta-boxes.php:1073
+msgid "Default template"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1884
+#: wp-admin/includes/class-wp-posts-list-table.php:1897
+msgid "Allow"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1885
+#: wp-admin/includes/class-wp-posts-list-table.php:1898
+msgid "Do not allow"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1914
+msgid "Allow Comments"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1923
+msgid "Allow Pings"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1961
+#: wp-admin/includes/class-wp-posts-list-table.php:1964
+msgid "Sticky"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1965
+msgid "Not Sticky"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1973
+msgid "Make this post sticky"
+msgstr ""
+
+#: wp-admin/includes/class-wp-posts-list-table.php:1986
+#: wp-admin/includes/meta-boxes.php:1611
+msgctxt "post format"
+msgid "Format"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:60
+msgid "Download personal data"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:61
+msgid "Downloading data..."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:62
+msgid "Download personal data again"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:63
+#: wp-admin/includes/class-wp-upgrader.php:160
+msgid "Download failed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:63
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:136
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:142
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:68
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:142
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:149
+msgid "Retry"
+msgstr ""
+
+#. translators: %s: Request email.
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:88
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:94
+msgid "Mark export request for &#8220;%s&#8221; as completed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:92
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:98
+msgid "Complete request"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:116
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:122
+msgid "Waiting for confirmation"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:133
+msgid "Send export link"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:134
+msgid "Sending email..."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:135
+msgid "Email sent."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:136
+msgid "Email could not be sent."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:156
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:163
+msgid "Remove request"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:65
+msgid "Force erase personal data"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:66
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:140
+msgid "Erasing data..."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:67
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:141
+msgid "Erasure completed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:68
+msgid "Force erasure has failed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:139
+msgid "Erase personal data"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:142
+msgid "Data erasure has failed."
+msgstr ""
+
+#. translators: %s: Privacy Policy Guide URL.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:147
+msgid "The suggested privacy policy text has changed. Please <a href=\"%s\">review the guide</a> and update your privacy policy."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-policy-content.php:335
+msgid "Need help putting together your new Privacy Policy page? Check out our guide for recommendations on what content to include, along with policies suggested by your plugins and theme."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-policy-content.php:337
+msgid "View Privacy Policy Guide."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:349
+#: wp-admin/includes/class-wp-site-health.php:753
+#: wp-admin/includes/class-wp-site-health.php:843
+#: wp-admin/includes/class-wp-site-health.php:1170
+#: wp-admin/includes/class-wp-site-health.php:1405
+#: wp-admin/includes/class-wp-site-health.php:1443
+#: wp-admin/includes/class-wp-site-health.php:1523
+#: wp-admin/includes/class-wp-site-health.php:1605
+#: wp-admin/includes/class-wp-site-health.php:1624
+#: wp-admin/includes/class-wp-site-health.php:2243
+#: wp-admin/includes/class-wp-site-health.php:2276
+#: wp-admin/includes/class-wp-site-health.php:2402
+#: wp-admin/includes/dashboard.php:1684
+#: wp-admin/includes/media.php:3172
+#: wp-admin/includes/meta-boxes.php:80
+#: wp-admin/includes/theme.php:842
+msgid "(opens in a new tab)"
+msgstr ""
+
+#. translators: %s: Date of plugin deactivation.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:377
+msgid "Removed %s."
+msgstr ""
+
+#. translators: %s: Date of plugin deactivation.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:380
+msgid "You deactivated this plugin on %s and may no longer need this policy."
+msgstr ""
+
+#. translators: %s: Date of privacy policy text update.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:386
+msgid "Updated %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-policy-content.php:411
+msgid "Copy suggested policy text to clipboard"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Plugin name.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:415
+msgid "Copy suggested policy text from %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-policy-content.php:437
+msgid "Suggested text:"
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:447
+msgid "Who we are"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:451
+msgid "In this section you should note your site URL, as well as the name of the company, organization, or individual behind it, and some accurate contact information."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:453
+msgid "The amount of information you may be required to show will vary depending on your local or national business regulations. You may, for example, be required to display a physical address, a registered address, or your company registration number."
+msgstr ""
+
+#. translators: Default privacy policy text. %s: Site URL.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:456
+msgid "Our website address is: %s."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:461
+msgid "What personal data we collect and why we collect it"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:463
+msgid "In this section you should note what personal data you collect from users and site visitors. This may include personal data, such as name, email address, personal account preferences; transactional data, such as purchase information; and technical data, such as information about cookies."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:465
+msgid "You should also note any collection and retention of sensitive personal data, such as data concerning health."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:467
+msgid "In addition to listing what personal data you collect, you need to note why you collect it. These explanations must note either the legal basis for your data collection and retention or the active consent the user has given."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:469
+msgid "Personal data is not just created by a user&#8217;s interactions with your site. Personal data is also generated from technical processes such as contact forms, comments, cookies, analytics, and third party embeds."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:471
+msgid "By default ClassicPress does not collect any personal data about visitors, and only collects the data shown on the User Profile screen from registered users. However some of your plugins may collect personal data. You should add the relevant information below."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:479
+msgid "In this subsection you should note what information is captured through comments. We have noted the data which ClassicPress collects by default."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:482
+msgid "When visitors leave comments on the site we collect the data shown in the comments form, and also the visitor&#8217;s IP address and browser user agent string to help spam detection."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:484
+msgid "An anonymized string created from your email address (also called a hash) may be provided to the Gravatar service to see if you are using it. The Gravatar service privacy policy is available here: https://automattic.com/privacy/. After approval of your comment, your profile picture is visible to the public in the context of your comment."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:492
+msgid "In this subsection you should note what information may be disclosed by users who can upload media files. All uploaded files are usually publicly accessible."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:495
+msgid "If you upload images to the website, you should avoid uploading images with embedded location data (EXIF GPS) included. Visitors to the website can download and extract any location data from images on the website."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:500
+msgid "Contact forms"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:502
+msgid "By default, ClassicPress does not include a contact form. If you use a contact form plugin, use this subsection to note what personal data is captured when someone submits a contact form, and how long you keep it. For example, you may note that you keep contact form submissions for a certain period for customer service purposes, but you do not use the information submitted through them for marketing purposes."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:506
+msgid "Cookies"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:510
+msgid "In this subsection you should list the cookies your web site uses, including those set by your plugins, social media, and analytics. We have provided the cookies which ClassicPress installs by default."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:513
+msgid "If you leave a comment on our site you may opt-in to saving your name, email address and website in cookies. These are for your convenience so that you do not have to fill in your details again when you leave another comment. These cookies will last for one year."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:515
+msgid "If you visit our login page, we will set a temporary cookie to determine if your browser accepts cookies. This cookie contains no personal data and is discarded when you close your browser."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:517
+msgid "When you log in, we will also set up several cookies to save your login information and your screen display choices. Login cookies last for two days, and screen options cookies last for a year. If you select &quot;Remember Me&quot;, your login will persist for two weeks. If you log out of your account, the login cookies will be removed."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:519
+msgid "If you edit or publish an article, an additional cookie will be saved in your browser. This cookie includes no personal data and simply indicates the post ID of the article you just edited. It expires after 1 day."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:524
+msgid "Embedded content from other websites"
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:526
+msgid "Articles on this site may include embedded content (e.g. videos, images, articles, etc.). Embedded content from other websites behaves in the exact same way as if the visitor has visited the other website."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:528
+msgid "These websites may collect data about you, use cookies, embed additional third-party tracking, and monitor your interaction with that embedded content, including tracking your interaction with the embedded content if you have an account and are logged in to that website."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:533
+msgid "Analytics"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:535
+msgid "In this subsection you should note what analytics package you use, how users can opt out of analytics tracking, and a link to your analytics provider&#8217;s privacy policy, if any."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:537
+msgid "By default ClassicPress does not collect any analytics data. However, many web hosting accounts collect some anonymous analytics data. You may also have installed a WordPress plugin that provides analytics services. In that case, add information from that plugin here."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:541
+msgid "Who we share your data with"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:545
+msgid "In this section you should name and list all third party providers with whom you share site data, including partners, cloud-based services, payment processors, and third party service providers, and note what data you share with them and why. Link to their own privacy policies if possible."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:547
+msgid "By default ClassicPress does not share any personal data with anyone."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:550
+msgid "If you request a password reset, your IP address will be included in the reset email."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:554
+msgid "How long we retain your data"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:558
+msgid "In this section you should explain how long you retain personal data collected or processed by the web site. While it is your responsibility to come up with the schedule of how long you keep each dataset for and why you keep it, that information does need to be listed here. For example, you may want to say that you keep contact form entries for six months, analytics records for a year, and customer purchase records for ten years."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:561
+msgid "If you leave a comment, the comment and its metadata are retained indefinitely. This is so we can recognize and approve any follow-up comments automatically instead of holding them in a moderation queue."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:563
+msgid "For users that register on our website (if any), we also store the personal information they provide in their user profile. All users can see, edit, or delete their personal information at any time (except they cannot change their username). Website administrators can also see and edit that information."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:567
+msgid "What rights you have over your data"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:571
+msgid "In this section you should explain what rights your users have over their data and how they can invoke those rights."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:574
+msgid "If you have an account on this site, or have left comments, you can request to receive an exported file of the personal data we hold about you, including any data you have provided to us. You can also request that we erase any personal data we hold about you. This does not include any data we are obliged to keep for administrative, legal, or security purposes."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:578
+msgid "Where your data is sent"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:582
+msgid "In this section you should list all transfers of your site data outside the European Union and describe the means by which that data is safeguarded to European data protection standards. This could include your web hosting, cloud storage, or other third party services."
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:584
+msgid "European data protection law requires data about European residents which is transferred outside the European Union to be safeguarded to the same standards as if the data was in Europe. So in addition to listing where data goes, you should describe how you ensure that these standards are met either by yourself or by your third party providers, whether that is through an agreement such as Privacy Shield, model clauses in your contracts, or binding corporate rules."
+msgstr ""
+
+#. translators: Default privacy policy text.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:587
+msgid "Visitor comments may be checked through an automated spam detection service."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:592
+msgid "Contact information"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:594
+msgid "In this section you should provide a contact method for privacy-specific concerns. If you are required to have a Data Protection Officer, list their name and full contact details here as well."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:599
+msgid "Additional information"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:601
+msgid "If you use your site for commercial purposes and you engage in more complex collection or processing of personal data, you should note the following information in your privacy policy in addition to the information we have already discussed."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:606
+msgid "How we protect your data"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:608
+msgid "In this section you should explain what measures you have taken to protect your users&#8217; data. This could include technical measures such as encryption; security measures such as two factor authentication; and measures such as staff training in data protection. If you have carried out a Privacy Impact Assessment, you can mention it here too."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:613
+msgid "What data breach procedures we have in place"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:615
+msgid "In this section you should explain what procedures you have in place to deal with data breaches, either potential or real, such as internal reporting systems, contact mechanisms, or bug bounties."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:620
+msgid "What third parties we receive data from"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:622
+msgid "If your web site receives data about users from third parties, including advertisers, this information must be included within the section of your privacy policy dealing with third party data."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:627
+msgid "What automated decision making and/or profiling we do with user data"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:629
+msgid "If your web site provides a service which includes automated decision making - for example, allowing customers to apply for credit, or aggregating their data into an advertising profile - you must note that this is taking place, and include information about how that information is used, what decisions are made with that aggregated data, and what rights users have over decisions made without human intervention."
+msgstr ""
+
+#. translators: Default privacy policy heading.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:634
+msgid "Industry regulatory disclosure requirements"
+msgstr ""
+
+#. translators: Privacy policy tutorial.
+#: wp-admin/includes/class-wp-privacy-policy-content.php:636
+msgid "If you are a member of a regulated industry, or if you are subject to additional privacy laws, you may be required to disclose that information here."
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:43
+msgid "Requester"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:45
+msgid "Requested"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:46
+msgid "Next steps"
+msgstr ""
+
+#. translators: %s: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:158
+msgctxt "requests"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:211
+msgid "Resend confirmation requests"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:212
+msgid "Mark requests as completed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-privacy-requests-table.php:213
+msgid "Delete requests"
+msgstr ""
+
+#. translators: %d: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:254
+msgid "%d confirmation request failed to resend."
+msgid_plural "%d confirmation requests failed to resend."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:271
+msgid "%d confirmation request re-sent successfully."
+msgid_plural "%d confirmation requests re-sent successfully."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:298
+msgid "%d request marked as complete."
+msgid_plural "%d requests marked as complete."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:324
+msgid "%d request failed to delete."
+msgid_plural "%d requests failed to delete."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: Number of requests.
+#: wp-admin/includes/class-wp-privacy-requests-table.php:341
+msgid "%d request deleted successfully."
+msgid_plural "%d requests deleted successfully."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-screen.php:288
+#: wp-admin/post.php:20
+msgid "A post ID mismatch has been detected."
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:738
+msgid "Filter items list"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:739
+msgid "Items list navigation"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:740
+msgid "Items list"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:848
+msgid "Contextual Help Tab"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:947
+msgid "Screen Options"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:980
+msgid "Additional settings"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:984
+msgid "Enable full-height editor and distraction-free functionality."
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:999
+msgctxt "Admin Post Navigation"
+msgid "Enable Previous and Next buttons"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1059
+msgid "Screen Options Tab"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1111
+msgid "Screen elements"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1113
+msgid "Some screen elements can be shown or hidden by using the checkboxes."
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1114
+msgid "Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows."
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1132
+msgctxt "Welcome panel"
+msgid "Welcome"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1153
+msgid "Columns"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1202
+#: wp-admin/includes/theme.php:334
+#: wp-admin/includes/theme.php:369
+#: wp-admin/index.php:70
+msgid "Layout"
+msgstr ""
+
+#. translators: %s: Number of columns on the page.
+#: wp-admin/includes/class-wp-screen.php:1209
+msgid "%s column"
+msgid_plural "%s columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-screen.php:1231
+msgid "Number of items per page:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1271
+msgid "Pagination"
+msgstr ""
+
+#: wp-admin/includes/class-wp-screen.php:1324
+msgid "View mode"
+msgstr ""
+
+#. translators: 1: Name of the constant used. 2: Value of the constant used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:78
+msgid "The %1$s constant is defined as %2$s"
+msgstr ""
+
+#. translators: %s: Name of the filter used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:101
+msgid "A plugin has prevented updates by disabling %s."
+msgstr ""
+
+#. translators: %s: Name of the filter used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:122
+msgid "The %s filter is enabled."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:149
+msgid "All automatic updates are disabled."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:169
+msgid "A previous automatic background update ended with a critical failure, so updates are now disabled."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:170
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:185
+msgid "You would have received an email because of this."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:171
+msgid "When you've been able to update using the \"Update now\" button on Dashboard > Updates, this error will be cleared for future update attempts."
+msgstr ""
+
+#. translators: %s: Code of error shown.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:174
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:191
+msgid "The error code was %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:183
+msgid "A previous automatic background update could not occur."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:188
+msgid "Another attempt will be made with the next release."
+msgstr ""
+
+#. translators: 1: Folder name. 2: Version control directory. 3: Filter name.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:243
+msgid "The folder %1$s was detected as being under version control (%2$s), but the %3$s filter is allowing updates."
+msgstr ""
+
+#. translators: 1: Folder name. 2: Version control directory.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:256
+msgid "The folder %1$s was detected as being under version control (%2$s)."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:265
+msgid "No version control systems were detected."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:287
+msgid "Your installation of ClassicPress prompts for FTP credentials to perform updates."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:288
+msgid "(Your site is performing updates over FTP due to file ownership. Talk to your hosting company.)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:297
+msgid "Your installation of ClassicPress does not require FTP credentials to perform updates."
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:349
+msgid "Couldn't retrieve a list of the checksums for ClassicPress %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:352
+msgid "This could mean that connections are failing to WordPress.org or ClassicPress.net."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:378
+msgid "Some files are not writable by ClassicPress:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:383
+msgid "All of your ClassicPress files are writable."
+msgstr ""
+
+#. translators: %s: Name of the constant used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:407
+msgid "ClassicPress development updates are blocked by the %s constant."
+msgstr ""
+
+#. translators: %s: Name of the filter used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:419
+msgid "ClassicPress development updates are blocked by the %s filter."
+msgstr ""
+
+#. translators: %s: Name of the constant used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:439
+msgid "ClassicPress security and maintenance releases are blocked by %s."
+msgstr ""
+
+#. translators: %s: Name of the filter used.
+#: wp-admin/includes/class-wp-site-health-auto-updates.php:451
+msgid "ClassicPress security and maintenance releases are blocked by the %s filter."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:259
+#: wp-admin/includes/class-wp-site-health.php:737
+#: wp-admin/includes/class-wp-site-health.php:828
+#: wp-admin/includes/class-wp-site-health.php:1066
+#: wp-admin/includes/class-wp-site-health.php:1107
+#: wp-admin/includes/class-wp-site-health.php:1157
+#: wp-admin/includes/class-wp-site-health.php:1250
+#: wp-admin/includes/class-wp-site-health.php:1696
+#: wp-admin/includes/class-wp-site-health.php:1885
+#: wp-admin/includes/class-wp-site-health.php:1928
+#: wp-admin/includes/class-wp-site-health.php:1999
+#: wp-admin/includes/class-wp-site-health.php:2110
+#: wp-admin/includes/class-wp-site-health.php:2264
+#: wp-admin/includes/class-wp-site-health.php:2389
+msgid "Performance"
+msgstr ""
+
+#. translators: %s: Your current version of ClassicPress.
+#: wp-admin/includes/class-wp-site-health.php:275
+msgid "ClassicPress version %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:281
+msgid "Unable to check if any new versions of ClassicPress are available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:287
+msgid "Check for updates manually"
+msgstr ""
+
+#. translators: %s: The latest version of ClassicPress available.
+#: wp-admin/includes/class-wp-site-health.php:300
+msgid "ClassicPress update available (%s)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:307
+msgid "Install the latest version of ClassicPress"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:315
+msgid "A new version of ClassicPress is available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:320
+#: wp-admin/includes/class-wp-site-health.php:360
+#: wp-admin/includes/class-wp-site-health.php:494
+#: wp-admin/includes/class-wp-site-health.php:1197
+#: wp-admin/includes/class-wp-site-health.php:1360
+#: wp-admin/includes/class-wp-site-health.php:1430
+#: wp-admin/includes/class-wp-site-health.php:1511
+#: wp-admin/includes/class-wp-site-health.php:1650
+#: wp-admin/includes/class-wp-site-health.php:1769
+#: wp-admin/includes/class-wp-site-health.php:1842
+#: wp-admin/includes/class-wp-site-health.php:2202
+msgid "Security"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:323
+msgid "A new minor update is available for your site. Because minor updates often address security, it&#8217;s important to install them."
+msgstr ""
+
+#. translators: %s: The current version of ClassicPress installed on this site.
+#: wp-admin/includes/class-wp-site-health.php:330
+msgid "Your version of ClassicPress (%s) is up to date"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:336
+msgid "You are currently running the latest version of ClassicPress available, keep it up!"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:357
+msgid "Your plugins are all up to date"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:365
+msgid "Plugins extend your site&#8217;s functionality with things like contact forms, ecommerce and much more. That means they have deep access to your site, so it&#8217;s vital to keep them up to date."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:370
+msgid "Manage your plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:399
+msgid "You have plugins waiting to be updated"
+msgstr ""
+
+#. translators: %d: The number of outdated plugins.
+#: wp-admin/includes/class-wp-site-health.php:405
+msgid "Your site has %d plugin waiting to be updated."
+msgid_plural "Your site has %d plugins waiting to be updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:417
+msgid "Update your plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:423
+msgid "Your site has 1 active plugin, and it is up to date."
+msgstr ""
+
+#. translators: %d: The number of active plugins.
+#: wp-admin/includes/class-wp-site-health.php:430
+msgid "Your site has %d active plugin, and it is up to date."
+msgid_plural "Your site has %d active plugins, and they are all up to date."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:441
+msgid "Your site does not have any active plugins."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:452
+msgid "You should remove inactive plugins"
+msgstr ""
+
+#. translators: %d: The number of inactive plugins.
+#: wp-admin/includes/class-wp-site-health.php:458
+msgid "Your site has %d inactive plugin."
+msgid_plural "Your site has %d inactive plugins."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:465
+msgid "Inactive plugins are tempting targets for attackers. If you are not going to use a plugin, you should consider removing it."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:471
+msgid "Manage inactive plugins"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:491
+msgid "Your themes are all up to date"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:499
+msgid "Themes add your site&#8217;s look and feel. It&#8217;s important to keep them up to date, to stay consistent with your brand and keep your site secure."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:504
+msgid "Manage your themes"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:572
+msgid "You have themes waiting to be updated"
+msgstr ""
+
+#. translators: %d: The number of outdated themes.
+#: wp-admin/includes/class-wp-site-health.php:578
+msgid "Your site has %d theme waiting to be updated."
+msgid_plural "Your site has %d themes waiting to be updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:591
+msgid "Your site has 1 installed theme, and it is up to date."
+msgstr ""
+
+#. translators: %d: The number of themes.
+#: wp-admin/includes/class-wp-site-health.php:598
+msgid "Your site has %d installed theme, and it is up to date."
+msgid_plural "Your site has %d installed themes, and they are all up to date."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:609
+msgid "Your site does not have any installed themes."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:621
+#: wp-admin/includes/class-wp-site-health.php:667
+msgid "You should remove inactive themes"
+msgstr ""
+
+#. translators: %d: The number of inactive themes.
+#: wp-admin/includes/class-wp-site-health.php:628
+#: wp-admin/includes/class-wp-site-health.php:647
+msgid "Your site has %d inactive theme."
+msgid_plural "Your site has %d inactive themes."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: The currently active theme. 2: The active theme's parent theme.
+#: wp-admin/includes/class-wp-site-health.php:637
+msgid "To enhance your site&#8217;s security, you should consider removing any themes you are not using. You should keep your active theme, %1$s, and %2$s, its parent theme."
+msgstr ""
+
+#. translators: 1: The default theme for ClassicPress. 2: The currently active theme. 3: The active theme's parent theme.
+#: wp-admin/includes/class-wp-site-health.php:656
+msgid "To enhance your site&#8217;s security, you should consider removing any themes you are not using. You should keep %1$s, the default ClassicPress theme, %2$s, your active theme, and %3$s, its parent theme."
+msgstr ""
+
+#. translators: 1: The amount of inactive themes. 2: The currently active theme.
+#: wp-admin/includes/class-wp-site-health.php:674
+msgid "Your site has %1$d inactive theme, other than %2$s, your active theme."
+msgid_plural "Your site has %1$d inactive themes, other than %2$s, your active theme."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:682
+#: wp-admin/includes/class-wp-site-health.php:698
+msgid "You should consider removing any unused themes to enhance your site&#8217;s security."
+msgstr ""
+
+#. translators: 1: The amount of inactive themes. 2: The default theme for ClassicPress. 3: The currently active theme.
+#: wp-admin/includes/class-wp-site-health.php:689
+msgid "Your site has %1$d inactive theme, other than %2$s, the default ClassicPress theme, and %3$s, your active theme."
+msgid_plural "Your site has %1$d inactive themes, other than %2$s, the default ClassicPress theme, and %3$s, your active theme."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:708
+msgid "Have a default theme available"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:712
+msgid "Your site does not have any default theme. Default themes are used by ClassicPress automatically if anything is wrong with your chosen theme."
+msgstr ""
+
+#. translators: %s: The current PHP version.
+#: wp-admin/includes/class-wp-site-health.php:732
+msgid "Your site is running PHP version (%s)"
+msgstr ""
+
+#. translators: %s: The minimum recommended PHP version.
+#: wp-admin/includes/class-wp-site-health.php:744
+msgid "PHP is one of the programming languages used to build ClassicPress. Newer versions of PHP receive regular security updates and may increase your site&#8217;s performance. The minimum recommended version of PHP is %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:751
+#: wp-admin/includes/dashboard.php:1682
+msgid "Learn more about updating PHP"
+msgstr ""
+
+#. translators: %s: The server PHP version.
+#: wp-admin/includes/class-wp-site-health.php:765
+msgid "Your site is running on an older and unsupported version of PHP (%s), which should be updated"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:825
+msgid "Required and recommended modules are installed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:833
+msgid "PHP modules perform most of the tasks on the server that make your site run. Any changes to these must be made by your server administrator."
+msgstr ""
+
+#. translators: 1: Link to the hosting group page about recommended PHP modules. 2: Additional link attributes. 3: Accessibility text.
+#: wp-admin/includes/class-wp-site-health.php:836
+msgid "ClassicPress maintains a list of those modules, both recommended and required, in <a href=\"%1$s\" %2$s>the server requirements%3$s</a>."
+msgstr ""
+
+#. translators: Localized team handbook, if one exists.
+#: wp-admin/includes/class-wp-site-health.php:838
+msgid "https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-site-health.php:1002
+#: wp-admin/includes/class-wp-site-health.php:1389
+#: wp-admin/includes/class-wp-site-health.php:1801
+msgid "Error"
+msgstr ""
+
+#. translators: %s: The module name.
+#: wp-admin/includes/class-wp-site-health.php:1005
+msgid "The required module, %s, is not installed, or has been disabled."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-site-health.php:1011
+#: wp-admin/includes/class-wp-site-health.php:1810
+msgid "Warning"
+msgstr ""
+
+#. translators: %s: The module name.
+#: wp-admin/includes/class-wp-site-health.php:1014
+msgid "The optional module, %s, is not installed, or has been disabled."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1042
+msgid "One or more recommended modules are missing"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1045
+msgid "One or more required modules are missing"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1063
+msgid "PHP default timezone is valid"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1071
+msgid "PHP default timezone was configured by ClassicPress on loading. This is necessary for correct calculations of dates and times."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1080
+msgid "PHP default timezone is invalid"
+msgstr ""
+
+#. translators: %s: date_default_timezone_set()
+#: wp-admin/includes/class-wp-site-health.php:1086
+msgid "PHP default timezone was changed after ClassicPress loading by a %s function call. This interferes with correct calculations of dates and times."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1104
+msgid "No PHP sessions detected"
+msgstr ""
+
+#. translators: 1: session_start(), 2: session_write_close()
+#: wp-admin/includes/class-wp-site-health.php:1114
+msgid "PHP sessions created by a %1$s function call may interfere with REST API and loopback requests. An active session should be closed by %2$s before making any HTTP requests."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1125
+msgid "An active PHP session was detected"
+msgstr ""
+
+#. translators: 1: session_start(), 2: session_write_close()
+#: wp-admin/includes/class-wp-site-health.php:1131
+msgid "A PHP session was created by a %1$s function call. This interferes with REST API and loopback requests. The session should be closed by %2$s before making any HTTP requests."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1154
+msgid "SQL server is up to date"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1162
+msgid "The SQL server is a required piece of software for the database ClassicPress uses to store all your site&#8217;s content and settings."
+msgstr ""
+
+#. translators: Localized version of ClassicPress requirements if one exists.
+#: wp-admin/includes/class-wp-site-health.php:1167
+msgid "https://wordpress.org/about/requirements/"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1168
+msgid "Learn more about what ClassicPress requires to run."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1180
+msgid "Outdated SQL server"
+msgstr ""
+
+#. translators: 1: The database engine in use (MySQL or MariaDB). 2: Database server recommended version number.
+#: wp-admin/includes/class-wp-site-health.php:1186
+msgid "For optimal performance and security reasons, you should consider running %1$s version %2$s or higher. Contact your web hosting company to correct this."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1196
+msgid "Severely outdated SQL server"
+msgstr ""
+
+#. translators: 1: The database engine in use (MySQL or MariaDB). 2: Database server minimum version number.
+#: wp-admin/includes/class-wp-site-health.php:1203
+msgid "ClassicPress requires %1$s version %2$s or higher. Contact your web hosting company to correct this."
+msgstr ""
+
+#. translators: 1: The name of the drop-in. 2: The name of the database engine.
+#: wp-admin/includes/class-wp-site-health.php:1216
+msgid "You are using a %1$s drop-in which might mean that a %2$s database is not being used."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1247
+msgid "UTF8MB4 is supported"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1255
+msgid "UTF8MB4 is the character set ClassicPress prefers for database storage because it safely supports the widest set of characters and encodings, including Emoji, enabling better support for non-English languages."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1265
+msgid "utf8mb4 requires a MySQL update"
+msgstr ""
+
+#. translators: %s: Version number.
+#: wp-admin/includes/class-wp-site-health.php:1271
+msgid "ClassicPress&#8217; utf8mb4 support requires MySQL version %s or greater. Please contact your server administrator."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1278
+msgid "Your MySQL version supports utf8mb4."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1285
+msgid "utf8mb4 requires a MariaDB update"
+msgstr ""
+
+#. translators: %s: Version number.
+#: wp-admin/includes/class-wp-site-health.php:1291
+msgid "ClassicPress&#8217; utf8mb4 support requires MariaDB version %s or greater. Please contact your server administrator."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1298
+msgid "Your MariaDB version supports utf8mb4."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1315
+#: wp-admin/includes/class-wp-site-health.php:1331
+msgid "utf8mb4 requires a newer client library"
+msgstr ""
+
+#. translators: 1: Name of the library, 2: Number of version.
+#: wp-admin/includes/class-wp-site-health.php:1321
+#: wp-admin/includes/class-wp-site-health.php:1337
+msgid "ClassicPress&#8217; utf8mb4 support requires MySQL client library (%1$s) version %2$s or newer. Please contact your server administrator."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1357
+msgid "Can communicate with ClassicPress.net"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1365
+msgid "Communicating with the ClassicPress servers is used to check for new versions, and to both install and update ClassicPress core, themes or plugins."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1382
+msgid "Could not reach ClassicPress.net"
+msgstr ""
+
+#. translators: 1: The IP address WordPress.org resolves to. 2: The error returned by the lookup.
+#: wp-admin/includes/class-wp-site-health.php:1392
+msgid "Your site is unable to reach ClassicPress.net at %1$s, and returned the error: %2$s"
+msgstr ""
+
+#. translators: Localized Support reference.
+#: wp-admin/includes/class-wp-site-health.php:1402
+msgid "https://wordpress.org/support"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1403
+msgid "Get help resolving this issue."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1427
+msgid "Your site is not set to output debug information"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1435
+msgid "Debug mode is often enabled to gather more details about an error or site failure, but may contain sensitive information which should not be available on a publicly available website."
+msgstr ""
+
+#. translators: Documentation explaining debugging in WordPress.
+#: wp-admin/includes/class-wp-site-health.php:1440
+msgid "https://wordpress.org/documentation/article/debugging-in-wordpress/"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1441
+msgid "Learn more about debugging in ClassicPress."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1450
+msgid "Your site is set to log errors to a potentially public file"
+msgstr ""
+
+#. translators: %s: WP_DEBUG_LOG
+#: wp-admin/includes/class-wp-site-health.php:1458
+msgid "The value, %s, has been added to this website&#8217;s configuration file. This means any errors on the site will be written to a file which is potentially available to all users."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1465
+msgid "Your site is set to display errors to site visitors"
+msgstr ""
+
+#. translators: 1: WP_DEBUG_DISPLAY, 2: WP_DEBUG
+#: wp-admin/includes/class-wp-site-health.php:1478
+msgid "The value, %1$s, has either been enabled by %2$s or added to your configuration file. This will make errors display on the front end of your site."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1508
+msgid "Your website is using an active HTTPS connection"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1516
+msgid "An HTTPS connection is a more secure way of browsing the web. Many services now have HTTPS as a requirement. HTTPS allows you to take advantage of new features that can increase site speed, improve search rankings, and gain the trust of your visitors by helping to protect their online privacy."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1521
+msgid "Learn more about why you should use HTTPS"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1532
+msgid "Your website does not use HTTPS"
+msgstr ""
+
+#. translators: %s: URL to Settings > General > Site Address.
+#: wp-admin/includes/class-wp-site-health.php:1540
+msgid "You are accessing this website using HTTPS, but your <a href=\"%s\">Site Address</a> is not set up to use HTTPS by default."
+msgstr ""
+
+#. translators: %s: URL to Settings > General > Site Address.
+#: wp-admin/includes/class-wp-site-health.php:1549
+msgid "Your <a href=\"%s\">Site Address</a> is not set up to use HTTPS."
+msgstr ""
+
+#. translators: 1: URL to Settings > General > ClassicPress Address, 2: URL to Settings > General > Site Address.
+#: wp-admin/includes/class-wp-site-health.php:1560
+msgid "You are accessing this website using HTTPS, but your <a href=\"%1$s\">ClassicPress Address</a> and <a href=\"%2$s\">Site Address</a> are not set up to use HTTPS by default."
+msgstr ""
+
+#. translators: 1: URL to Settings > General > ClassicPress Address, 2: URL to Settings > General > Site Address.
+#: wp-admin/includes/class-wp-site-health.php:1570
+msgid "Your <a href=\"%1$s\">ClassicPress Address</a> and <a href=\"%2$s\">Site Address</a> are not set up to use HTTPS."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1581
+msgid "HTTPS is already supported for your website."
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: WP_HOME, 3: WP_SITEURL
+#: wp-admin/includes/class-wp-site-health.php:1589
+msgid "However, your ClassicPress Address is currently controlled by a PHP constant and therefore cannot be updated. You need to edit your %1$s and remove or update the definitions of %2$s and %3$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1603
+#: wp-admin/includes/class-wp-site-health.php:1611
+msgid "Update your site to use HTTPS"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1622
+#: wp-admin/includes/class-wp-site-health.php:1629
+msgid "Talk to your web host about supporting HTTPS for your website."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1655
+msgid "Securely communicating between servers are needed for transactions such as fetching files, conducting sales on store sites, and much more."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1666
+msgid "Your site can communicate securely with other services"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1670
+msgid "Your site is unable to communicate securely with other services"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1674
+msgid "Talk to your web host about OpenSSL support for PHP."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1693
+msgid "Scheduled events are running"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1701
+msgid "Scheduled events are what periodically looks for updates to plugins, themes and ClassicPress itself. It is also what makes sure scheduled posts are published on time. It may also be used by various plugins to make sure that planned actions are executed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1712
+msgid "It was not possible to check your scheduled events"
+msgstr ""
+
+#. translators: %s: The error message returned while from the cron scheduler.
+#: wp-admin/includes/class-wp-site-health.php:1718
+msgid "While trying to test your site&#8217;s scheduled events, the following error was returned: %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1725
+msgid "A scheduled event has failed"
+msgstr ""
+
+#. translators: %s: The name of the failed cron event.
+#: wp-admin/includes/class-wp-site-health.php:1731
+msgid "The scheduled event, %s, failed to run. Your site still works, but this may indicate that scheduling posts or automated updates may not work as intended."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1738
+msgid "A scheduled event is late"
+msgstr ""
+
+#. translators: %s: The name of the late cron event.
+#: wp-admin/includes/class-wp-site-health.php:1744
+msgid "The scheduled event, %s, is late to run. Your site still works, but this may indicate that scheduling posts or automated updates may not work as intended."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1766
+msgid "Background updates are working"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1774
+msgid "Background updates ensure that ClassicPress can auto-update if a security update is released for the version you are currently using."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-site-health.php:1793
+msgid "Passed"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1796
+msgid "Background updates are not working as expected"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1805
+msgid "Background updates may not be working properly"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1839
+msgid "Plugin and theme auto-updates appear to be configured correctly"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1847
+msgid "Plugin and theme auto-updates ensure that the latest versions are always installed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1858
+msgid "Your site may have problems auto-updating plugins and themes"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1882
+msgid "Your site can perform loopback requests"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1890
+msgid "Loopback requests are used to run scheduled events, and are also used by the built-in editors for themes and plugins to verify code stability."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1901
+msgid "Your site could not complete a loopback request"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1925
+msgid "HTTP requests seem to be working as expected"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1933
+msgid "It is possible for site maintainers to block all, or some, communication to other sites and services. If set up incorrectly, this may prevent plugins and themes from working as intended."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1953
+msgid "HTTP requests are blocked"
+msgstr ""
+
+#. translators: %s: Name of the constant used.
+#: wp-admin/includes/class-wp-site-health.php:1959
+msgid "HTTP requests have been blocked by the %s constant, with no allowed hosts."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1968
+msgid "HTTP requests are partially blocked"
+msgstr ""
+
+#. translators: 1: Name of the constant used. 2: List of allowed hostnames.
+#: wp-admin/includes/class-wp-site-health.php:1974
+msgid "HTTP requests have been blocked by the %1$s constant, with some allowed hosts: %2$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:1996
+msgid "The REST API is available"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2004
+msgid "The REST API is one way that ClassicPress and other applications communicate with the server. For example, the block editor screen relies on the REST API to display and save your posts and pages."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2039
+msgid "The REST API encountered an error"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2043
+msgid "When testing the REST API, an error was encountered:"
+msgstr ""
+
+#. translators: %s: The REST API URL.
+#: wp-admin/includes/class-wp-site-health.php:2046
+#: wp-admin/includes/class-wp-site-health.php:2066
+msgid "REST API Endpoint: %s"
+msgstr ""
+
+#. translators: 1: The ClassicPress error code. 2: The ClassicPress error message.
+#. translators: 1: The ClassicPress error code. 2: The HTTP status code error message.
+#: wp-admin/includes/class-wp-site-health.php:2051
+#: wp-admin/includes/class-wp-site-health.php:2071
+msgid "REST API Response: (%1$s) %2$s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2059
+msgid "The REST API encountered an unexpected result"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2063
+msgid "When testing the REST API, an unexpected result was returned:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2082
+msgid "The REST API did not behave correctly"
+msgstr ""
+
+#. translators: %s: The name of the query parameter being tested.
+#: wp-admin/includes/class-wp-site-health.php:2088
+msgid "The REST API did not process the %s query parameter correctly."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2107
+msgid "Files can be uploaded"
+msgstr ""
+
+#. translators: 1: file_uploads, 2: php.ini
+#: wp-admin/includes/class-wp-site-health.php:2117
+msgid "The %1$s directive in %2$s determines if uploading files is allowed on your site."
+msgstr ""
+
+#. translators: %s: ini_get()
+#: wp-admin/includes/class-wp-site-health.php:2130
+msgid "The %s function has been disabled, some media settings are unavailable because of this."
+msgstr ""
+
+#. translators: 1: file_uploads, 2: 0
+#: wp-admin/includes/class-wp-site-health.php:2142
+msgid "%1$s is set to %2$s. You won't be able to upload files on your site."
+msgstr ""
+
+#. translators: 1: post_max_size, 2: upload_max_filesize
+#: wp-admin/includes/class-wp-site-health.php:2156
+msgid "The \"%1$s\" value is smaller than \"%2$s\""
+msgstr ""
+
+#. translators: 1: post_max_size, 2: upload_max_filesize
+#: wp-admin/includes/class-wp-site-health.php:2167
+msgid "The setting for %1$s is currently configured as 0, this could cause some problems when trying to upload files through plugin or theme features that rely on various upload methods. It is recommended to configure this setting to a fixed value, ideally matching the value of %2$s, as some upload methods read the value 0 as either unlimited, or disabled."
+msgstr ""
+
+#. translators: 1: post_max_size, 2: upload_max_filesize
+#: wp-admin/includes/class-wp-site-health.php:2177
+msgid "The setting for %1$s is smaller than %2$s, this could cause some problems when trying to upload files."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2199
+msgid "The Authorization header is working as expected"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2207
+msgid "The Authorization header is used by third-party applications you have approved for this site. Without this header, those apps cannot connect to your site."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2214
+msgid "The authorization header is missing"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2216
+msgid "The authorization header is invalid"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2224
+msgid "If you are still seeing this warning after having tried the actions below, you may need to contact your hosting provider for further assistance."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2235
+msgid "Flush permalinks"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2240
+msgid "https://developer.wordpress.org/rest-api/frequently-asked-questions/#why-is-authentication-not-working"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2241
+msgid "Learn how to configure the Authorization header."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2258
+msgid "Page cache enhances the speed and performance of your site by saving and serving static pages instead of calling for a page every time a user visits."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2259
+msgid "Page cache is detected by looking for an active page cache plugin as well as making three requests to the homepage and looking for one or more of the following HTTP client caching response headers:"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2273
+msgid "https://wordpress.org/documentation/article/optimization/#Caching"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2274
+msgid "Learn more about page cache"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2283
+msgid "Unable to detect the presence of page cache"
+msgstr ""
+
+#. translators: 1: Error message, 2: Error code.
+#: wp-admin/includes/class-wp-site-health.php:2287
+msgid "Unable to detect page cache due to possible loopback request problem. Please verify that the loopback request test is passing. Error: %1$s (Code: %2$s)"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2299
+msgid "Page cache is not detected but the server response time is OK"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2302
+msgid "Page cache is detected and the server response time is good"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2306
+msgid "Page cache is not detected and the server response time is slow"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2308
+msgid "Page cache is detected but the server response time is still slow"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2315
+msgid "Server response time could not be determined. Verify that loopback requests are working."
+msgstr ""
+
+#. translators: 1: The response time in milliseconds, 2: The recommended threshold in milliseconds.
+#: wp-admin/includes/class-wp-site-health.php:2322
+msgid "Median server response time was %1$s milliseconds. This is less than the recommended %2$s milliseconds threshold."
+msgstr ""
+
+#. translators: 1: The response time in milliseconds, 2: The recommended threshold in milliseconds.
+#: wp-admin/includes/class-wp-site-health.php:2329
+msgid "Median server response time was %1$s milliseconds. It should be less than the recommended %2$s milliseconds threshold."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2336
+msgid "No client caching response headers were detected."
+msgstr ""
+
+#. translators: %d: Number of caching headers.
+#: wp-admin/includes/class-wp-site-health.php:2341
+msgid "There was %d client caching response header detected:"
+msgid_plural "There were %d client caching response headers detected:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-site-health.php:2354
+msgid "A page cache plugin was detected."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2357
+msgid "A page cache plugin was not detected."
+msgstr ""
+
+#. translators: Localized Support reference.
+#: wp-admin/includes/class-wp-site-health.php:2382
+msgid "https://wordpress.org/documentation/article/optimization/#persistent-object-cache"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2392
+msgid "A persistent object cache is being used"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2395
+msgid "A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because ClassicPress can retrieve your site&#8217;s content and settings much more quickly."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2400
+msgid "Learn more about persistent object caching."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2411
+msgid "A persistent object cache is not required"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2418
+msgid "Your hosting provider can tell you if a persistent object cache can be enabled on your site."
+msgstr ""
+
+#. translators: Available object caching services.
+#: wp-admin/includes/class-wp-site-health.php:2423
+msgid "Your host appears to support the following object caching services: %s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2444
+msgid "You should use a persistent object cache"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2477
+msgid "ClassicPress Version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2481
+msgid "Plugin Versions"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2485
+msgid "Theme Versions"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2489
+msgid "PHP Version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2493
+msgid "PHP Extensions"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2497
+msgid "PHP Default Timezone"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2501
+msgid "PHP Sessions"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2505
+msgid "Database Server version"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2509
+msgid "MySQL utf8mb4 support"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2513
+msgid "Secure communication"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2517
+msgid "Scheduled events"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2521
+msgid "HTTP Requests"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2525
+msgid "REST API availability"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2530
+msgid "Debugging enabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2538
+msgid "Plugin and theme auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2544
+msgid "Communication with ClassicPress.net"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2550
+msgid "Background updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2556
+msgid "Loopback request"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2562
+msgid "HTTPS status"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2573
+msgid "Authorization header"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2584
+msgid "Page cache"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2591
+msgid "Persistent object cache"
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2702
+msgid "No scheduled events exist on this site."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2837
+msgid "Auto-updates for plugins and/or themes appear to be disabled, but settings are still set to be displayed. This could cause auto-updates to not work as expected."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2846
+msgid "Auto-updates for plugins and themes appear to be disabled. This will prevent your site from receiving new versions automatically when available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2851
+msgid "Auto-updates for plugins appear to be disabled. This will prevent your site from receiving new versions automatically when available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2856
+msgid "Auto-updates for themes appear to be disabled. This will prevent your site from receiving new versions automatically when available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2862
+msgid "There appear to be no issues with plugin and theme auto-updates."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2910
+msgid "The loopback request to your site failed, this means features relying on them are not currently working as expected."
+msgstr ""
+
+#. translators: 1: The ClassicPress error message. 2: The ClassicPress error code.
+#: wp-admin/includes/class-wp-site-health.php:2913
+msgid "Error: %1$s (%2$s)"
+msgstr ""
+
+#. translators: %d: The HTTP response code returned.
+#: wp-admin/includes/class-wp-site-health.php:2926
+msgid "The loopback request returned an unexpected http status code, %d, it was not possible to determine if this will prevent features from working as expected."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:2934
+msgid "The loopback request to your site completed successfully."
+msgstr ""
+
+#: wp-admin/includes/class-wp-site-health.php:3041
+#: wp-admin/js/site-health.js:340
+msgid "A test is unavailable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-terms-list-table.php:198
+#: wp-admin/link-manager.php:50
+#: wp-admin/menu.php:80
+msgid "Links"
+msgstr ""
+
+#: wp-admin/includes/class-wp-terms-list-table.php:200
+msgctxt "Number/count of items"
+msgid "Count"
+msgstr ""
+
+#. translators: %s: Taxonomy term name.
+#: wp-admin/includes/class-wp-terms-list-table.php:492
+msgid "Delete &#8220;%s&#8221;"
+msgstr ""
+
+#. translators: %s: Taxonomy term name.
+#: wp-admin/includes/class-wp-terms-list-table.php:502
+msgid "View &#8220;%s&#8221; archive"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-terms-list-table.php:551
+msgid "No description"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:63
+msgctxt "themes"
+msgid "Featured"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:65
+#: wp-admin/theme-install.php:195
+msgctxt "themes"
+msgid "Latest"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:66
+msgctxt "themes"
+msgid "Recently Updated"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:175
+msgid "No themes match your request."
+msgstr ""
+
+#. translators: %s: Theme version.
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/class-wp-theme-install-list-table.php:317
+#: wp-admin/includes/class-wp-theme-install-list-table.php:476
+#: wp-admin/update-core.php:74
+msgid "Update to version %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:325
+#: wp-admin/includes/class-wp-theme-install-list-table.php:484
+msgid "This theme is already installed and is up to date"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:326
+#: wp-admin/includes/class-wp-theme-install-list-table.php:485
+#: wp-admin/theme-install.php:286
+msgctxt "theme"
+msgid "Installed"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-theme-install-list-table.php:335
+#: wp-admin/theme-install.php:398
+msgctxt "theme"
+msgid "Install %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-theme-install-list-table.php:345
+msgid "Preview %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-theme-install-list-table.php:395
+#: wp-admin/theme-install.php:421
+msgid "Close"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:402
+#: wp-admin/theme-install.php:71
+#: wp-admin/theme-install.php:558
+msgid "Collapse Sidebar"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:404
+#: wp-admin/theme-install.php:560
+msgid "Collapse"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/class-wp-theme-install-list-table.php:493
+#: wp-admin/includes/deprecated.php:1391
+#: wp-admin/includes/network.php:370
+#: wp-admin/includes/theme.php:1043
+#: wp-admin/theme-install.php:400
+#: wp-admin/theme-install.php:452
+msgid "Install"
+msgstr ""
+
+#: wp-admin/includes/class-wp-theme-install-list-table.php:519
+#: wp-admin/includes/class-wp-themes-list-table.php:278
+#: wp-admin/includes/plugin-install.php:685
+msgid "Version:"
+msgstr ""
+
+#. translators: 1: URL to Themes tab on Edit Site screen, 2: URL to Add Themes screen.
+#: wp-admin/includes/class-wp-themes-list-table.php:101
+msgid "You only have one theme enabled for this site right now. Visit the Network Admin to <a href=\"%1$s\">enable</a> or <a href=\"%2$s\">install</a> more themes."
+msgstr ""
+
+#. translators: %s: URL to Themes tab on Edit Site screen.
+#: wp-admin/includes/class-wp-themes-list-table.php:110
+msgid "You only have one theme enabled for this site right now. Visit the Network Admin to <a href=\"%s\">enable</a> more themes."
+msgstr ""
+
+#. translators: %s: URL to Add Themes screen.
+#: wp-admin/includes/class-wp-themes-list-table.php:121
+msgid "You only have one theme installed right now. Live a little! You can choose from over 1,000 free themes in the ClassicPress Theme Directory at any time: just click on the <a href=\"%s\">Install Themes</a> tab above."
+msgstr ""
+
+#. translators: %s: Network title.
+#: wp-admin/includes/class-wp-themes-list-table.php:131
+msgid "Only the active theme is available to you. Contact the %s administrator for information about accessing additional themes."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-themes-list-table.php:231
+msgid ""
+"You are about to delete this theme '%s'\n"
+"  'Cancel' to stop, 'OK' to delete."
+msgstr ""
+
+#. translators: 1: Link to documentation on child themes, 2: Name of parent theme.
+#: wp-admin/includes/class-wp-themes-list-table.php:284
+msgid "This <a href=\"%1$s\">child theme</a> requires its parent theme, %2$s."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:150
+msgid "Invalid data provided."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:152
+#: wp-admin/includes/plugin.php:952
+#: wp-admin/includes/theme.php:66
+msgid "Filesystem error."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:153
+msgid "Unable to locate ClassicPress root directory."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:154
+msgid "Unable to locate ClassicPress content directory (wp-content)."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:155
+#: wp-admin/includes/plugin.php:958
+msgid "Unable to locate ClassicPress plugin directory."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:156
+#: wp-admin/includes/theme.php:72
+msgid "Unable to locate ClassicPress theme directory."
+msgstr ""
+
+#. translators: %s: Directory name.
+#: wp-admin/includes/class-wp-upgrader.php:158
+msgid "Unable to locate needed folder (%s)."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:161
+msgid "Installing the latest version&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:162
+msgid "The package contains no files."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:163
+msgid "Destination folder already exists."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:164
+#: wp-admin/includes/file.php:1716
+#: wp-admin/includes/file.php:1857
+#: wp-admin/includes/file.php:1931
+#: wp-admin/includes/file.php:2014
+msgid "Could not create directory."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:165
+msgid "The package could not be installed."
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:168
+#: wp-admin/includes/update-core.php:505
+msgid "Enabling Maintenance mode&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-upgrader.php:169
+#: wp-admin/includes/update-core.php:650
+msgid "Disabling Maintenance mode&#8230;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:158
+#: wp-admin/includes/deprecated.php:578
+msgid "No users found."
+msgstr ""
+
+#. translators: %s: Number of users.
+#: wp-admin/includes/class-wp-users-list-table.php:206
+msgctxt "users"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: User role name, 2: Number of users.
+#: wp-admin/includes/class-wp-users-list-table.php:231
+#: wp-admin/includes/class-wp-users-list-table.php:249
+msgid "%1$s <span class=\"count\">(%2$s)</span>"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:246
+msgid "No role"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:286
+#: wp-admin/includes/class-wp-users-list-table.php:506
+msgid "Send password reset"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-users-list-table.php:309
+#: wp-admin/includes/class-wp-users-list-table.php:313
+msgid "Change role to&hellip;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:315
+#: wp-admin/user-edit.php:451
+#: wp-admin/user-edit.php:453
+#: wp-admin/users.php:127
+msgid "&mdash; No role for this site &mdash;"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:318
+msgid "Change"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:373
+#: wp-admin/includes/file.php:2430
+#: wp-admin/install.php:118
+#: wp-admin/install.php:434
+#: wp-admin/setup-config.php:230
+#: wp-admin/user-edit.php:432
+#: wp-admin/user-new.php:532
+msgid "Username"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:376
+#: wp-admin/user-edit.php:438
+#: wp-admin/user-new.php:467
+#: wp-admin/user-new.php:628
+msgid "Role"
+msgstr ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:455
+#: wp-admin/user-edit.php:463
+msgid "Super Admin"
+msgstr ""
+
+#. translators: %s: Author's display name.
+#: wp-admin/includes/class-wp-users-list-table.php:497
+msgid "View posts by %s"
+msgstr ""
+
+#. translators: 1: User's first name, 2: Last name.
+#: wp-admin/includes/class-wp-users-list-table.php:576
+msgctxt "Display name based on first name and last name"
+msgid "%1$s %2$s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-users-list-table.php:588
+msgctxt "name"
+msgid "Unknown"
+msgstr ""
+
+#. translators: Hidden accessibility text. %s: Number of posts.
+#: wp-admin/includes/class-wp-users-list-table.php:606
+msgid "%s post by this author"
+msgid_plural "%s posts by this author"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-users-list-table.php:669
+msgctxt "no user roles"
+msgid "None"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:35
+msgid "You are using an insecure browser!"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:37
+msgid "Your browser is out of date!"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:50
+msgid "PHP Update Required"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:52
+msgid "PHP Update Recommended"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:68
+#: wp-admin/site-health.php:238
+msgid "Site Health Status"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:73
+msgid "At a Glance"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:77
+msgid "Right Now"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:82
+msgid "Activity"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:87
+msgid "Quick Draft"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:87
+#: wp-admin/includes/dashboard.php:660
+msgid "Your Recent Drafts"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:92
+msgid "ClassicPress News"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:99
+msgid "ClassicPress Directory"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:156
+msgid "View all"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:218
+msgid "Configure"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:259
+#: wp-admin/includes/template.php:2478
+#: wp-admin/nav-menus.php:847
+#: wp-admin/options.php:417
+msgid "Save Changes"
+msgstr ""
+
+#. translators: %s: Number of posts.
+#: wp-admin/includes/dashboard.php:320
+msgid "%s Post"
+msgid_plural "%s Posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of pages.
+#: wp-admin/includes/dashboard.php:323
+msgid "%s Page"
+msgid_plural "%s Pages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/dashboard.php:408
+msgid "Search engines discouraged"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:459
+msgid "Create a New Site"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:462
+msgid "Create a New User"
+msgstr ""
+
+#. translators: %s: Number of users on the network.
+#: wp-admin/includes/dashboard.php:469
+msgid "%s user"
+msgid_plural "%s users"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites on the network.
+#: wp-admin/includes/dashboard.php:471
+msgid "%s site"
+msgid_plural "%s sites"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: Text indicating the number of sites on the network, 2: Text indicating the number of users on the network.
+#: wp-admin/includes/dashboard.php:474
+msgid "You have %1$s and %2$s."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/dashboard.php:505
+#: wp-admin/includes/dashboard.php:509
+#: wp-admin/users.php:651
+msgid "Search Users"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/dashboard.php:518
+#: wp-admin/includes/dashboard.php:522
+msgid "Search Sites"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:599
+#: wp-admin/index.php:104
+msgid "Content"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:600
+msgid "What&#8217;s on your mind?"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:608
+#: wp-admin/includes/meta-boxes.php:56
+#: wp-admin/js/post.js:859
+msgid "Save Draft"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:656
+msgid "View all drafts"
+msgstr ""
+
+#. translators: Maximum number of words used in a preview of a draft on the dashboard.
+#: wp-admin/includes/dashboard.php:664
+msgctxt "draft_length"
+msgid "10"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:800
+msgid "View this comment"
+msgstr ""
+
+#. translators: 1: Comment author, 2: Post link, 3: Notification if the comment is pending.
+#: wp-admin/includes/dashboard.php:864
+msgid "From %1$s on %2$s %3$s"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:867
+#: wp-admin/includes/dashboard.php:874
+#: wp-admin/includes/dashboard.php:904
+#: wp-admin/includes/dashboard.php:911
+msgid "[Pending]"
+msgstr ""
+
+#. translators: 1: Comment author, 2: Notification if the comment is pending.
+#: wp-admin/includes/dashboard.php:872
+msgid "From %1$s %2$s"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:884
+msgid "Pingback"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:887
+msgid "Trackback"
+msgstr ""
+
+#. translators: 1: Type of comment, 2: Post link, 3: Notification if the comment is pending.
+#: wp-admin/includes/dashboard.php:901
+msgctxt "dashboard"
+msgid "%1$s on %2$s %3$s"
+msgstr ""
+
+#. translators: 1: Type of comment, 2: Notification if the comment is pending.
+#: wp-admin/includes/dashboard.php:909
+msgctxt "dashboard"
+msgid "%1$s %2$s"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:943
+msgid "Publishing Soon"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:952
+msgid "Recently Published"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:961
+msgid "No activity yet!"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1025
+msgid "Today"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1027
+msgid "Tomorrow"
+msgstr ""
+
+#. translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/includes/dashboard.php:1030
+msgid "M jS Y"
+msgstr ""
+
+#. translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/includes/dashboard.php:1033
+msgid "M jS"
+msgstr ""
+
+#. translators: 1: Relative date, 2: Time.
+#: wp-admin/includes/dashboard.php:1043
+msgctxt "dashboard"
+msgid "%1$s, %2$s"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1107
+msgid "Recent Comments"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/dashboard.php:1128
+msgid "View more comments"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1176
+msgid "This widget requires JavaScript."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1281
+msgid "Unknown Feed"
+msgstr ""
+
+#. translators: link to ClassicPress blog
+#: wp-admin/includes/dashboard.php:1312
+msgid "You can always find the latest ClassicPress news on our <a href=\"%s\" target=\"_blank\">official blog <span aria-hidden=\"true\" class=\"dashicons dashicons-external\"></span></a>."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1322
+msgid "Get Help"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1323
+msgid "Feature Requests"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1324
+msgid "Volunteer"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1325
+msgid "Donate"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1349
+#: wp-admin/index.php:98
+msgid "https://www.classicpress.net/blog/"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1358
+msgid "https://www.classicpress.net/feed/"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1367
+msgid "ClassicPress Blog"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1426
+msgid "Storage Space"
+msgstr ""
+
+#. translators: %s: Number of megabytes.
+#: wp-admin/includes/dashboard.php:1433
+msgid "%s MB Space Allowed"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/dashboard.php:1441
+#: wp-admin/includes/dashboard.php:1457
+msgid "Manage Uploads"
+msgstr ""
+
+#. translators: 1: Number of megabytes, 2: Percentage.
+#: wp-admin/includes/dashboard.php:1448
+msgid "%1$s MB (%2$s%%) Space Used"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1482
+msgid "Internet Explorer does not give you the best ClassicPress experience. Switch to Microsoft Edge, or another more modern browser to get the most from your site."
+msgstr ""
+
+#. translators: %s: Browser name and link.
+#: wp-admin/includes/dashboard.php:1486
+msgid "It looks like you're using an insecure version of %s. Using an outdated browser makes your computer unsafe. For the best ClassicPress experience, please update your browser."
+msgstr ""
+
+#. translators: %s: Browser name and link.
+#: wp-admin/includes/dashboard.php:1492
+msgid "It looks like you're using an old version of %s. For the best ClassicPress experience, please update your browser."
+msgstr ""
+
+#. translators: %s: Browse Happy URL.
+#: wp-admin/includes/dashboard.php:1515
+msgid "Learn how to <a href=\"%s\" class=\"update-browser-link\">browse happy</a>"
+msgstr ""
+
+#. translators: 1: Browser update URL, 2: Browser name, 3: Browse Happy URL.
+#: wp-admin/includes/dashboard.php:1521
+msgid "<a href=\"%1$s\" class=\"update-browser-link\">Update %2$s</a> or learn how to <a href=\"%3$s\" class=\"browse-happy-link\">browse happy</a>"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1529
+msgid "Dismiss the browser warning panel"
+msgstr ""
+
+#. translators: %s: The server PHP version.
+#: wp-admin/includes/dashboard.php:1637
+msgid "Your site is running on an outdated version of PHP (%s), which does not receive security updates and soon will not be supported by WordPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress."
+msgstr ""
+
+#. translators: %s: The server PHP version.
+#: wp-admin/includes/dashboard.php:1643
+msgid "Your site is running on an outdated version of PHP (%s), which does not receive security updates. It should be updated."
+msgstr ""
+
+#. translators: %s: The server PHP version.
+#: wp-admin/includes/dashboard.php:1650
+msgid "Your site is running on an outdated version of PHP (%s), which soon will not be supported by WordPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress."
+msgstr ""
+
+#. translators: %s: The server PHP version.
+#: wp-admin/includes/dashboard.php:1656
+msgid "Your site is running on an outdated version of PHP (%s), which should be updated."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1663
+msgid "What is PHP and how does it affect my site?"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1665
+msgid "PHP is one of the programming languages used to build ClassicPress. Newer versions of PHP receive regular security updates and may increase your site&#8217;s performance."
+msgstr ""
+
+#. translators: %s: The minimum recommended PHP version.
+#: wp-admin/includes/dashboard.php:1670
+msgid "The minimum recommended version of PHP is %s."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1752
+msgid "No information yet&hellip;"
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1754
+#: wp-admin/site-health.php:127
+msgid "Results are still loading&hellip;"
+msgstr ""
+
+#. translators: %s: URL to Site Health screen.
+#: wp-admin/includes/dashboard.php:1765
+msgid "Site health checks will automatically run periodically to gather information about your site. You can also <a href=\"%s\">visit the Site Health screen</a> to gather information about your site now."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1773
+msgid "Great job! Your site currently passes all site health checks."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1775
+msgid "Your site has a critical issue that should be addressed as soon as possible to improve its performance and security."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1777
+msgid "Your site has critical issues that should be addressed as soon as possible to improve its performance and security."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1779
+msgid "Your site&#8217;s health is looking good, but there is still one thing you can do to improve its performance and security."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1781
+msgid "Your site&#8217;s health is looking good, but there are still some things you can do to improve its performance and security."
+msgstr ""
+
+#. translators: 1: Number of issues. 2: URL to Site Health screen.
+#: wp-admin/includes/dashboard.php:1791
+msgid "Take a look at the <strong>%1$d item</strong> on the <a href=\"%2$s\">Site Health screen</a>."
+msgid_plural "Take a look at the <strong>%1$d items</strong> on the <a href=\"%2$s\">Site Health screen</a>."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/dashboard.php:1828
+msgid "We would like to let you know about the ClassicPress Directory."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1829
+msgid "You can browse the new directory at <a href=\"%1$s\" target=\"_blank\">%1$s</a>."
+msgstr ""
+
+#: wp-admin/includes/dashboard.php:1841
+msgid "<a href=\"%1$s\">Install</a> the ClassicPress Directory Integration plugin to install plugins from the Plugins Menu."
+msgstr ""
+
+#. translators: 1: Starting number of users on the current page, 2: Ending number of users, 3: Total number of users.
+#: wp-admin/includes/deprecated.php:613
+msgid "Displaying %1$s&#8211;%2$s of %3$s"
+msgstr ""
+
+#: wp-admin/includes/deprecated.php:1388
+msgid "Popular Plugin"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/deprecated.php:1391
+msgctxt "plugin"
+msgid "Install %s"
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:14
+msgid "Item added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:15
+msgid "Item deleted."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:16
+msgid "Item updated."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:17
+msgid "Item not added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:19
+msgid "Items deleted."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:24
+msgid "Category added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:25
+msgid "Category deleted."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:26
+msgid "Category updated."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:27
+msgid "Category not added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:28
+msgid "Category not updated."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:29
+msgid "Categories deleted."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:34
+msgid "Tag added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:35
+msgid "Tag deleted."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:36
+msgid "Tag updated."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:37
+msgid "Tag not added."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:38
+msgid "Tag not updated."
+msgstr ""
+
+#: wp-admin/includes/edit-tag-messages.php:39
+msgid "Tags deleted."
+msgstr ""
+
+#: wp-admin/includes/file.php:16
+msgid "Theme Functions"
+msgstr ""
+
+#: wp-admin/includes/file.php:17
+msgid "Theme Header"
+msgstr ""
+
+#: wp-admin/includes/file.php:18
+msgid "Theme Footer"
+msgstr ""
+
+#: wp-admin/includes/file.php:19
+#: wp-admin/widgets-form.php:299
+msgid "Sidebar"
+msgstr ""
+
+#: wp-admin/includes/file.php:21
+msgid "Search Form"
+msgstr ""
+
+#: wp-admin/includes/file.php:22
+msgid "404 Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:23
+msgid "Links Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:25
+msgid "Main Index Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:26
+msgid "Archives"
+msgstr ""
+
+#: wp-admin/includes/file.php:27
+msgid "Author Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:28
+msgid "Taxonomy Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:29
+msgid "Category Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:30
+msgid "Tag Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:31
+msgid "Posts Page"
+msgstr ""
+
+#: wp-admin/includes/file.php:33
+msgid "Date Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:35
+msgid "Singular Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:36
+msgid "Single Post"
+msgstr ""
+
+#: wp-admin/includes/file.php:37
+msgid "Single Page"
+msgstr ""
+
+#: wp-admin/includes/file.php:38
+msgid "Homepage"
+msgstr ""
+
+#: wp-admin/includes/file.php:39
+msgid "Privacy Policy Page"
+msgstr ""
+
+#: wp-admin/includes/file.php:41
+msgid "Attachment Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:42
+msgid "Image Attachment Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:43
+msgid "Video Attachment Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:44
+msgid "Audio Attachment Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:45
+msgid "Application Attachment Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:47
+msgid "Embed Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:48
+msgid "Embed 404 Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:49
+msgid "Embed Content Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:50
+msgid "Embed Header Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:51
+msgid "Embed Footer Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:53
+#: wp-admin/includes/file.php:61
+msgid "Stylesheet"
+msgstr ""
+
+#: wp-admin/includes/file.php:54
+msgid "Visual Editor Stylesheet"
+msgstr ""
+
+#: wp-admin/includes/file.php:55
+msgid "Visual Editor RTL Stylesheet"
+msgstr ""
+
+#: wp-admin/includes/file.php:56
+msgid "RTL Stylesheet"
+msgstr ""
+
+#: wp-admin/includes/file.php:58
+msgid "my-hacks.php (legacy hacks support)"
+msgstr ""
+
+#: wp-admin/includes/file.php:59
+msgid ".htaccess (for rewrite rules )"
+msgstr ""
+
+#: wp-admin/includes/file.php:62
+msgid "Comments Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:63
+msgid "Popup Comments Template"
+msgstr ""
+
+#: wp-admin/includes/file.php:64
+msgid "Popup Comments"
+msgstr ""
+
+#. translators: %s: Template name.
+#: wp-admin/includes/file.php:92
+msgid "%s Page Template"
+msgstr ""
+
+#. translators: 1: Line number, 2: File path.
+#: wp-admin/includes/file.php:312
+msgid "Your PHP code changes were rolled back due to an error on line %1$s of file %2$s. Please fix and try saving again."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/file.php:324
+#: wp-admin/plugin-editor.php:298
+#: wp-admin/theme-editor.php:328
+msgid "You need to make this file writable before you can save your changes. See <a href=\"%s\">Changing File Permissions</a> for more information."
+msgstr ""
+
+#: wp-admin/includes/file.php:325
+#: wp-admin/plugin-editor.php:299
+#: wp-admin/setup-config.php:474
+#: wp-admin/theme-editor.php:329
+msgid "https://wordpress.org/documentation/article/changing-file-permissions/"
+msgstr ""
+
+#: wp-admin/includes/file.php:336
+msgid "Update anyway, even though it might break your site?"
+msgstr ""
+
+#: wp-admin/includes/file.php:402
+#: wp-admin/plugin-editor.php:18
+msgid "Sorry, you are not allowed to edit plugins for this site."
+msgstr ""
+
+#: wp-admin/includes/file.php:414
+#: wp-admin/includes/file.php:475
+#: wp-admin/includes/file.php:722
+#: wp-admin/includes/file.php:728
+msgid "Sorry, that file cannot be edited."
+msgstr ""
+
+#: wp-admin/includes/file.php:435
+#: wp-admin/theme-editor.php:18
+msgid "Sorry, you are not allowed to edit templates for this site."
+msgstr ""
+
+#: wp-admin/includes/file.php:488
+#: wp-admin/plugin-editor.php:110
+#: wp-admin/theme-editor.php:284
+msgid "File does not exist! Please double check the name and try again."
+msgstr ""
+
+#: wp-admin/includes/file.php:496
+#: wp-admin/plugin-editor.php:117
+msgid "Files of this type are not editable."
+msgstr ""
+
+#: wp-admin/includes/file.php:516
+msgid "Unable to write to file."
+msgstr ""
+
+#: wp-admin/includes/file.php:585
+msgid "Unable to communicate back with site to check for fatal errors, so the PHP change was reverted. You will need to upload your PHP file change by some other means, such as by using SFTP."
+msgstr ""
+
+#. translators: 1: upload_max_filesize, 2: php.ini
+#: wp-admin/includes/file.php:868
+msgid "The uploaded file exceeds the %1$s directive in %2$s."
+msgstr ""
+
+#. translators: %s: MAX_FILE_SIZE
+#: wp-admin/includes/file.php:874
+msgid "The uploaded file exceeds the %s directive that was specified in the HTML form."
+msgstr ""
+
+#: wp-admin/includes/file.php:877
+msgid "The uploaded file was only partially uploaded."
+msgstr ""
+
+#: wp-admin/includes/file.php:878
+msgid "No file was uploaded."
+msgstr ""
+
+#: wp-admin/includes/file.php:880
+msgid "Missing a temporary folder."
+msgstr ""
+
+#: wp-admin/includes/file.php:881
+msgid "Failed to write file to disk."
+msgstr ""
+
+#: wp-admin/includes/file.php:882
+msgid "File upload stopped by extension."
+msgstr ""
+
+#: wp-admin/includes/file.php:896
+msgid "Invalid form submission."
+msgstr ""
+
+#: wp-admin/includes/file.php:907
+msgid "Specified file failed upload test."
+msgstr ""
+
+#: wp-admin/includes/file.php:914
+msgid "File is empty. Please upload something more substantial."
+msgstr ""
+
+#. translators: 1: php.ini, 2: post_max_size, 3: upload_max_filesize
+#: wp-admin/includes/file.php:918
+#: wp-admin/includes/import.php:87
+msgid "File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your %1$s file or by %2$s being defined as smaller than %3$s in %1$s."
+msgstr ""
+
+#: wp-admin/includes/file.php:941
+msgid "Sorry, you are not allowed to upload this file type."
+msgstr ""
+
+#. translators: %s: Destination file path.
+#: wp-admin/includes/file.php:1009
+msgid "The uploaded file could not be moved to %s."
+msgstr ""
+
+#: wp-admin/includes/file.php:1134
+msgid "Invalid URL Provided."
+msgstr ""
+
+#: wp-admin/includes/file.php:1145
+msgid "Could not create temporary file."
+msgstr ""
+
+#. translators: 1: File checksum, 2: Expected checksum value.
+#: wp-admin/includes/file.php:1343
+msgid "The checksum of the file (%1$s) does not match the expected checksum value (%2$s)."
+msgstr ""
+
+#. translators: %s: The filename of the package.
+#: wp-admin/includes/file.php:1372
+#: wp-admin/includes/file.php:1391
+#: wp-admin/includes/file.php:1426
+msgid "The authenticity of %s could not be verified as signature verification is unavailable on this system."
+msgstr ""
+
+#. translators: %s: The filename of the package.
+#: wp-admin/includes/file.php:1444
+msgid "The authenticity of %s could not be verified as no signature was found."
+msgstr ""
+
+#. translators: %s: The filename of the package.
+#: wp-admin/includes/file.php:1492
+msgid "The authenticity of %s could not be verified."
+msgstr ""
+
+#: wp-admin/includes/file.php:1645
+#: wp-admin/includes/file.php:1725
+msgid "Could not retrieve file from archive."
+msgstr ""
+
+#: wp-admin/includes/file.php:1744
+msgid "Could not extract file from archive."
+msgstr ""
+
+#: wp-admin/includes/file.php:1748
+#: wp-admin/includes/file.php:1878
+#: wp-admin/includes/file.php:1923
+#: wp-admin/includes/update-core.php:701
+msgid "Could not copy file."
+msgstr ""
+
+#: wp-admin/includes/file.php:1795
+msgid "Empty archive."
+msgstr ""
+
+#: wp-admin/includes/file.php:1906
+msgid "Directory listing failed."
+msgstr ""
+
+#: wp-admin/includes/file.php:1980
+msgid "The source and destination are the same."
+msgstr ""
+
+#: wp-admin/includes/file.php:1985
+msgid "The destination folder already exists."
+msgstr ""
+
+#: wp-admin/includes/file.php:1988
+msgid "The destination directory already exists and could not be removed."
+msgstr ""
+
+#: wp-admin/includes/file.php:2385
+msgid "<strong>Error:</strong> Could not connect to the server. Please verify the settings are correct."
+msgstr ""
+
+#: wp-admin/includes/file.php:2394
+msgid "FTP"
+msgstr ""
+
+#: wp-admin/includes/file.php:2397
+msgid "FTPS (SSL)"
+msgstr ""
+
+#: wp-admin/includes/file.php:2400
+msgid "SSH2"
+msgstr ""
+
+#: wp-admin/includes/file.php:2426
+msgid "Connection Information"
+msgstr ""
+
+#: wp-admin/includes/file.php:2432
+msgid "To perform the requested action, ClassicPress needs to access your web server."
+msgstr ""
+
+#: wp-admin/includes/file.php:2436
+msgid "Please enter your FTP or SSH credentials to proceed."
+msgstr ""
+
+#: wp-admin/includes/file.php:2437
+msgid "FTP/SSH Username"
+msgstr ""
+
+#: wp-admin/includes/file.php:2438
+msgid "FTP/SSH Password"
+msgstr ""
+
+#: wp-admin/includes/file.php:2440
+msgid "Please enter your FTP credentials to proceed."
+msgstr ""
+
+#: wp-admin/includes/file.php:2441
+msgid "FTP Username"
+msgstr ""
+
+#: wp-admin/includes/file.php:2442
+msgid "FTP Password"
+msgstr ""
+
+#: wp-admin/includes/file.php:2446
+msgid "If you do not remember your credentials, you should contact your web host."
+msgstr ""
+
+#: wp-admin/includes/file.php:2460
+msgid "Hostname"
+msgstr ""
+
+#: wp-admin/includes/file.php:2461
+msgid "example: www.wordpress.org"
+msgstr ""
+
+#: wp-admin/includes/file.php:2475
+msgid "This password will not be stored on the server."
+msgstr ""
+
+#: wp-admin/includes/file.php:2481
+msgid "Connection Type"
+msgstr ""
+
+#: wp-admin/includes/file.php:2502
+msgid "Authentication Keys"
+msgstr ""
+
+#: wp-admin/includes/file.php:2504
+msgid "Public Key:"
+msgstr ""
+
+#: wp-admin/includes/file.php:2508
+msgid "Private Key:"
+msgstr ""
+
+#: wp-admin/includes/file.php:2511
+msgid "Enter the location on the server where the public and private keys are located. If a passphrase is needed, enter that in the password field above."
+msgstr ""
+
+#: wp-admin/includes/file.php:2531
+msgid "Proceed"
+msgstr ""
+
+#. translators: %s: The function name.
+#: wp-admin/includes/file.php:2659
+msgid "%s expects a non-empty string."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:28
+#: wp-admin/includes/image-edit.php:928
+msgid "Image data does not exist. Please re-upload the image."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:62
+msgid "Crop"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:74
+msgid "Rotate left"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:75
+msgid "Rotate right"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:78
+msgid "Image rotation is not supported by your web host."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:84
+msgid "Flip vertical"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:85
+msgid "Flip horizontal"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:89
+msgid "Redo"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:114
+msgid "Scale Image"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:118
+msgid "Scale Image Help"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:122
+msgid "You can proportionally scale the original image. For best results, scaling should be done before you crop, flip, or rotate. Images can only be scaled down, not up."
+msgstr ""
+
+#. translators: %s: Image width and height in pixels.
+#: wp-admin/includes/image-edit.php:129
+msgid "Original dimensions %s"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:138
+msgid "New dimensions:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:143
+msgid "scale width"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:151
+msgid "scale height"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:156
+msgid "Scale"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:168
+msgid "Restore original image"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:172
+msgid "Discard any changes and restore the original image."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:175
+msgid "Previously edited copies of the image will not be deleted."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:180
+msgid "Restore image"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:190
+msgid "Image Crop"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:194
+msgid "Image Crop Help"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:199
+msgid "To crop the image, click on it and drag to make your selection."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:201
+msgid "Crop Aspect Ratio"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:202
+msgid "The aspect ratio is the relationship between the width and height. You can preserve the aspect ratio by holding down the shift key while resizing your selection. Use the input box to specify the aspect ratio, e.g. 1:1 (square), 4:3, 16:9, etc."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:204
+msgid "Crop Selection"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:205
+msgid "Once you have made your selection, you can adjust it by entering the size in pixels. The minimum selection size is the thumbnail size as set in the Media settings."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:210
+msgid "Aspect ratio:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:215
+msgid "crop ratio width"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:223
+msgid "crop ratio height"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:231
+msgid "Selection:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:236
+msgid "selection width"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:244
+msgid "selection height"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:260
+msgid "Thumbnail Settings"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/image-edit.php:264
+msgid "Thumbnail Settings Help"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:268
+msgid "You can edit the image while preserving the thumbnail. For example, you may wish to have a square thumbnail that displays just a section of the image."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:274
+msgid "Current thumbnail"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:279
+msgid "Apply changes to:"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:283
+msgid "All image sizes"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:293
+msgid "All sizes except thumbnail"
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:325
+msgid "There are unsaved changes that will be lost. 'OK' to continue, 'Cancel' to return to the Image Editor."
+msgstr ""
+
+#. translators: 1: $image, 2: WP_Image_Editor
+#: wp-admin/includes/image-edit.php:360
+#: wp-admin/includes/image-edit.php:449
+#: wp-admin/includes/image-edit.php:614
+msgid "%1$s needs to be a %2$s object."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:790
+msgid "Cannot load image metadata."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:850
+msgid "Cannot save image metadata."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:855
+msgid "Image metadata is inconsistent."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:857
+msgid "Image restored successfully."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:887
+msgid "Unable to create new image."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:911
+msgid "Error while saving the scaled image. Please reload the page and try again."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:920
+msgid "Nothing to save, the image has not changed."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:969
+msgid "Unable to save the image."
+msgstr ""
+
+#: wp-admin/includes/image-edit.php:1106
+msgid "Image saved"
+msgstr ""
+
+#: wp-admin/includes/image.php:167
+msgid "The attached file cannot be found."
+msgstr ""
+
+#: wp-admin/includes/import.php:186
+msgid "Blogger"
+msgstr ""
+
+#: wp-admin/includes/import.php:187
+msgid "Import posts, comments, and users from a Blogger blog."
+msgstr ""
+
+#: wp-admin/includes/import.php:192
+#: wp-admin/tools.php:48
+#: wp-admin/tools.php:73
+msgid "Categories and Tags Converter"
+msgstr ""
+
+#: wp-admin/includes/import.php:193
+msgid "Convert existing categories to tags or tags to categories, selectively."
+msgstr ""
+
+#: wp-admin/includes/import.php:198
+msgid "LiveJournal"
+msgstr ""
+
+#: wp-admin/includes/import.php:199
+msgid "Import posts from LiveJournal using their API."
+msgstr ""
+
+#: wp-admin/includes/import.php:204
+msgid "Movable Type and TypePad"
+msgstr ""
+
+#: wp-admin/includes/import.php:205
+msgid "Import posts and comments from a Movable Type or TypePad blog."
+msgstr ""
+
+#: wp-admin/includes/import.php:210
+msgid "Blogroll"
+msgstr ""
+
+#: wp-admin/includes/import.php:211
+msgid "Import links in OPML format."
+msgstr ""
+
+#: wp-admin/includes/import.php:216
+msgid "RSS"
+msgstr ""
+
+#: wp-admin/includes/import.php:217
+msgid "Import posts from an RSS feed."
+msgstr ""
+
+#: wp-admin/includes/import.php:222
+msgid "Tumblr"
+msgstr ""
+
+#: wp-admin/includes/import.php:223
+msgid "Import posts &amp; media from Tumblr using their API."
+msgstr ""
+
+#: wp-admin/includes/import.php:229
+msgid "Install the WordPress importer to import posts, pages, comments, custom fields, categories, and tags from a WordPress export file."
+msgstr ""
+
+#: wp-admin/includes/media.php:18
+msgid "From Computer"
+msgstr ""
+
+#: wp-admin/includes/media.php:19
+msgid "From URL"
+msgstr ""
+
+#: wp-admin/includes/media.php:20
+msgid "Gallery"
+msgstr ""
+
+#: wp-admin/includes/media.php:21
+#: wp-admin/upload.php:164
+#: wp-admin/upload.php:309
+msgid "Media Library"
+msgstr ""
+
+#. translators: %s: Number of attachments.
+#: wp-admin/includes/media.php:64
+msgid "Gallery (%s)"
+msgstr ""
+
+#. translators: 1: Audio track title, 2: Album title, 3: Artist name.
+#: wp-admin/includes/media.php:331
+msgid "\"%1$s\" from %2$s by %3$s."
+msgstr ""
+
+#. translators: 1: Audio track title, 2: Album title.
+#: wp-admin/includes/media.php:334
+msgid "\"%1$s\" from %2$s."
+msgstr ""
+
+#. translators: 1: Audio track title, 2: Artist name.
+#: wp-admin/includes/media.php:337
+msgid "\"%1$s\" by %2$s."
+msgstr ""
+
+#. translators: %s: Audio track title.
+#: wp-admin/includes/media.php:340
+msgid "\"%s\"."
+msgstr ""
+
+#. translators: 1: Audio album title, 2: Artist name.
+#: wp-admin/includes/media.php:346
+msgid "%1$s by %2$s."
+msgstr ""
+
+#. translators: Audio file track information. %d: Year of audio track release.
+#: wp-admin/includes/media.php:358
+msgid "Released: %d."
+msgstr ""
+
+#. translators: Audio file track information. 1: Audio track number, 2: Total audio tracks.
+#: wp-admin/includes/media.php:368
+msgid "Track %1$s of %2$s."
+msgstr ""
+
+#. translators: Audio file track information. %s: Audio track number.
+#: wp-admin/includes/media.php:375
+msgid "Track %s."
+msgstr ""
+
+#. translators: Audio file genre information. %s: Audio genre name.
+#: wp-admin/includes/media.php:384
+msgid "Genre: %s."
+msgstr ""
+
+#: wp-admin/includes/media.php:531
+msgid "Uploads"
+msgstr ""
+
+#: wp-admin/includes/media.php:652
+msgid "Add Media"
+msgstr ""
+
+#: wp-admin/includes/media.php:957
+msgid "Saved."
+msgstr ""
+
+#: wp-admin/includes/media.php:1036
+msgid "Invalid image URL."
+msgstr ""
+
+#: wp-admin/includes/media.php:1245
+msgid "Size"
+msgstr ""
+
+#: wp-admin/includes/media.php:1280
+#: wp-admin/includes/media.php:1416
+msgid "File URL"
+msgstr ""
+
+#: wp-admin/includes/media.php:1281
+msgid "Attachment Post URL"
+msgstr ""
+
+#: wp-admin/includes/media.php:1396
+#: wp-admin/includes/media.php:3181
+msgid "Caption"
+msgstr ""
+
+#: wp-admin/includes/media.php:1406
+msgid "Link URL"
+msgstr ""
+
+#: wp-admin/includes/media.php:1409
+#: wp-admin/includes/media.php:2929
+msgid "Enter a link URL or click above for presets."
+msgstr ""
+
+#: wp-admin/includes/media.php:1420
+msgid "Location of the uploaded file."
+msgstr ""
+
+#: wp-admin/includes/media.php:1476
+#: wp-admin/includes/media.php:2901
+#: wp-admin/includes/media.php:3158
+msgid "Alternative Text"
+msgstr ""
+
+#: wp-admin/includes/media.php:1477
+#: wp-admin/includes/media.php:2904
+msgid "Alt text for the image, e.g. &#8220;The Mona Lisa&#8221;"
+msgstr ""
+
+#: wp-admin/includes/media.php:1481
+#: wp-admin/includes/media.php:2908
+msgid "Alignment"
+msgstr ""
+
+#: wp-admin/includes/media.php:1554
+#: wp-admin/includes/media.php:2503
+#: wp-admin/js/user-profile.js:84
+msgid "Show"
+msgstr ""
+
+#: wp-admin/includes/media.php:1555
+#: wp-admin/includes/media.php:2504
+#: wp-admin/install.php:146
+#: wp-admin/user-edit.php:701
+#: wp-admin/user-new.php:596
+#: wp-admin/js/user-profile.js:84
+msgid "Hide"
+msgstr ""
+
+#: wp-admin/includes/media.php:1618
+#: wp-admin/includes/media.php:3069
+msgid "Edit Image"
+msgstr ""
+
+#: wp-admin/includes/media.php:1637
+#: wp-admin/includes/media.php:3292
+msgid "File type:"
+msgstr ""
+
+#: wp-admin/includes/media.php:1638
+msgid "Upload date:"
+msgstr ""
+
+#: wp-admin/includes/media.php:1641
+#: wp-admin/includes/media.php:3414
+msgid "Dimensions:"
+msgstr ""
+
+#: wp-admin/includes/media.php:1663
+#: wp-admin/includes/media.php:2934
+#: wp-admin/includes/media.php:2940
+msgid "Insert into Post"
+msgstr ""
+
+#. translators: %s: File name.
+#: wp-admin/includes/media.php:1674
+msgid "You are about to delete %s."
+msgstr ""
+
+#: wp-admin/includes/media.php:1675
+#: wp-admin/upgrade.php:75
+#: wp-admin/upgrade.php:155
+msgid "Continue"
+msgstr ""
+
+#. translators: %s: https://apps.wordpress.org
+#: wp-admin/includes/media.php:2033
+msgid "The web browser on your device cannot be used to upload files. You may be able to use the <a href=\"%s\">native app for your device</a> instead."
+msgstr ""
+
+#: wp-admin/includes/media.php:2177
+msgid "Drop files to upload"
+msgstr ""
+
+#: wp-admin/includes/media.php:2178
+msgctxt "Uploader: Drop files here - or - Select Files"
+msgid "or"
+msgstr ""
+
+#: wp-admin/includes/media.php:2179
+msgid "Select Files"
+msgstr ""
+
+#. translators: %s: Maximum allowed file size.
+#: wp-admin/includes/media.php:2228
+msgid "Maximum upload file size: %s."
+msgstr ""
+
+#: wp-admin/includes/media.php:2281
+msgid "Add media files from your computer"
+msgstr ""
+
+#: wp-admin/includes/media.php:2310
+#: wp-admin/includes/media.php:2527
+#: wp-admin/includes/media.php:2833
+msgid "Save all changes"
+msgstr ""
+
+#: wp-admin/includes/media.php:2348
+msgid "Insert media from another website"
+msgstr ""
+
+#: wp-admin/includes/media.php:2502
+msgid "All Tabs:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2506
+msgid "Sort Order:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2507
+#: wp-admin/includes/media.php:2584
+msgid "Ascending"
+msgstr ""
+
+#: wp-admin/includes/media.php:2508
+#: wp-admin/includes/media.php:2587
+msgid "Descending"
+msgstr ""
+
+#: wp-admin/includes/media.php:2509
+msgctxt "verb"
+msgid "Clear"
+msgstr ""
+
+#: wp-admin/includes/media.php:2517
+msgid "Actions"
+msgstr ""
+
+#: wp-admin/includes/media.php:2543
+msgid "Gallery Settings"
+msgstr ""
+
+#: wp-admin/includes/media.php:2548
+msgid "Link thumbnails to:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2553
+msgid "Image File"
+msgstr ""
+
+#: wp-admin/includes/media.php:2556
+msgid "Attachment Page"
+msgstr ""
+
+#: wp-admin/includes/media.php:2563
+msgid "Order images by:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2568
+msgid "Menu order"
+msgstr ""
+
+#: wp-admin/includes/media.php:2570
+msgid "Date/Time"
+msgstr ""
+
+#: wp-admin/includes/media.php:2571
+msgid "Random"
+msgstr ""
+
+#: wp-admin/includes/media.php:2579
+msgid "Order:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2594
+msgid "Gallery columns:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2614
+msgid "Insert gallery"
+msgstr ""
+
+#: wp-admin/includes/media.php:2615
+msgid "Update gallery settings"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/media.php:2677
+#: wp-admin/includes/media.php:2681
+msgid "Search Media"
+msgstr ""
+
+#: wp-admin/includes/media.php:2716
+msgid "All Types"
+msgstr ""
+
+#: wp-admin/includes/media.php:2758
+#: wp-admin/includes/nav-menu.php:462
+#: wp-admin/includes/nav-menu.php:764
+msgid "&laquo;"
+msgstr ""
+
+#: wp-admin/includes/media.php:2759
+#: wp-admin/includes/nav-menu.php:463
+#: wp-admin/includes/nav-menu.php:765
+msgid "&raquo;"
+msgstr ""
+
+#: wp-admin/includes/media.php:2808
+msgid "Filter &#187;"
+msgstr ""
+
+#: wp-admin/includes/media.php:2854
+msgid "Image Caption"
+msgstr ""
+
+#: wp-admin/includes/media.php:2877
+msgid "Image"
+msgstr ""
+
+#: wp-admin/includes/media.php:2877
+msgid "Audio, Video, or Other File"
+msgstr ""
+
+#: wp-admin/includes/media.php:2897
+msgid "Link text, e.g. &#8220;Ransom Demands (PDF)&#8221;"
+msgstr ""
+
+#: wp-admin/includes/media.php:2923
+msgid "Link Image To:"
+msgstr ""
+
+#: wp-admin/includes/media.php:2928
+msgid "Link to image"
+msgstr ""
+
+#. translators: 1: URL to browser uploader, 2: Additional link attributes.
+#: wp-admin/includes/media.php:2968
+msgid "You are using the multi-file uploader. Problems? Try the <a href=\"%1$s\" %2$s>browser uploader</a> instead."
+msgstr ""
+
+#: wp-admin/includes/media.php:2985
+msgid "You are using the browser&#8217;s built-in file uploader. The ClassicPress uploader includes multiple file selection and drag and drop capability. <a href=\"#\">Switch to the multi-file uploader</a>."
+msgstr ""
+
+#. translators: 1: Link start tag, 2: Link end tag, 3: Width, 4: Height.
+#: wp-admin/includes/media.php:3017
+msgid "Scale images to match the large size selected in %1$simage options%2$s (%3$d &times; %4$d)."
+msgstr ""
+
+#. translators: %s: Allowed space allocation.
+#: wp-admin/includes/media.php:3032
+msgid "Sorry, you have used your space allocation of %s. Please delete some files to upload more files."
+msgstr ""
+
+#. translators: 1: Link to tutorial, 2: Additional link attributes, 3: Accessibility text.
+#: wp-admin/includes/media.php:3166
+msgid "<a href=\"%1$s\" %2$s>Learn how to describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative."
+msgstr ""
+
+#: wp-admin/includes/media.php:3202
+msgid "Displayed on attachment pages."
+msgstr ""
+
+#: wp-admin/includes/media.php:3242
+msgid "(no author)"
+msgstr ""
+
+#: wp-admin/includes/media.php:3252
+#: wp-admin/includes/media.php:3254
+msgid "Uploaded by:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3267
+#: wp-admin/includes/media.php:3269
+msgid "Uploaded to:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3278
+msgid "File URL:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3325
+msgid "File size:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3332
+msgid "Length:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3333
+msgid "Bitrate:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3380
+msgid "Audio Format:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3381
+msgid "Audio Codec:"
+msgstr ""
+
+#: wp-admin/includes/media.php:3422
+msgid "Original image:"
+msgstr ""
+
+#: wp-admin/includes/menu.php:364
+msgid "Sorry, you are not allowed to access this page."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:59
+#: wp-admin/js/post.js:857
+msgid "Save as Pending"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:71
+msgid "Preview Changes"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:109
+#: wp-admin/includes/meta-boxes.php:154
+#: wp-admin/js/post.js:823
+#: wp-admin/js/post.js:825
+msgid "Privately Published"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:138
+msgid "Edit status"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:147
+msgid "Set status"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:165
+#: wp-admin/includes/meta-boxes.php:223
+#: wp-admin/includes/template.php:893
+#: wp-admin/js/post.js:1027
+msgid "OK"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:174
+msgid "Visibility:"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:183
+#: wp-admin/includes/meta-boxes.php:217
+msgid "Password protected"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:186
+#: wp-admin/js/post.js:903
+msgid "Public, Sticky"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:189
+#: wp-admin/includes/meta-boxes.php:211
+#: wp-admin/js/post.js:903
+msgid "Public"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:200
+msgid "Edit visibility"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:214
+msgid "Stick this post to the front page"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:218
+msgid "Password:"
+msgstr ""
+
+#. translators: Post date information. %s: Date on which the post is currently scheduled to be published.
+#: wp-admin/includes/meta-boxes.php:241
+msgid "Scheduled for: %s"
+msgstr ""
+
+#. translators: Post date information. %s: Date on which the post was published.
+#: wp-admin/includes/meta-boxes.php:244
+msgid "Published on: %s"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:246
+#: wp-admin/includes/meta-boxes.php:260
+msgid "Publish <b>immediately</b>"
+msgstr ""
+
+#. translators: Post date information. %s: Date on which the post is to be published.
+#: wp-admin/includes/meta-boxes.php:249
+msgid "Schedule for: %s"
+msgstr ""
+
+#. translators: Post date information. %s: Date on which the post is to be published.
+#: wp-admin/includes/meta-boxes.php:252
+msgid "Publish on: %s"
+msgstr ""
+
+#. translators: Post revisions heading. %s: The number of available revisions.
+#: wp-admin/includes/meta-boxes.php:273
+msgid "Revisions: %s"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:275
+msgctxt "revisions"
+msgid "Browse"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:278
+msgid "Browse revisions"
+msgstr ""
+
+#. translators: %s: URL to the Customizer.
+#: wp-admin/includes/meta-boxes.php:320
+msgid "This draft comes from your <a href=\"%s\">unpublished customization changes</a>. You can edit, but there is no need to publish now. It will be published automatically with those changes."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:384
+#: wp-admin/includes/meta-boxes.php:385
+#: wp-admin/js/post.js:792
+msgctxt "post action/button label"
+msgid "Schedule"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:395
+#: wp-admin/includes/meta-boxes.php:396
+msgid "Submit for Review"
+msgstr ""
+
+#. translators: Attachment information. %s: Date the attachment was uploaded.
+#: wp-admin/includes/meta-boxes.php:446
+msgid "Uploaded on: %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:528
+#: wp-admin/includes/theme.php:329
+msgid "Post Formats"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:609
+#: wp-admin/includes/meta-boxes.php:1222
+msgid "Add"
+msgstr ""
+
+#. translators: %s: Add New taxonomy label.
+#: wp-admin/includes/meta-boxes.php:691
+msgid "+ %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:760
+#: wp-admin/includes/meta-boxes.php:1652
+#: wp-admin/options-reading.php:177
+msgid "Excerpt"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/meta-boxes.php:767
+msgid "Excerpts are optional hand-crafted summaries of your content that can be used in your theme. <a href=\"%s\">Learn more about manual excerpts</a>."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:768
+msgid "https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:787
+msgid "Already pinged:"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:797
+msgid "Send trackbacks to:"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:800
+msgid "Separate multiple URLs with spaces"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/meta-boxes.php:805
+msgid "Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. If you link other ClassicPress sites, they&#8217;ll be notified automatically using <a href=\"%s\">pingbacks</a>, no other action necessary."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:806
+msgid "https://wordpress.org/documentation/article/introduction-to-blogging/#comments"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/meta-boxes.php:842
+msgid "Custom fields can be used to add extra metadata to a post that you can <a href=\"%s\">use in your theme</a>."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:843
+msgid "https://wordpress.org/documentation/article/assign-custom-fields/"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:861
+msgid "Allow comments"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/meta-boxes.php:866
+msgid "Allow <a href=\"%s\">trackbacks and pingbacks</a>"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:867
+msgid "https://wordpress.org/documentation/article/introduction-to-blogging/#managing-comments"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:908
+#: wp-admin/includes/template.php:506
+msgid "Add Comment"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:922
+msgid "No comments yet."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:932
+msgid "Show comments"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1020
+msgid "(no parent)"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1093
+msgid "Need help? Use the Help tab above the screen title."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1124
+msgid "Visit Link"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1132
+msgid "Keep this link private"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1190
+msgid "All categories"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1191
+msgctxt "categories"
+msgid "Most Used"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/meta-boxes.php:1213
+#: wp-admin/includes/meta-boxes.php:1218
+msgid "+ Add New Category"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1221
+msgid "New category name"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1249
+msgid "<code>_blank</code> &mdash; new window or tab."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1252
+msgid "<code>_top</code> &mdash; current window or tab, with no frames."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1255
+msgid "<code>_none</code> &mdash; same window or tab."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1257
+msgid "Choose the target frame for your link."
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1331
+msgid "rel:"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1335
+#: wp-admin/includes/meta-boxes.php:1340
+msgid "identity"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1345
+msgid "another web address of mine"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1349
+#: wp-admin/includes/meta-boxes.php:1354
+msgid "friendship"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1358
+msgid "contact"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1361
+msgid "acquaintance"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1364
+msgid "friend"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1367
+#: wp-admin/includes/meta-boxes.php:1418
+#: wp-admin/includes/meta-boxes.php:1447
+msgid "none"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1372
+#: wp-admin/includes/meta-boxes.php:1377
+msgid "physical"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1381
+msgid "met"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1386
+#: wp-admin/includes/meta-boxes.php:1391
+msgid "professional"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1395
+msgid "co-worker"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1398
+msgid "colleague"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1403
+#: wp-admin/includes/meta-boxes.php:1408
+msgid "geographical"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1412
+msgid "co-resident"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1415
+msgid "neighbor"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1423
+#: wp-admin/includes/meta-boxes.php:1428
+msgid "family"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1432
+#: wp-admin/nav-menus.php:530
+msgid "child"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1435
+msgid "kin"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1438
+msgid "parent"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1441
+msgid "sibling"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1444
+msgid "spouse"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1452
+#: wp-admin/includes/meta-boxes.php:1457
+msgid "romantic"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1461
+msgid "muse"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1464
+msgid "crush"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1467
+msgid "date"
+msgstr ""
+
+#. translators: xfn: https://gmpg.org/xfn
+#: wp-admin/includes/meta-boxes.php:1470
+msgid "sweetheart"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1476
+msgid "If the link is to a person, you can specify your relationship with them using the above form. If you would like to learn more about the idea check out <a href=\"https://gmpg.org/xfn/\">XFN</a>."
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1491
+msgid "Image Address"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1495
+msgid "RSS Address"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1499
+msgid "Notes"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1514
+msgid "(Leave at 0 for no rating.)"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1593
+#: wp-admin/revision.php:112
+msgid "Revisions"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1604
+msgid "Metadata"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1656
+msgid "Send Trackbacks"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1662
+msgid "Custom Fields"
+msgstr ""
+
+#: wp-admin/includes/meta-boxes.php:1686
+#: wp-admin/menu.php:339
+msgid "Discussion"
+msgstr ""
+
+#: wp-admin/includes/misc.php:42
+msgid "commit %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/misc.php:468
+#: wp-admin/includes/misc.php:570
+msgid "folder"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/misc.php:1076
+#: wp-admin/user-edit.php:321
+msgid "Admin Color Scheme"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/misc.php:1258
+msgid "%s has taken over and is currently editing."
+msgstr ""
+
+#: wp-admin/includes/misc.php:1380
+#: wp-admin/includes/post.php:2031
+#: wp-admin/widgets-form.php:366
+msgid "Error while saving."
+msgstr ""
+
+#. translators: Draft saved date format, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/includes/misc.php:1384
+msgid "g:i:s a"
+msgstr ""
+
+#. translators: %s: Date and time.
+#: wp-admin/includes/misc.php:1388
+msgid "Draft saved at %s."
+msgstr ""
+
+#. translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders.
+#: wp-admin/includes/misc.php:1491
+msgid ""
+"Hello ###USERNAME###,\n"
+"\n"
+"Someone with administrator capabilities recently requested to have the\n"
+"administration email address changed on this site:\n"
+"###SITEURL###\n"
+"\n"
+"To confirm this change, please click on the following link:\n"
+"###ADMIN_URL###\n"
+"\n"
+"You can safely ignore and delete this email if you do not want to\n"
+"take this action.\n"
+"\n"
+"This email has been sent to ###EMAIL###\n"
+"\n"
+"Regards,\n"
+"All at ###SITENAME###\n"
+"###SITEURL###"
+msgstr ""
+
+#. translators: New admin email address notification email subject. %s: Site title.
+#: wp-admin/includes/misc.php:1551
+msgid "[%s] New Admin Email Address"
+msgstr ""
+
+#. translators: %s: Page title.
+#: wp-admin/includes/misc.php:1576
+msgid "%s (Draft)"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:148
+msgid "Custom Links"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:305
+msgid "Link Text"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:311
+#: wp-admin/includes/nav-menu.php:682
+#: wp-admin/includes/nav-menu.php:919
+msgid "Add to Menu"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:392
+msgctxt "nav menu home label"
+msgid "Home"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:442
+#: wp-admin/includes/nav-menu.php:737
+msgid "No items."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/nav-menu.php:465
+#: wp-admin/includes/nav-menu.php:767
+msgid "Page"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:513
+#: wp-admin/includes/nav-menu.php:528
+msgid "Most Recent"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:518
+#: wp-admin/includes/nav-menu.php:820
+msgid "View All"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:606
+#: wp-admin/includes/nav-menu.php:907
+#: wp-admin/js/nav-menu.js:496
+msgid "No results found."
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1056
+msgid "Add menu items from the column on the left."
+msgstr ""
+
+#. translators: %s: Walker class name.
+#: wp-admin/includes/nav-menu.php:1080
+msgid "The Walker class named %s does not exist."
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1098
+msgid "Click Save Menu to make pending menu items public."
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1102
+msgid "There are some invalid menu items. Please check or delete them."
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1123
+msgid "Show advanced menu properties"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1125
+msgid "Link Target"
+msgstr ""
+
+#: wp-admin/includes/nav-menu.php:1127
+msgid "CSS Classes"
+msgstr ""
+
+#. translators: %s: Nav menu title.
+#: wp-admin/includes/nav-menu.php:1263
+msgid "%s has been updated."
+msgstr ""
+
+#. translators: %s: DO_NOT_UPGRADE_GLOBAL_TABLES
+#: wp-admin/includes/network.php:118
+msgid "The constant %s cannot be defined when creating a network."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/network.php:128
+#: wp-admin/includes/network.php:142
+#: wp-admin/includes/network.php:199
+#: wp-admin/includes/network.php:259
+#: wp-admin/includes/network.php:308
+#: wp-admin/includes/network.php:321
+#: wp-admin/includes/network.php:423
+#: wp-admin/includes/network.php:621
+#: wp-admin/includes/network.php:683
+#: wp-admin/includes/template.php:1287
+#: wp-admin/options.php:366
+msgid "Warning:"
+msgstr ""
+
+#. translators: %s: URL to Plugins screen.
+#: wp-admin/includes/network.php:130
+msgid "Please <a href=\"%s\">deactivate your plugins</a> before enabling the Network feature."
+msgstr ""
+
+#: wp-admin/includes/network.php:133
+msgid "Once the network is created, you may reactivate your plugins."
+msgstr ""
+
+#: wp-admin/includes/network.php:142
+msgid "Installing a network of sites with your server address is experimental."
+msgstr ""
+
+#. translators: %s: Port number.
+#: wp-admin/includes/network.php:145
+msgid "Use port numbers such as %s at your own risk."
+msgstr ""
+
+#: wp-admin/includes/network.php:156
+msgid "Error: The network could not be created."
+msgstr ""
+
+#. translators: %s: Default network title.
+#: wp-admin/includes/network.php:168
+msgid "%s Sites"
+msgstr ""
+
+#: wp-admin/includes/network.php:177
+msgid "Welcome to the Network installation process!"
+msgstr ""
+
+#: wp-admin/includes/network.php:178
+msgid "Fill in the information below and you&#8217;ll be on your way to creating a network of ClassicPress sites. Configuration files will be created in the next step."
+msgstr ""
+
+#: wp-admin/includes/network.php:191
+msgid "Note:"
+msgstr ""
+
+#. translators: %s: mod_rewrite
+#: wp-admin/includes/network.php:194
+msgid "Please make sure the Apache %s module is installed as it will be used at the end of this installation."
+msgstr ""
+
+#. translators: %s: mod_rewrite
+#: wp-admin/includes/network.php:202
+msgid "It looks like the Apache %s module is not installed."
+msgstr ""
+
+#. translators: 1: mod_rewrite, 2: mod_rewrite documentation URL, 3: Google search for mod_rewrite.
+#: wp-admin/includes/network.php:212
+msgid "If %1$s is disabled, ask your administrator to enable that module, or look at the <a href=\"%2$s\">Apache documentation</a> or <a href=\"%3$s\">elsewhere</a> for help setting it up."
+msgstr ""
+
+#: wp-admin/includes/network.php:223
+msgid "Addresses of Sites in your Network"
+msgstr ""
+
+#: wp-admin/includes/network.php:224
+msgid "Please choose whether you would like sites in your ClassicPress network to use sub-domains or sub-directories."
+msgstr ""
+
+#: wp-admin/includes/network.php:225
+msgid "You cannot change this later."
+msgstr ""
+
+#: wp-admin/includes/network.php:226
+msgid "You will need a wildcard DNS record if you are going to use the virtual host (sub-domain) functionality."
+msgstr ""
+
+#: wp-admin/includes/network.php:230
+msgid "Sub-domains"
+msgstr ""
+
+#. translators: 1: Host name.
+#: wp-admin/includes/network.php:235
+msgctxt "subdomain examples"
+msgid "like <code>site1.%1$s</code> and <code>site2.%1$s</code>"
+msgstr ""
+
+#: wp-admin/includes/network.php:242
+msgid "Sub-directories"
+msgstr ""
+
+#. translators: 1: Host name.
+#: wp-admin/includes/network.php:247
+msgctxt "subdirectory examples"
+msgid "like <code>%1$s/site1</code> and <code>%1$s/site2</code>"
+msgstr ""
+
+#: wp-admin/includes/network.php:259
+#: wp-admin/includes/network.php:621
+#: wp-admin/includes/network.php:683
+msgid "Subdirectory networks may not be fully compatible with custom wp-content directories."
+msgstr ""
+
+#: wp-admin/includes/network.php:265
+#: wp-admin/includes/network.php:279
+#: wp-admin/includes/network.php:339
+msgid "Server Address"
+msgstr ""
+
+#. translators: 1: Site URL, 2: Host name, 3: www.
+#: wp-admin/includes/network.php:270
+msgid "You should consider changing your site domain to %1$s before enabling the network feature. It will still be possible to visit your site using the %3$s prefix with an address like %2$s but any links will not have the %3$s prefix."
+msgstr ""
+
+#. translators: %s: Host name.
+#: wp-admin/includes/network.php:284
+#: wp-admin/includes/network.php:344
+msgid "The internet address of your network will be %s."
+msgstr ""
+
+#: wp-admin/includes/network.php:293
+msgid "Network Details"
+msgstr ""
+
+#: wp-admin/includes/network.php:297
+#: wp-admin/includes/network.php:315
+msgid "Sub-directory Installation"
+msgstr ""
+
+#. translators: 1: localhost, 2: localhost.localdomain
+#: wp-admin/includes/network.php:302
+msgid "Because you are using %1$s, the sites in your ClassicPress network must use sub-directories. Consider using %2$s if you wish to use sub-domains."
+msgstr ""
+
+#: wp-admin/includes/network.php:308
+#: wp-admin/includes/network.php:321
+#: wp-admin/includes/network.php:332
+msgid "The main site in a sub-directory installation will need to use a modified permalink structure, potentially breaking existing links."
+msgstr ""
+
+#: wp-admin/includes/network.php:318
+msgid "Because your installation is in a directory, the sites in your ClassicPress network must use sub-directories."
+msgstr ""
+
+#: wp-admin/includes/network.php:328
+msgid "Sub-domain Installation"
+msgstr ""
+
+#: wp-admin/includes/network.php:331
+msgid "Because your installation is not new, the sites in your ClassicPress network must use sub-domains."
+msgstr ""
+
+#: wp-admin/includes/network.php:352
+msgid "Network Title"
+msgstr ""
+
+#: wp-admin/includes/network.php:356
+msgid "What would you like to call your network?"
+msgstr ""
+
+#: wp-admin/includes/network.php:361
+msgid "Network Admin Email"
+msgstr ""
+
+#: wp-admin/includes/network.php:365
+msgid "Your email address."
+msgstr ""
+
+#: wp-admin/includes/network.php:418
+msgid "The original configuration steps are shown here for reference."
+msgstr ""
+
+#: wp-admin/includes/network.php:423
+msgid "An existing ClassicPress network was detected."
+msgstr ""
+
+#: wp-admin/includes/network.php:424
+msgid "Please complete the configuration steps. To create a new network, you will need to empty or remove the network database tables."
+msgstr ""
+
+#: wp-admin/includes/network.php:435
+msgid "Enabling the Network"
+msgstr ""
+
+#: wp-admin/includes/network.php:436
+msgid "Complete the following steps to enable the features for creating a network of sites."
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: .htaccess
+#. translators: 1: wp-config.php, 2: web.config
+#: wp-admin/includes/network.php:443
+#: wp-admin/includes/network.php:451
+msgid "You should back up your existing %1$s and %2$s files."
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/includes/network.php:459
+msgid "You should back up your existing %s file."
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: Location of wp-config file, 3: Translated version of "That's all, stop editing! Happy publishing."
+#: wp-admin/includes/network.php:473
+msgid "Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:"
+msgstr ""
+
+#. translators: This string should only be translated if wp-config-sample.php is localized. You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
+#: wp-admin/includes/network.php:481
+msgid "That&#8217;s all, stop editing! Happy publishing."
+msgstr ""
+
+#. translators: %s: File name (wp-config.php, .htaccess or web.config).
+#: wp-admin/includes/network.php:489
+#: wp-admin/includes/network.php:628
+#: wp-admin/includes/network.php:690
+msgid "Network configuration rules for %s"
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/includes/network.php:539
+msgid "This unique authentication key is also missing from your %s file."
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/includes/network.php:545
+msgid "These unique authentication keys are also missing from your %s file."
+msgstr ""
+
+#: wp-admin/includes/network.php:550
+msgid "To make your installation more secure, you should also add:"
+msgstr ""
+
+#: wp-admin/includes/network.php:552
+msgid "Network configuration authentication keys"
+msgstr ""
+
+#. translators: 1: File name (.htaccess or web.config), 2: File path.
+#: wp-admin/includes/network.php:615
+#: wp-admin/includes/network.php:677
+msgid "Add the following to your %1$s file in %2$s, <strong>replacing</strong> other ClassicPress rules:"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/includes/network.php:643
+msgid "It seems your network is running with Nginx web server. <a href=\"%s\">Learn more about further configuration</a>."
+msgstr ""
+
+#: wp-admin/includes/network.php:644
+msgid "https://wordpress.org/documentation/article/nginx/"
+msgstr ""
+
+#: wp-admin/includes/network.php:704
+msgid "Once you complete these steps, your network is enabled and configured. You will have to log in again."
+msgstr ""
+
+#: wp-admin/includes/network.php:704
+#: wp-admin/install.php:227
+#: wp-admin/install.php:448
+msgid "Log In"
+msgstr ""
+
+#: wp-admin/includes/options.php:135
+msgid "The <a href=\"https://wordpress.org/documentation/article/wordpress-glossary/#character-set\">character encoding</a> of your site (UTF-8 is recommended)"
+msgstr ""
+
+#. translators: %s: Support forums URL.
+#. translators: %s: support forums URL
+#: wp-admin/includes/plugin-install.php:169
+#: wp-admin/includes/plugin-install.php:185
+#: wp-admin/includes/theme.php:550
+#: wp-admin/includes/theme.php:565
+#: wp-admin/includes/translation-install.php:69
+#: wp-admin/includes/translation-install.php:84
+#: wp-admin/includes/translation-install.php:96
+msgid "An unexpected error occurred. Something may be wrong with WordPress.org, ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:170
+#: wp-admin/includes/translation-install.php:70
+#: wp-admin/includes/update-core.php:1042
+#: wp-admin/includes/update.php:138
+msgid "https://forums.classicpress.net/c/support"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:171
+msgid "(ClassicPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:248
+msgid "Popular tags"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:249
+msgid "You may also browse based on the most popular tags in the Plugin Directory:"
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/plugin-install.php:275
+msgid "%s plugin"
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/plugin-install.php:277
+msgid "%s plugins"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/plugin-install.php:301
+msgid "Search plugins by:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:305
+#: wp-admin/includes/theme-install.php:108
+msgid "Keyword"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:307
+msgctxt "Plugin Installer"
+msgid "Tag"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/plugin-install.php:312
+#: wp-admin/includes/plugin-install.php:316
+msgid "Search Plugins"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:315
+msgid "Search plugins..."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:329
+msgid "If you have a plugin in a .zip format, you may install or update it by uploading it here."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/plugin-install.php:335
+msgid "Plugin zip file"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:354
+msgid "If you have marked plugins as favorites on ClassicPress.net, you can browse them here."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:358
+msgid "Your ClassicPress.net username:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:360
+msgid "Get Favorites"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:375
+msgid "Forms"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:376
+#: wp-admin/widgets.php:28
+msgid "Widgets"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:377
+msgid "Admin Utilities"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:378
+msgid "Page Builders"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:379
+msgid "eCommerce"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:381
+msgid "SEO"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:382
+msgid "Advertising"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:383
+msgid "Social Networking"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/plugin-install.php:384
+#: wp-admin/options-general.php:337
+#: wp-admin/options-general.php:341
+msgid "Membership"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:385
+msgid "Newsletters"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:386
+msgid "Forums"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:390
+msgid "These are some of the most common types of plugins. Not all categories are represented here."
+msgstr ""
+
+#. translators: %s: URL to "Features as Plugins" page.
+#: wp-admin/includes/plugin-install.php:424
+msgid "You are using a development version of ClassicPress. These feature plugins are also under development. <a href=\"%s\">Learn more</a>."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:429
+msgid "These suggestions are based on the plugins you and other users have installed."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:600
+msgctxt "Plugin installer section title"
+msgid "Description"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:601
+msgctxt "Plugin installer section title"
+msgid "Installation"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:602
+msgctxt "Plugin installer section title"
+msgid "FAQ"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:603
+msgctxt "Plugin installer section title"
+msgid "Screenshots"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:604
+msgctxt "Plugin installer section title"
+msgid "Changelog"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:605
+msgctxt "Plugin installer section title"
+msgid "Reviews"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:606
+msgctxt "Plugin installer section title"
+msgid "Other Notes"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:629
+#: wp-admin/update.php:152
+msgid "Plugin Installation"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:687
+msgid "Author:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:697
+msgid "Requires WordPress Version:"
+msgstr ""
+
+#. translators: %s: Version number.
+#: wp-admin/includes/plugin-install.php:700
+#: wp-admin/includes/plugin-install.php:710
+msgid "%s or higher"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:704
+msgid "Compatible Up to WordPress Version:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:707
+msgid "Requires PHP Version:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:714
+msgid "Active Installations:"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:731
+msgid "WordPress.org Plugin Page &#187;"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:733
+msgid "Plugin Homepage &#187;"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:735
+#: wp-admin/includes/plugin-install.php:822
+msgid "Donate to this plugin &#187;"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:739
+msgid "Average Rating"
+msgstr ""
+
+#. translators: %s: Number of ratings.
+#: wp-admin/includes/plugin-install.php:753
+msgid "(based on %s rating)"
+msgid_plural "(based on %s ratings)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/plugin-install.php:763
+msgid "Reviews"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:764
+msgid "Read all reviews on WordPress.org or write your own!"
+msgstr ""
+
+#. translators: 1: Number of stars (used to determine singular/plural), 2: Number of reviews.
+#: wp-admin/includes/plugin-install.php:772
+msgid "Reviews with %1$d star: %2$s. Opens in a new tab."
+msgid_plural "Reviews with %1$d stars: %2$s. Opens in a new tab."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of stars.
+#: wp-admin/includes/plugin-install.php:790
+msgid "%d star"
+msgid_plural "%d stars"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/plugin-install.php:804
+msgid "Contributors"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:837
+msgid "<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>."
+msgstr ""
+
+#. translators: %s: URL to Update PHP page.
+#: wp-admin/includes/plugin-install.php:841
+msgid "<a href=\"%s\" target=\"_blank\">Click here to learn more about updating PHP</a>."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:854
+msgid "<strong>Warning:</strong> This plugin <strong>has not been tested</strong> with your current version of ClassicPress."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:858
+msgid "<strong>Error:</strong> This plugin <strong>requires a newer version of ClassicPress</strong>."
+msgstr ""
+
+#. translators: %s: URL to WordPress Updates screen.
+#: wp-admin/includes/plugin-install.php:862
+msgid "<a href=\"%s\" target=\"_parent\">Click here to update ClassicPress</a>."
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:903
+msgid "Install Update Now"
+msgstr ""
+
+#. translators: %s: Plugin version.
+#: wp-admin/includes/plugin-install.php:914
+msgid "Newer Version (%s) Installed"
+msgstr ""
+
+#: wp-admin/includes/plugin-install.php:917
+msgid "Latest Version Installed"
+msgstr ""
+
+#. translators: 1: Site Wide Only: true, 2: Network: true
+#: wp-admin/includes/plugin.php:100
+msgid "The %1$s plugin header is deprecated. Use %2$s instead."
+msgstr ""
+
+#. translators: %s: Plugin author.
+#: wp-admin/includes/plugin.php:222
+msgid "By %s."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:502
+msgid "Advanced caching plugin."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:503
+msgid "Custom database class."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:504
+msgid "Custom database error message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:505
+msgid "Custom installation script."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:506
+msgid "Custom maintenance message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:507
+msgid "External object cache."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:508
+msgid "Custom PHP error message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:509
+msgid "Custom PHP fatal error handler."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:513
+msgid "Executed before Multisite is loaded."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:514
+msgid "Custom site deleted message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:515
+msgid "Custom site inactive message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:516
+msgid "Custom site suspended message."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:735
+msgid "The plugin generated unexpected output."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:886
+msgid "One of the plugins is invalid."
+msgstr ""
+
+#. translators: %s: Plugin filename.
+#: wp-admin/includes/plugin.php:1045
+msgid "Could not fully remove the plugin %s."
+msgstr ""
+
+#. translators: %s: Comma-separated list of plugin filenames.
+#: wp-admin/includes/plugin.php:1048
+msgid "Could not fully remove the plugins %s."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:1108
+msgid "Invalid plugin path."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:1111
+msgid "Plugin file does not exist."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:1116
+msgid "The plugin does not have a valid header."
+msgstr ""
+
+#. translators: 1: Current WordPress version, 2: Current PHP version, 3: Plugin name, 4: Required WordPress version, 5: Required PHP version.
+#: wp-admin/includes/plugin.php:1163
+msgctxt "plugin"
+msgid "<strong>Error:</strong> Current versions of ClassicPress (%1$s) and PHP (%2$s) do not meet minimum requirements for %3$s. The plugin requires WordPress %4$s and PHP %5$s."
+msgstr ""
+
+#. translators: 1: Current PHP version, 2: Plugin name, 3: Required PHP version.
+#: wp-admin/includes/plugin.php:1176
+msgctxt "plugin"
+msgid "<strong>Error:</strong> Current PHP version (%1$s) does not meet minimum requirements for %2$s. The plugin requires PHP %3$s."
+msgstr ""
+
+#. translators: 1: Current WordPress version, 2: Plugin name, 3: Required WordPress version.
+#: wp-admin/includes/plugin.php:1187
+msgctxt "plugin"
+msgid "<strong>Error:</strong> Current ClassicPress version (%1$s) does not meet minimum requirements for %2$s. The plugin requires WordPress %3$s."
+msgstr ""
+
+#. translators: %s: add_menu_page()
+#. translators: %s: add_submenu_page()
+#: wp-admin/includes/plugin.php:1345
+#: wp-admin/includes/plugin.php:1449
+msgid "The seventh parameter passed to %s should be numeric representing menu position."
+msgstr ""
+
+#. translators: %s: admin_init
+#: wp-admin/includes/plugin.php:2361
+msgid "The suggested privacy policy content should be added only in wp-admin by using the %s (or later) action."
+msgstr ""
+
+#. translators: %s: admin_init
+#: wp-admin/includes/plugin.php:2372
+msgid "The suggested privacy policy content should be added by using the %s (or later) action. Please see the inline documentation."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:2481
+msgid "Could not resume the plugin."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:2510
+msgid "One or more plugins failed to load properly."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:2511
+msgid "You can find more details and make changes on the Plugins screen."
+msgstr ""
+
+#: wp-admin/includes/plugin.php:2513
+#: wp-admin/includes/plugin.php:2591
+msgid "Go to the Plugins screen"
+msgstr ""
+
+#. translators: 1: Name of deactivated plugin, 2: Plugin version deactivated, 3: Current WP version, 4: Compatible plugin version.
+#: wp-admin/includes/plugin.php:2565
+msgid "%1$s %2$s was deactivated due to incompatibility with ClassicPress %3$s, please upgrade to %1$s %4$s or later."
+msgstr ""
+
+#. translators: 1: Name of deactivated plugin, 2: Plugin version deactivated, 3: Current WP version.
+#: wp-admin/includes/plugin.php:2574
+msgid "%1$s %2$s was deactivated due to incompatibility with ClassicPress %3$s."
+msgstr ""
+
+#. translators: %s: Name of deactivated plugin.
+#: wp-admin/includes/plugin.php:2586
+msgid "%s plugin deactivated during ClassicPress upgrade."
+msgstr ""
+
+#: wp-admin/includes/post.php:35
+#: wp-admin/includes/post.php:80
+msgid "Sorry, you are not allowed to edit pages as this user."
+msgstr ""
+
+#: wp-admin/includes/post.php:37
+#: wp-admin/includes/post.php:82
+msgid "Sorry, you are not allowed to edit posts as this user."
+msgstr ""
+
+#: wp-admin/includes/post.php:41
+#: wp-admin/includes/post.php:86
+msgid "Sorry, you are not allowed to create pages as this user."
+msgstr ""
+
+#: wp-admin/includes/post.php:43
+#: wp-admin/includes/post.php:88
+#: wp-admin/post-new.php:61
+#: wp-admin/press-this.php:20
+msgid "Sorry, you are not allowed to create posts as this user."
+msgstr ""
+
+#: wp-admin/includes/post.php:191
+msgid "Invalid date."
+msgstr ""
+
+#: wp-admin/includes/post.php:499
+msgid "Sorry, you are not allowed to edit pages."
+msgstr ""
+
+#: wp-admin/includes/post.php:501
+msgid "Sorry, you are not allowed to edit posts."
+msgstr ""
+
+#: wp-admin/includes/post.php:715
+msgid "Auto Draft"
+msgstr ""
+
+#: wp-admin/includes/post.php:865
+msgid "Sorry, you are not allowed to create pages on this site."
+msgstr ""
+
+#: wp-admin/includes/post.php:867
+msgid "Sorry, you are not allowed to create posts or drafts on this site."
+msgstr ""
+
+#: wp-admin/includes/post.php:1520
+#: wp-admin/includes/post.php:1545
+msgid "Permalink:"
+msgstr ""
+
+#: wp-admin/includes/post.php:1533
+msgid "Change Permalink Structure"
+msgstr ""
+
+#: wp-admin/includes/post.php:1548
+msgid "Edit permalink"
+msgstr ""
+
+#: wp-admin/includes/post.php:1622
+msgid "Click the image to edit or update"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/post.php:1815
+msgid "%s is currently editing this post. Do you want to take over?"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/post.php:1818
+msgid "%s is currently editing this post."
+msgstr ""
+
+#: wp-admin/includes/post.php:1844
+msgid "Take over"
+msgstr ""
+
+#: wp-admin/includes/post.php:1858
+msgid "Saving revision&hellip;"
+msgstr ""
+
+#: wp-admin/includes/post.php:1859
+msgid "Your latest changes were saved as a revision."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:23
+#: wp-admin/includes/privacy-tools.php:52
+msgid "Invalid personal data request."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:31
+msgid "Unable to initiate confirmation for personal data request."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:91
+msgid "Confirmation request sent again successfully."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:107
+#: wp-admin/includes/privacy-tools.php:124
+msgid "Invalid personal data action."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:135
+msgid "Unable to add this request. A valid email address or username must be supplied."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:155
+msgid "Unable to initiate confirmation request."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:171
+msgid "Confirmation request initiated successfully."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:173
+msgid "Request added successfully."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:294
+msgid "Go to top"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:312
+msgid "Unable to generate personal data export file. ZipArchive not available."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:319
+msgid "Invalid request ID when generating personal data export file."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:325
+msgid "Invalid email address when generating personal data export file."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:333
+msgid "Unable to create personal data export folder."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:341
+msgid "Unable to protect personal data export folder from browsing."
+msgstr ""
+
+#. translators: %s: User's email address.
+#: wp-admin/includes/privacy-tools.php:361
+msgid "Personal Data Export for %s"
+msgstr ""
+
+#. translators: Header for the About section in a personal data export.
+#: wp-admin/includes/privacy-tools.php:368
+msgctxt "personal data group label"
+msgid "About"
+msgstr ""
+
+#. translators: Description for the About section in a personal data export.
+#: wp-admin/includes/privacy-tools.php:370
+msgctxt "personal data group description"
+msgid "Overview of export report."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:374
+msgctxt "email address"
+msgid "Report generated for"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:378
+msgctxt "website name"
+msgid "For site"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:382
+msgctxt "website URL"
+msgid "At URL"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:386
+msgctxt "date/time"
+msgid "On"
+msgstr ""
+
+#. translators: %s: Post meta key.
+#: wp-admin/includes/privacy-tools.php:404
+msgid "The %s post meta must be an array."
+msgstr ""
+
+#. translators: %s: Error message.
+#: wp-admin/includes/privacy-tools.php:419
+msgid "Unable to encode the personal data for export. Error: %s"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:432
+msgid "Unable to open personal data export file (JSON report) for writing."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:447
+msgid "Unable to open personal data export (HTML report) for writing."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:467
+msgid "Personal Data Export"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:472
+msgid "Table of Contents"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:541
+msgid "Unable to archive the personal data export file (JSON format)."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:545
+msgid "Unable to archive the personal data export file (HTML format)."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:566
+msgid "Unable to open personal data export file (archive) for writing."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:593
+msgid "Invalid request ID when sending personal data export email."
+msgstr ""
+
+#. translators: Personal data export notification email subject. %s: Site title.
+#: wp-admin/includes/privacy-tools.php:636
+msgid "[%s] Personal Data Export"
+msgstr ""
+
+#. translators: Do not translate EXPIRATION, LINK, SITENAME, SITEURL: those are placeholders.
+#: wp-admin/includes/privacy-tools.php:662
+msgid ""
+"Howdy,\n"
+"\n"
+"Your request for an export of personal data has been completed. You may\n"
+"download your personal data by clicking on the link below. For privacy\n"
+"and security, we will automatically delete the file on ###EXPIRATION###,\n"
+"so please download it before then.\n"
+"\n"
+"###LINK###\n"
+"\n"
+"Regards,\n"
+"All at ###SITENAME###\n"
+"###SITEURL###"
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:746
+msgid "Unable to send personal data export email."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:793
+msgid "Invalid request ID when merging personal data to export."
+msgstr ""
+
+#: wp-admin/includes/privacy-tools.php:944
+msgid "Invalid request ID when processing personal data to erase."
+msgstr ""
+
+#: wp-admin/includes/revision.php:95
+msgid "Removed"
+msgstr ""
+
+#: wp-admin/includes/revision.php:96
+msgid "Added"
+msgstr ""
+
+#: wp-admin/includes/revision.php:247
+#: wp-admin/includes/revision.php:290
+msgid "M j, Y @ H:i"
+msgstr ""
+
+#: wp-admin/includes/revision.php:248
+#: wp-admin/includes/revision.php:291
+msgctxt "revision date short format"
+msgid "j M @ H:i"
+msgstr ""
+
+#: wp-admin/includes/revision.php:369
+msgctxt "Button label for a previous revision"
+msgid "Previous"
+msgstr ""
+
+#: wp-admin/includes/revision.php:373
+msgctxt "Button label for a next revision"
+msgid "Next"
+msgstr ""
+
+#: wp-admin/includes/revision.php:387
+msgid "Compare any two revisions"
+msgstr ""
+
+#: wp-admin/includes/revision.php:396
+msgctxt "Followed by post revision info"
+msgid "From:"
+msgstr ""
+
+#: wp-admin/includes/revision.php:398
+msgctxt "Followed by post revision info"
+msgid "To:"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/revision.php:408
+msgid "Autosave by %s"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/revision.php:418
+msgid "Current Revision by %s"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/includes/revision.php:428
+msgid "Revision by %s"
+msgstr ""
+
+#: wp-admin/includes/revision.php:446
+msgid "Restore This Autosave"
+msgstr ""
+
+#: wp-admin/includes/revision.php:448
+msgid "Restore This Revision"
+msgstr ""
+
+#: wp-admin/includes/revision.php:460
+msgid "Sorry, something went wrong. The requested comparison could not be loaded."
+msgstr ""
+
+#. translators: default GMT offset or timezone string. Must be either a valid offset (-12 to 14) or a valid timezone string (America/New_York). See https://www.php.net/manual/en/timezones.php for all timezone strings currently supported by PHP. Important: When a previous timezone string, like `Europe/Kiev`, has been superseded by an updated one, like `Europe/Kyiv`, as a rule of thumb, the **old** timezone name should be used in the "translation" to allow for the default timezone setting to be PHP cross-version compatible, as old timezone names will be recognized in new PHP versions, while new timezone names cannot be recognized in old PHP versions. To verify which timezone strings are available in the _oldest_ PHP version supported, you can use https://3v4l.org/6YQAt#v5.6.20 and replace the "BR" (Brazil) in the code line with the country code for which you want to look up the supported timezone names.
+#: wp-admin/includes/schema.php:403
+msgctxt "default GMT offset or timezone string"
+msgid "0"
+msgstr ""
+
+#: wp-admin/includes/schema.php:413
+msgid "My Site"
+msgstr ""
+
+#. translators: Default start of the week. 0 = Sunday, 1 = Monday.
+#: wp-admin/includes/schema.php:421
+msgctxt "start of week"
+msgid "1"
+msgstr ""
+
+#. translators: Links last updated date format, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/includes/schema.php:442
+msgid "F j, Y g:i a"
+msgstr ""
+
+#: wp-admin/includes/schema.php:989
+msgid "You must provide a domain name."
+msgstr ""
+
+#: wp-admin/includes/schema.php:992
+msgid "You must provide a name for your network of sites."
+msgstr ""
+
+#: wp-admin/includes/schema.php:999
+#: wp-admin/includes/schema.php:1003
+msgid "The network already exists."
+msgstr ""
+
+#: wp-admin/includes/schema.php:1008
+msgid "You must provide a valid email address."
+msgstr ""
+
+#: wp-admin/includes/schema.php:1111
+msgid "Warning! Wildcard DNS may not be configured correctly!"
+msgstr ""
+
+#. translators: %s: Host name.
+#: wp-admin/includes/schema.php:1115
+msgid "The installer attempted to contact a random hostname (%s) on your domain."
+msgstr ""
+
+#. translators: %s: Error message.
+#: wp-admin/includes/schema.php:1120
+msgid "This resulted in an error message: %s"
+msgstr ""
+
+#. translators: %s: Asterisk symbol (*).
+#: wp-admin/includes/schema.php:1126
+msgid "To use a subdomain configuration, you must have a wildcard entry in your DNS. This usually means adding a %s hostname record pointing at your web server in your DNS configuration tool."
+msgstr ""
+
+#: wp-admin/includes/schema.php:1130
+msgid "You can still use your site but any subdomain you create may not be accessible. If you know your DNS is correct, ignore this message."
+msgstr ""
+
+#. translators: Do not translate USERNAME, SITE_NAME, BLOG_URL, PASSWORD: those are placeholders.
+#: wp-admin/includes/schema.php:1214
+msgid ""
+"Hello USERNAME,\n"
+"\n"
+"Your new SITE_NAME site has been successfully set up at:\n"
+"BLOG_URL\n"
+"\n"
+"You can log in to the administrator account with the following information:\n"
+"\n"
+"Username: USERNAME\n"
+"Password: PASSWORD\n"
+"Log in here: BLOG_URLwp-login.php\n"
+"\n"
+"We hope you enjoy your new site. Thanks!\n"
+"\n"
+"--The Team @ SITE_NAME"
+msgstr ""
+
+#: wp-admin/includes/schema.php:1265
+msgid "My Network"
+msgstr ""
+
+#. translators: %s: Site link.
+#. translators: First post content. %s: Site link.
+#: wp-admin/includes/schema.php:1278
+#: wp-admin/includes/upgrade.php:195
+msgid "Welcome to %s. This is your first post. Edit or delete it, then start writing!"
+msgstr ""
+
+#: wp-admin/includes/taxonomy.php:136
+msgid "You did not enter a category name."
+msgstr ""
+
+#: wp-admin/includes/template.php:461
+msgid "Reply to Comment"
+msgstr ""
+
+#: wp-admin/includes/template.php:462
+msgid "Add new Comment"
+msgstr ""
+
+#: wp-admin/includes/template.php:507
+msgid "Update Comment"
+msgstr ""
+
+#: wp-admin/includes/template.php:508
+msgid "Submit Reply"
+msgstr ""
+
+#. translators: %s: Comment author, filled by Ajax.
+#: wp-admin/includes/template.php:552
+msgid "Comment by %s moved to the Trash."
+msgstr ""
+
+#. translators: %s: Comment author, filled by Ajax.
+#: wp-admin/includes/template.php:561
+msgid "Comment by %s marked as spam."
+msgstr ""
+
+#: wp-admin/includes/template.php:583
+#: wp-admin/includes/template.php:598
+#: wp-admin/includes/template.php:736
+msgctxt "meta name"
+msgid "Name"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:584
+#: wp-admin/includes/template.php:599
+#: wp-admin/includes/template.php:669
+#: wp-admin/includes/template.php:737
+msgid "Value"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:656
+msgid "Key"
+msgstr ""
+
+#: wp-admin/includes/template.php:732
+msgid "Add New Custom Field:"
+msgstr ""
+
+#: wp-admin/includes/template.php:758
+msgid "Enter new"
+msgstr ""
+
+#: wp-admin/includes/template.php:771
+msgid "Add Custom Field"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:835
+msgid "Month"
+msgstr ""
+
+#. translators: 1: Month number (01, 02, etc.), 2: Month abbreviation.
+#: wp-admin/includes/template.php:842
+msgid "%1$s-%2$s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:848
+msgid "Day"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:852
+msgid "Year"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:856
+msgid "Hour"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:860
+msgid "Minute"
+msgstr ""
+
+#. translators: 1: Month, 2: Day, 3: Year, 4: Hour, 5: Minute.
+#: wp-admin/includes/template.php:865
+#: wp-admin/js/comment.js:89
+#: wp-admin/js/post.js:809
+msgid "%1$s %2$s, %3$s at %4$s:%5$s"
+msgstr ""
+
+#: wp-admin/includes/template.php:1013
+msgid "Before you can upload your import file, you will need to fix the following error:"
+msgstr ""
+
+#: wp-admin/includes/template.php:1023
+msgid "Choose a file from your computer:"
+msgstr ""
+
+#. translators: %s: Maximum allowed file size.
+#: wp-admin/includes/template.php:1025
+msgid "Maximum size: %s"
+msgstr ""
+
+#: wp-admin/includes/template.php:1032
+msgid "Upload file and import"
+msgstr ""
+
+#. translators: %s: Meta box title.
+#: wp-admin/includes/template.php:1315
+msgid "Move %s box up"
+msgstr ""
+
+#. translators: %s: Meta box title.
+#: wp-admin/includes/template.php:1328
+msgid "Move %s box down"
+msgstr ""
+
+#. translators: %s: misc
+#. translators: %s: privacy
+#: wp-admin/includes/template.php:1530
+#: wp-admin/includes/template.php:1543
+#: wp-admin/includes/template.php:1597
+#: wp-admin/includes/template.php:1610
+msgid "The \"%s\" options group has been removed. Use another settings group."
+msgstr ""
+
+#: wp-admin/includes/template.php:1909
+msgid "Attach to existing content"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/template.php:1913
+msgid "Close media attachment panel"
+msgstr ""
+
+#: wp-admin/includes/template.php:1938
+#: wp-admin/nav-menus.php:942
+#: wp-admin/plugin-editor.php:238
+#: wp-admin/theme-editor.php:244
+msgid "Select"
+msgstr ""
+
+#: wp-admin/includes/template.php:2171
+msgctxt "post status"
+msgid "Password protected"
+msgstr ""
+
+#: wp-admin/includes/template.php:2175
+msgctxt "post status"
+msgid "Private"
+msgstr ""
+
+#: wp-admin/includes/template.php:2180
+msgid "Customization Draft"
+msgstr ""
+
+#: wp-admin/includes/template.php:2182
+msgctxt "post status"
+msgid "Draft"
+msgstr ""
+
+#: wp-admin/includes/template.php:2185
+msgctxt "post status"
+msgid "Customization Draft"
+msgstr ""
+
+#: wp-admin/includes/template.php:2189
+msgctxt "post status"
+msgid "Pending"
+msgstr ""
+
+#: wp-admin/includes/template.php:2193
+msgctxt "post status"
+msgid "Sticky"
+msgstr ""
+
+#: wp-admin/includes/template.php:2197
+msgctxt "post status"
+msgid "Scheduled"
+msgstr ""
+
+#: wp-admin/includes/template.php:2202
+msgctxt "page label"
+msgid "Front Page"
+msgstr ""
+
+#: wp-admin/includes/template.php:2206
+msgctxt "page label"
+msgid "Posts Page"
+msgstr ""
+
+#: wp-admin/includes/template.php:2211
+msgctxt "page label"
+msgid "Privacy Policy Page"
+msgstr ""
+
+#: wp-admin/includes/template.php:2302
+msgid "Current Header Image"
+msgstr ""
+
+#: wp-admin/includes/template.php:2309
+msgid "Current Header Video"
+msgstr ""
+
+#: wp-admin/includes/template.php:2322
+msgid "Current Background Image"
+msgstr ""
+
+#: wp-admin/includes/template.php:2328
+#: wp-admin/options-general.php:89
+msgid "Site Icon"
+msgstr ""
+
+#: wp-admin/includes/template.php:2332
+msgid "Logo"
+msgstr ""
+
+#. translators: 1: wp-admin/includes/template.php, 2: add_meta_box(), 3: add_meta_boxes
+#: wp-admin/includes/template.php:2557
+msgid "Likely direct inclusion of %1$s in order to use %2$s. This is very wrong. Hook the %2$s call into the %3$s action instead."
+msgstr ""
+
+#: wp-admin/includes/template.php:2583
+msgid "The backup of this post in your browser is different from the version below."
+msgstr ""
+
+#: wp-admin/includes/template.php:2584
+msgid "Restore the backup"
+msgstr ""
+
+#: wp-admin/includes/template.php:2587
+msgid "This will replace the current editor content with the last backup version. You can use undo and redo in the editor to get the old content back or to return to the restored version."
+msgstr ""
+
+#. translators: Hidden accessibility text. 1: The rating, 2: The number of ratings.
+#: wp-admin/includes/template.php:2640
+msgid "%1$s rating based on %2$s rating"
+msgid_plural "%1$s rating based on %2$s ratings"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: Hidden accessibility text. %s: The rating.
+#: wp-admin/includes/template.php:2644
+msgid "%s rating"
+msgstr ""
+
+#: wp-admin/includes/template.php:2670
+msgid "You are currently editing the page that shows your latest posts."
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:95
+msgid "Search for themes by keyword."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme-install.php:104
+msgid "Type of search"
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:110
+msgctxt "Theme Installer"
+msgid "Tag"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme-install.php:117
+#: wp-admin/includes/theme-install.php:134
+msgid "Search by keyword"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme-install.php:121
+msgid "Search by author"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme-install.php:125
+msgid "Search by tag"
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:152
+#: wp-admin/theme-install.php:198
+msgid "Feature Filter"
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:153
+msgid "Find a theme based on specific features."
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:185
+msgid "Find Themes"
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:197
+msgid "If you have a theme in a .zip format, you may install or update it by uploading it here."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme-install.php:203
+msgid "Theme zip file"
+msgstr ""
+
+#: wp-admin/includes/theme-install.php:264
+msgid "Theme Installation"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:102
+msgid "Could not fully remove the theme %s."
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number.
+#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number.
+#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number.
+#: wp-admin/includes/theme.php:223
+#: wp-admin/includes/update.php:488
+#: wp-admin/includes/update.php:679
+msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>."
+msgstr ""
+
+#. translators: 1: Theme name, 2: Version number.
+#. translators: 1: Plugin name, 2: Version number.
+#: wp-admin/includes/theme.php:229
+#: wp-admin/includes/theme.php:242
+#: wp-admin/includes/theme.php:255
+#: wp-admin/includes/update.php:494
+#: wp-admin/includes/update.php:507
+#: wp-admin/includes/update.php:521
+#: wp-admin/includes/update.php:540
+#: wp-admin/includes/update.php:685
+#: wp-admin/includes/update.php:698
+#: wp-admin/includes/update.php:711
+#: wp-admin/update-core.php:417
+msgid "View %1$s version %2$s details"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number.
+#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number.
+#: wp-admin/includes/theme.php:236
+#: wp-admin/includes/update.php:692
+msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this theme.</em>"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
+#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
+#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
+#: wp-admin/includes/theme.php:249
+#: wp-admin/includes/update.php:515
+#: wp-admin/includes/update.php:705
+msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a> or <a href=\"%5$s\" %6$s>update now</a>."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:262
+#: wp-admin/includes/update.php:718
+msgctxt "theme"
+msgid "Update %s now"
+msgstr ""
+
+#: wp-admin/includes/theme.php:306
+#: wp-admin/includes/theme.php:371
+msgid "Subject"
+msgstr ""
+
+#: wp-admin/includes/theme.php:307
+msgid "Blog"
+msgstr ""
+
+#: wp-admin/includes/theme.php:308
+msgid "E-Commerce"
+msgstr ""
+
+#: wp-admin/includes/theme.php:309
+msgid "Education"
+msgstr ""
+
+#: wp-admin/includes/theme.php:310
+msgid "Entertainment"
+msgstr ""
+
+#: wp-admin/includes/theme.php:311
+msgid "Food & Drink"
+msgstr ""
+
+#: wp-admin/includes/theme.php:312
+msgid "Holiday"
+msgstr ""
+
+#: wp-admin/includes/theme.php:313
+msgid "News"
+msgstr ""
+
+#: wp-admin/includes/theme.php:314
+msgid "Photography"
+msgstr ""
+
+#: wp-admin/includes/theme.php:315
+msgid "Portfolio"
+msgstr ""
+
+#: wp-admin/includes/theme.php:318
+#: wp-admin/includes/theme.php:370
+msgid "Features"
+msgstr ""
+
+#: wp-admin/includes/theme.php:319
+msgid "Accessibility Ready"
+msgstr ""
+
+#: wp-admin/includes/theme.php:321
+msgid "Custom Colors"
+msgstr ""
+
+#: wp-admin/includes/theme.php:323
+msgid "Custom Logo"
+msgstr ""
+
+#: wp-admin/includes/theme.php:324
+msgid "Editor Style"
+msgstr ""
+
+#: wp-admin/includes/theme.php:325
+msgid "Featured Image Header"
+msgstr ""
+
+#: wp-admin/includes/theme.php:326
+msgid "Featured Images"
+msgstr ""
+
+#: wp-admin/includes/theme.php:327
+msgid "Footer Widgets"
+msgstr ""
+
+#: wp-admin/includes/theme.php:328
+msgid "Full Width Template"
+msgstr ""
+
+#: wp-admin/includes/theme.php:330
+msgid "Sticky Post"
+msgstr ""
+
+#: wp-admin/includes/theme.php:331
+msgid "Theme Options"
+msgstr ""
+
+#: wp-admin/includes/theme.php:335
+msgid "Grid Layout"
+msgstr ""
+
+#: wp-admin/includes/theme.php:336
+msgid "One Column"
+msgstr ""
+
+#: wp-admin/includes/theme.php:337
+msgid "Two Columns"
+msgstr ""
+
+#: wp-admin/includes/theme.php:338
+msgid "Three Columns"
+msgstr ""
+
+#: wp-admin/includes/theme.php:339
+msgid "Four Columns"
+msgstr ""
+
+#: wp-admin/includes/theme.php:340
+msgid "Left Sidebar"
+msgstr ""
+
+#: wp-admin/includes/theme.php:341
+msgid "Right Sidebar"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme.php:790
+#: wp-admin/themes.php:944
+msgid "Show previous theme"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme.php:796
+#: wp-admin/themes.php:950
+msgid "Show next theme"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/theme.php:802
+#: wp-admin/themes.php:956
+msgid "Close details dialog"
+msgstr ""
+
+#. translators: %s: Theme version.
+#: wp-admin/includes/theme.php:822
+#: wp-admin/theme-install.php:490
+#: wp-admin/themes.php:976
+msgid "Version: %s"
+msgstr ""
+
+#. translators: %s: Number of ratings.
+#: wp-admin/includes/theme.php:840
+#: wp-admin/theme-install.php:479
+msgid "(%s ratings)"
+msgstr ""
+
+#: wp-admin/includes/theme.php:852
+#: wp-admin/themes.php:1044
+msgid "Update Available"
+msgstr ""
+
+#: wp-admin/includes/theme.php:857
+#: wp-admin/themes.php:1049
+msgid "Update Incompatible"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:863
+#: wp-admin/includes/update.php:726
+#: wp-admin/themes.php:412
+#: wp-admin/themes.php:763
+#: wp-admin/themes.php:1055
+msgid "There is a new version of %s available, but it does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:893
+#: wp-admin/includes/update.php:754
+#: wp-admin/themes.php:440
+#: wp-admin/themes.php:793
+#: wp-admin/themes.php:1085
+msgid "There is a new version of %s available, but it does not work with your version of ClassicPress."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:908
+#: wp-admin/includes/update.php:767
+#: wp-admin/themes.php:453
+#: wp-admin/themes.php:808
+#: wp-admin/themes.php:1100
+msgid "There is a new version of %s available, but it does not work with your version of PHP."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:931
+#: wp-admin/themes.php:1128
+msgid "This is a child theme of %s."
+msgstr ""
+
+#: wp-admin/includes/theme.php:942
+#: wp-admin/theme-install.php:293
+#: wp-admin/theme-install.php:498
+#: wp-admin/themes.php:474
+#: wp-admin/themes.php:829
+#: wp-admin/themes.php:990
+msgid "This theme does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#: wp-admin/includes/theme.php:968
+#: wp-admin/theme-install.php:323
+#: wp-admin/theme-install.php:528
+#: wp-admin/themes.php:498
+#: wp-admin/themes.php:855
+#: wp-admin/themes.php:1016
+msgid "This theme does not work with your version of ClassicPress."
+msgstr ""
+
+#: wp-admin/includes/theme.php:979
+#: wp-admin/theme-install.php:334
+#: wp-admin/theme-install.php:539
+#: wp-admin/themes.php:507
+#: wp-admin/themes.php:866
+#: wp-admin/themes.php:1027
+msgid "This theme does not work with your version of PHP."
+msgstr ""
+
+#: wp-admin/includes/theme.php:994
+msgid "This theme doesn't support Customizer."
+msgstr ""
+
+#. translators: %s: URL to the themes page (also it activates the theme).
+#: wp-admin/includes/theme.php:1000
+msgid "However, you can still <a href=\"%s\">activate this theme</a>, and use the Site Editor to customize it."
+msgstr ""
+
+#: wp-admin/includes/theme.php:1011
+#: wp-admin/themes.php:1134
+msgid "Tags:"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/theme.php:1029
+#: wp-admin/theme-install.php:364
+#: wp-admin/theme-install.php:440
+#: wp-admin/themes.php:554
+#: wp-admin/themes.php:914
+#: wp-admin/themes.php:1148
+#: wp-admin/js/updates.js:1415
+msgctxt "theme"
+msgid "Activate %s"
+msgstr ""
+
+#: wp-admin/includes/theme.php:1044
+#: wp-admin/includes/theme.php:1047
+msgid "Install &amp; Preview"
+msgstr ""
+
+#: wp-admin/includes/theme.php:1046
+#: wp-admin/theme-install.php:407
+#: wp-admin/theme-install.php:454
+msgctxt "theme"
+msgid "Cannot Install"
+msgstr ""
+
+#: wp-admin/includes/theme.php:1159
+msgid "Could not resume the theme."
+msgstr ""
+
+#: wp-admin/includes/theme.php:1188
+msgid "One or more themes failed to load properly."
+msgstr ""
+
+#: wp-admin/includes/theme.php:1189
+msgid "You can find more details and make changes on the Themes screen."
+msgstr ""
+
+#: wp-admin/includes/theme.php:1191
+msgid "Go to the Themes screen"
+msgstr ""
+
+#: wp-admin/includes/translation-install.php:24
+msgid "Invalid translation type."
+msgstr ""
+
+#: wp-admin/includes/translation-install.php:71
+#: wp-admin/includes/update-core.php:1043
+#: wp-admin/includes/update.php:139
+msgid "(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)"
+msgstr ""
+
+#: wp-admin/includes/update-core.php:290
+msgid "Verifying the unpacked files&#8230;"
+msgstr ""
+
+#: wp-admin/includes/update-core.php:297
+msgid "The update could not be unpacked"
+msgstr ""
+
+#. translators: 1: WordPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number.
+#: wp-admin/includes/update-core.php:375
+msgid "The update cannot be installed because ClassicPress %1$s requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s."
+msgstr ""
+
+#. translators: 1: WordPress version number, 2: Minimum required PHP version number, 3: Current PHP version number.
+#: wp-admin/includes/update-core.php:388
+msgid "The update cannot be installed because ClassicPress %1$s requires PHP version %2$s or higher. You are running version %3$s."
+msgstr ""
+
+#. translators: 1: WordPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number.
+#: wp-admin/includes/update-core.php:399
+msgid "The update cannot be installed because ClassicPress %1$s requires MySQL version %2$s or higher. You are running version %3$s."
+msgstr ""
+
+#. translators: 1: WordPress version number, 2: The PHP extension name needed.
+#: wp-admin/includes/update-core.php:413
+msgid "The update cannot be installed because ClassicPress %1$s requires the %2$s PHP extension."
+msgstr ""
+
+#: wp-admin/includes/update-core.php:421
+msgid "Preparing to install the latest version&#8230;"
+msgstr ""
+
+#: wp-admin/includes/update-core.php:497
+#: wp-admin/includes/update-core.php:533
+msgid "The update cannot be installed because your site is unable to copy some files. This is usually due to inconsistent file permissions."
+msgstr ""
+
+#: wp-admin/includes/update-core.php:514
+msgid "Copying the required files&#8230;"
+msgstr ""
+
+#: wp-admin/includes/update-core.php:598
+msgid "There is not enough free disk space to complete the update."
+msgstr ""
+
+#: wp-admin/includes/update-core.php:757
+msgid "Upgrading database&#8230;"
+msgstr ""
+
+#: wp-admin/includes/update-core.php:884
+#: wp-admin/update-core.php:786
+msgid "ClassicPress updated successfully"
+msgstr ""
+
+#. translators: 1: ClassicPress version, 2: URL to About screen.
+#: wp-admin/includes/update-core.php:890
+#: wp-admin/update-core.php:787
+msgid "Welcome to ClassicPress %1$s. You will be redirected to the About ClassicPress screen. If not, click <a href=\"%2$s\">here</a>."
+msgstr ""
+
+#. translators: 1: ClassicPress version, 2: URL to About screen.
+#: wp-admin/includes/update-core.php:898
+#: wp-admin/update-core.php:788
+msgid "Welcome to ClassicPress %1$s. <a href=\"%2$s\">Learn more</a>."
+msgstr ""
+
+#. translators: %s: support forums URL
+#. translators: %s: Support forums URL.
+#: wp-admin/includes/update-core.php:1041
+#: wp-admin/includes/update.php:137
+msgid "An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: ClassicPress updates admin screen URL
+#: wp-admin/includes/update.php:251
+msgid "You are using a development version (%1$s). Cool! Please <a href=\"%2$s\">stay updated</a>."
+msgstr ""
+
+#. translators: %s: WordPress version.
+#: wp-admin/includes/update.php:258
+msgid "Get Version %s"
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/includes/update.php:295
+msgid "https://www.classicpress.net/version/%s"
+msgstr ""
+
+#. translators: 1: URL to ClassicPress release notes, 2: New ClassicPress version, 3: URL to network admin, 4: Accessibility text.
+#: wp-admin/includes/update.php:302
+msgid "<a href=\"%1$s\">ClassicPress %2$s</a> is available! <a href=\"%3$s\" aria-label=\"%4$s\">Please update now</a>."
+msgstr ""
+
+#: wp-admin/includes/update.php:306
+msgid "Please update ClassicPress now"
+msgstr ""
+
+#. translators: 1: URL to ClassicPress release notes, 2: New ClassicPress version.
+#: wp-admin/includes/update.php:311
+msgid "<a href=\"%1$s\">ClassicPress %2$s</a> is available! Please notify the site administrator."
+msgstr ""
+
+#. translators: %s: WordPress version number, or 'Latest' string.
+#: wp-admin/includes/update.php:341
+msgid "Update to %s"
+msgstr ""
+
+#. translators: %s: WordPress version number, or 'Latest' string.
+#: wp-admin/includes/update.php:341
+msgid "Latest"
+msgstr ""
+
+#. translators: 1: Version number, 2: Theme name.
+#: wp-admin/includes/update.php:347
+msgid "ClassicPress %1$s running %2$s theme."
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number.
+#: wp-admin/includes/update.php:501
+msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this plugin.</em>"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number 5: URL to Update PHP page.
+#: wp-admin/includes/update.php:534
+msgid "There is a new version of %1$s available, but it does not work with your version of PHP. <a href=\"%2$s\" %3$s>View version %4$s details</a> or <a href=\"%5$s\">learn more about updating PHP</a>."
+msgstr ""
+
+#. translators: %s: URL to WordPress Updates screen.
+#: wp-admin/includes/update.php:842
+msgid "An automated ClassicPress update has failed to complete - <a href=\"%s\">please attempt the update again now</a>."
+msgstr ""
+
+#: wp-admin/includes/update.php:846
+msgid "An automated ClassicPress update has failed to complete! Please notify the site administrator."
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/update.php:881
+msgid "%s plugin successfully updated."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/update.php:886
+msgid "%s theme successfully updated."
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/includes/update.php:893
+msgid "%s plugins successfully updated."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/update.php:898
+msgid "%s themes successfully updated."
+msgstr ""
+
+#. translators: %s: Number of failed updates.
+#: wp-admin/includes/update.php:908
+msgid "%s update failed."
+msgstr ""
+
+#. translators: %s: Number of failed updates.
+#: wp-admin/includes/update.php:913
+msgid "%s updates failed."
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/includes/update.php:981
+msgctxt "plugin"
+msgid "%s was successfully deleted."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/update.php:989
+msgctxt "theme"
+msgid "%s was successfully deleted."
+msgstr ""
+
+#. translators: %s: Recovery Mode exit link.
+#: wp-admin/includes/update.php:1020
+msgid "You are in recovery mode. This means there may be an error with a theme or plugin. To exit recovery mode, log out or use the Exit button. <a href=\"%s\">Exit Recovery Mode</a>"
+msgstr ""
+
+#: wp-admin/includes/update.php:1097
+msgid "Automatic update not scheduled. There may be a problem with WP-Cron."
+msgstr ""
+
+#. translators: %s: Duration that WP-Cron has been overdue.
+#: wp-admin/includes/update.php:1107
+msgid "Automatic update overdue by %s. There may be a problem with WP-Cron."
+msgstr ""
+
+#. translators: %s: Time until the next update.
+#: wp-admin/includes/update.php:1113
+msgid "Automatic update scheduled in %s."
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:89
+msgid "<strong><em>Note that password</em></strong> carefully! It is a <em>random</em> password that was generated just for you."
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:96
+msgid "Your chosen password."
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:100
+msgid "User already exists. Password inherited."
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:117
+msgid "The password you chose during installation."
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:158
+msgid "Uncategorized"
+msgstr ""
+
+#. translators: Default category slug.
+#: wp-admin/includes/upgrade.php:160
+msgctxt "Default category slug"
+msgid "Uncategorized"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:207
+msgid "Welcome to ClassicPress. This is your first post. Edit or delete it, then start writing!"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:218
+msgid "Hello world!"
+msgstr ""
+
+#. translators: Default post slug.
+#: wp-admin/includes/upgrade.php:220
+#: wp-admin/includes/upgrade.php:525
+msgctxt "Default post slug"
+msgid "hello-world"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:251
+msgid "A ClassicPress Commenter"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:254
+msgid ""
+"Hi, this is a comment.\n"
+"To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard."
+msgstr ""
+
+#. translators: First page content.
+#: wp-admin/includes/upgrade.php:279
+msgid "This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:"
+msgstr ""
+
+#. translators: First page content.
+#: wp-admin/includes/upgrade.php:281
+msgid "Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)"
+msgstr ""
+
+#. translators: First page content.
+#: wp-admin/includes/upgrade.php:283
+msgid "...or something like this:"
+msgstr ""
+
+#. translators: First page content.
+#: wp-admin/includes/upgrade.php:285
+msgid "The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community."
+msgstr ""
+
+#. translators: First page content. %s: Site admin URL.
+#: wp-admin/includes/upgrade.php:288
+msgid "As a new ClassicPress user, you should go to <a href=\"%s\">your dashboard</a> to delete this page and create new pages for your content. Have fun!"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:303
+msgid "Sample Page"
+msgstr ""
+
+#. translators: Default page slug.
+#: wp-admin/includes/upgrade.php:305
+msgid "sample-page"
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:348
+#: wp-admin/options-privacy.php:90
+#: wp-admin/privacy.php:63
+msgid "Privacy Policy"
+msgstr ""
+
+#. translators: Privacy Policy page slug.
+#: wp-admin/includes/upgrade.php:350
+msgid "privacy-policy"
+msgstr ""
+
+#. translators: New site notification email. 1: New site URL, 2: User login, 3: User password or password reset link, 4: Login URL.
+#: wp-admin/includes/upgrade.php:579
+msgid ""
+"Your new ClassicPress site has been successfully set up at:\n"
+"\n"
+"%1$s\n"
+"\n"
+"You can log in to the administrator account with the following information:\n"
+"\n"
+"Username: %2$s\n"
+"Password: %3$s\n"
+"Log in here: %4$s\n"
+"\n"
+"We hope you enjoy your new site. Thanks!\n"
+"\n"
+"--The ClassicPress Team\n"
+"https://www.classicpress.net/\n"
+""
+msgstr ""
+
+#: wp-admin/includes/upgrade.php:604
+msgid "New ClassicPress Site"
+msgstr ""
+
+#: wp-admin/includes/user.php:62
+#: wp-admin/users.php:131
+msgid "Sorry, you are not allowed to give users that role."
+msgstr ""
+
+#: wp-admin/includes/user.php:152
+msgid "<strong>Error:</strong> Please enter a username."
+msgstr ""
+
+#: wp-admin/includes/user.php:157
+msgid "<strong>Error:</strong> Please enter a nickname."
+msgstr ""
+
+#: wp-admin/includes/user.php:173
+msgid "<strong>Error:</strong> Please enter a password."
+msgstr ""
+
+#: wp-admin/includes/user.php:178
+msgid "<strong>Error:</strong> Passwords may not contain the character \"\\\"."
+msgstr ""
+
+#: wp-admin/includes/user.php:183
+msgid "<strong>Error:</strong> Passwords do not match. Please enter the same password in both password fields."
+msgstr ""
+
+#: wp-admin/includes/user.php:191
+msgid "<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username."
+msgstr ""
+
+#: wp-admin/includes/user.php:195
+msgid "<strong>Error:</strong> This username is already registered. Please choose another one."
+msgstr ""
+
+#: wp-admin/includes/user.php:202
+msgid "<strong>Error:</strong> Sorry, that username is not allowed."
+msgstr ""
+
+#: wp-admin/includes/user.php:207
+msgid "<strong>Error:</strong> Please enter an email address."
+msgstr ""
+
+#: wp-admin/includes/user.php:209
+msgid "<strong>Error:</strong> The email address is not correct."
+msgstr ""
+
+#: wp-admin/includes/user.php:213
+msgid "<strong>Error:</strong> This email is already registered. Please choose another one."
+msgstr ""
+
+#: wp-admin/includes/user.php:531
+msgid "Notice:"
+msgstr ""
+
+#: wp-admin/includes/user.php:532
+msgid "You&rsquo;re using the auto-generated password for your account. Would you like to change it?"
+msgstr ""
+
+#: wp-admin/includes/user.php:534
+msgid "Yes, take me to my profile page"
+msgstr ""
+
+#: wp-admin/includes/user.php:535
+msgid "No thanks, do not remind me again"
+msgstr ""
+
+#: wp-admin/includes/user.php:571
+msgid "Use https"
+msgstr ""
+
+#: wp-admin/includes/user.php:572
+msgid "Always use https when visiting the admin"
+msgstr ""
+
+#. translators: 1: Site title, 2: Site URL, 3: User role.
+#: wp-admin/includes/user.php:595
+msgid ""
+"Hi,\n"
+"You've been invited to join '%1$s' at\n"
+"%2$s with the role of %3$s.\n"
+"If you do not want to join this site please ignore\n"
+"this email. This invitation will expire in a few days.\n"
+"\n"
+"Please click the following link to activate your user account:\n"
+"%%s"
+msgstr ""
+
+#: wp-admin/includes/user.php:655
+msgid "The application ID must be a UUID."
+msgstr ""
+
+#: wp-admin/includes/user.php:697
+#: wp-admin/includes/user.php:719
+msgid "Invalid URL format."
+msgstr ""
+
+#: wp-admin/includes/user.php:726
+msgid "The URL must be served over a secure connection."
+msgstr ""
+
+#: wp-admin/includes/widgets.php:239
+msgctxt "widget"
+msgid "Edit"
+msgstr ""
+
+#: wp-admin/includes/widgets.php:240
+msgctxt "widget"
+msgid "Add"
+msgstr ""
+
+#: wp-admin/includes/widgets.php:252
+#: wp-admin/widgets-form.php:292
+msgid "There are no options for this widget."
+msgstr ""
+
+#: wp-admin/includes/widgets.php:273
+#: wp-admin/js/set-post-thumbnail.js:21
+msgid "Done"
+msgstr ""
+
+#: wp-admin/index.php:33
+#: wp-admin/menu.php:24
+#: wp-admin/user/menu.php:10
+msgid "Dashboard"
+msgstr ""
+
+#: wp-admin/index.php:36
+msgid "Welcome to your ClassicPress Dashboard!"
+msgstr ""
+
+#: wp-admin/index.php:37
+msgid "The Dashboard is the first place you will come to every time you log into your site. It is where you access to all the site management features of ClassicPress. You can get help for any screen by clicking the Help tab above the screen title."
+msgstr ""
+
+#: wp-admin/index.php:51
+msgid "The left-hand navigation menu provides links to all of the ClassicPress administration screens, with submenu items displayed on hover. You can minimize this menu to a narrow icon strip by clicking on the Collapse Menu arrow at the bottom."
+msgstr ""
+
+#: wp-admin/index.php:52
+msgid "Links in the Toolbar at the top of the screen connect your dashboard and the front end of your site, and provide access to your profile and helpful ClassicPress information."
+msgstr ""
+
+#: wp-admin/index.php:57
+msgid "Navigation"
+msgstr ""
+
+#: wp-admin/index.php:62
+msgid "You can use the following controls to arrange your Dashboard screen to suit your workflow. This is true on most other administration screens as well."
+msgstr ""
+
+#: wp-admin/index.php:63
+msgid "<strong>Screen Options</strong> &mdash; Use the Screen Options tab to choose which Dashboard boxes to show."
+msgstr ""
+
+#: wp-admin/index.php:64
+msgid "<strong>Drag and Drop</strong> &mdash; To rearrange the boxes, drag and drop by clicking on the title bar of the selected box and releasing when you see a gray dotted-line rectangle appear in the location you want to place the box."
+msgstr ""
+
+#: wp-admin/index.php:65
+msgid "<strong>Box Controls</strong> &mdash; Click the title bar of the box to expand or collapse it. Some boxes added by plugins may have configurable content, and will show a &#8220;Configure&#8221; link in the title bar if you hover over it."
+msgstr ""
+
+#: wp-admin/index.php:75
+msgid "The boxes on your Dashboard screen are:"
+msgstr ""
+
+#: wp-admin/index.php:78
+msgid "<strong>Welcome</strong> &mdash; Shows links for some of the most common tasks when setting up a new site."
+msgstr ""
+
+#: wp-admin/index.php:82
+msgid "<strong>Site Health Status</strong> &mdash; Informs you of any potential issues that should be addressed to improve the performance or security of your website."
+msgstr ""
+
+#: wp-admin/index.php:86
+msgid "<strong>At a Glance</strong> &mdash; Displays a summary of the content on your site and identifies which theme and version of ClassicPress you are using."
+msgstr ""
+
+#: wp-admin/index.php:89
+msgid "<strong>Activity</strong> &mdash; Shows the upcoming scheduled posts, recently published posts, and the most recent comments on your posts and allows you to moderate them."
+msgstr ""
+
+#: wp-admin/index.php:92
+msgid "<strong>Quick Draft</strong> &mdash; Allows you to create a new post and save it as a draft. Also displays links to the 3 most recent draft posts you've started."
+msgstr ""
+
+#. translators: %s: ClassicPress Planet URL.
+#: wp-admin/index.php:97
+msgid "<strong>ClassicPress News</strong> &mdash; Latest news from the official <a href=\"%s\">ClassicPress blog</a>."
+msgstr ""
+
+#: wp-admin/index.php:113
+msgid "<a href=\"https://wordpress.org/support/article/dashboard-screen/\">Documentation on Dashboard</a>"
+msgstr ""
+
+#. translators: %s: Human-readable time interval.
+#: wp-admin/index.php:143
+msgid "The admin email verification page will reappear after %s."
+msgstr ""
+
+#: wp-admin/index.php:166
+msgid "Dismiss the welcome panel"
+msgstr ""
+
+#: wp-admin/install.php:73
+msgid "ClassicPress &rsaquo; Installation"
+msgstr ""
+
+#: wp-admin/install.php:108
+msgctxt "Howdy"
+msgid "Welcome"
+msgstr ""
+
+#: wp-admin/install.php:114
+#: wp-admin/options-general.php:69
+msgid "Site Title"
+msgstr ""
+
+#: wp-admin/install.php:122
+msgid "User(s) already exists."
+msgstr ""
+
+#: wp-admin/install.php:127
+msgid "Usernames can have only alphanumeric characters, spaces, underscores, hyphens, periods, and the @ symbol."
+msgstr ""
+
+#: wp-admin/install.php:144
+#: wp-admin/user-edit.php:699
+#: wp-admin/user-new.php:594
+#: wp-admin/js/user-profile.js:81
+msgid "Hide password"
+msgstr ""
+
+#: wp-admin/install.php:151
+#: wp-admin/user-edit.php:204
+msgid "Important:"
+msgstr ""
+
+#. translators: The non-breaking space prevents 1Password from thinking the text "log in" should trigger a password save prompt.
+#: wp-admin/install.php:153
+msgid "You will need this password to log&nbsp;in. Please store it in a secure location."
+msgstr ""
+
+#: wp-admin/install.php:158
+#: wp-admin/user-new.php:603
+msgid "Repeat Password"
+msgstr ""
+
+#: wp-admin/install.php:159
+#: wp-admin/user-edit.php:485
+#: wp-admin/user-edit.php:533
+#: wp-admin/user-new.php:532
+#: wp-admin/user-new.php:536
+#: wp-admin/user-new.php:583
+#: wp-admin/user-new.php:603
+msgid "(required)"
+msgstr ""
+
+#: wp-admin/install.php:167
+#: wp-admin/user-edit.php:723
+#: wp-admin/user-new.php:610
+msgid "Confirm Password"
+msgstr ""
+
+#: wp-admin/install.php:171
+#: wp-admin/user-edit.php:727
+#: wp-admin/user-new.php:614
+#: wp-admin/js/user-profile.js:52
+msgid "Confirm use of weak password"
+msgstr ""
+
+#: wp-admin/install.php:177
+msgid "Your Email"
+msgstr ""
+
+#: wp-admin/install.php:179
+msgid "Double-check your email address before continuing."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/install.php:182
+#: wp-admin/install.php:189
+#: wp-admin/options-reading.php:44
+#: wp-admin/options-reading.php:192
+#: wp-admin/options-reading.php:198
+msgid "Site visibility"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/install.php:182
+#: wp-admin/install.php:191
+#: wp-admin/options-reading.php:44
+#: wp-admin/options-reading.php:192
+#: wp-admin/options-reading.php:200
+msgid "Search engine visibility"
+msgstr ""
+
+#: wp-admin/install.php:198
+#: wp-admin/options-reading.php:205
+msgid "Allow search engines to index this site"
+msgstr ""
+
+#: wp-admin/install.php:200
+#: wp-admin/install.php:208
+#: wp-admin/options-reading.php:207
+#: wp-admin/options-reading.php:228
+msgid "Discourage search engines from indexing this site"
+msgstr ""
+
+#: wp-admin/install.php:201
+#: wp-admin/options-reading.php:208
+msgid "Note: Neither of these options blocks access to your site &mdash; it is up to search engines to honor your request."
+msgstr ""
+
+#: wp-admin/install.php:209
+#: wp-admin/options-reading.php:229
+msgid "It is up to search engines to honor this request."
+msgstr ""
+
+#: wp-admin/install.php:215
+msgid "Install ClassicPress"
+msgstr ""
+
+#: wp-admin/install.php:225
+msgid "Already Installed"
+msgstr ""
+
+#: wp-admin/install.php:226
+msgid "You appear to have already installed ClassicPress. To reinstall please clear your old database tables first."
+msgstr ""
+
+#. translators: 1: URL to ClassicPress release notes, 2: ClassicPress version number, 3: Minimum required PHP version number, 4: Minimum required MySQL version number, 5: Current PHP version number, 6: Current MySQL version number.
+#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number
+#. translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number
+#: wp-admin/install.php:266
+#: wp-admin/install.php:276
+#: wp-admin/install.php:284
+msgid "<a href=\""
+msgstr ""
+
+#: wp-admin/install.php:293
+msgid "Requirements Not Met"
+msgstr ""
+
+#: wp-admin/install.php:299
+#: wp-admin/install.php:312
+msgid "Configuration Error"
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/install.php:302
+msgid "Your %s file has an empty database table prefix, which is not supported."
+msgstr ""
+
+#. translators: %s: DO_NOT_UPGRADE_GLOBAL_TABLES
+#: wp-admin/install.php:315
+msgid "The constant %s cannot be defined when installing ClassicPress."
+msgstr ""
+
+#: wp-admin/install.php:363
+msgid "Admin Setup"
+msgstr ""
+
+#: wp-admin/install.php:365
+msgid "Give your site a great title and fill out your administrator account details. Take note of your username and password – you will need these again in a moment."
+msgstr ""
+
+#: wp-admin/install.php:396
+msgid "Please provide a valid username."
+msgstr ""
+
+#: wp-admin/install.php:399
+msgid "The username you provided has invalid characters."
+msgstr ""
+
+#: wp-admin/install.php:403
+msgid "Your passwords do not match. Please try again."
+msgstr ""
+
+#: wp-admin/install.php:407
+msgid "You must provide an email address."
+msgstr ""
+
+#: wp-admin/install.php:411
+msgid "Sorry, that is not a valid email address. Email addresses look like <code>username@example.com</code>."
+msgstr ""
+
+#: wp-admin/install.php:420
+msgid "Success!"
+msgstr ""
+
+#. translators: link to Open Collective donation page
+#: wp-admin/install.php:426
+msgid "ClassicPress has been installed. Consider making a donation to support <a href=\"%s\">ClassicPress</a>, please. Thank you, and enjoy!"
+msgstr ""
+
+#: wp-admin/link-add.php:13
+msgid "Sorry, you are not allowed to add links to this site."
+msgstr ""
+
+#: wp-admin/link-add.php:17
+msgid "Add New Link"
+msgstr ""
+
+#. translators: %s: URL to Widgets screen.
+#: wp-admin/link-manager.php:61
+msgid "You can add links here to be displayed on your site, usually using <a href=\"%s\">Widgets</a>. By default, links to several sites in the ClassicPress community are included as examples."
+msgstr ""
+
+#: wp-admin/link-manager.php:64
+msgid "Links may be separated into Link Categories; these are different than the categories used on your posts."
+msgstr ""
+
+#: wp-admin/link-manager.php:65
+msgid "You can customize the display of this screen using the Screen Options tab and/or the dropdown filters above the links table."
+msgstr ""
+
+#: wp-admin/link-manager.php:71
+msgid "Deleting Links"
+msgstr ""
+
+#: wp-admin/link-manager.php:73
+msgid "If you delete a link, it will be removed permanently, as Links do not have a Trash function yet."
+msgstr ""
+
+#: wp-admin/link-manager.php:79
+msgid "<a href=\"https://codex.wordpress.org/Links_Screen\">Documentation on Managing Links</a>"
+msgstr ""
+
+#: wp-admin/link-manager.php:85
+msgid "Links list"
+msgstr ""
+
+#. translators: %s: Number of links.
+#: wp-admin/link-manager.php:125
+msgid "%s link deleted."
+msgid_plural "%s links deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/link-manager.php:133
+msgid "Search Links"
+msgstr ""
+
+#: wp-admin/link-parse-opml.php:77
+#: wp-admin/link-parse-opml.php:78
+msgid "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension."
+msgstr ""
+
+#. translators: 1: Error message, 2: Line number.
+#: wp-admin/link-parse-opml.php:89
+msgid "XML Error: %1$s at line %2$s"
+msgstr ""
+
+#: wp-admin/link.php:112
+msgid "Edit Link"
+msgstr ""
+
+#: wp-admin/link.php:118
+msgid "Link not found."
+msgstr ""
+
+#: wp-admin/maint/repair.php:20
+msgid "ClassicPress &rsaquo; Database Repair"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/maint/repair.php:32
+msgid "Allow automatic database repair"
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/maint/repair.php:38
+msgid "To allow use of this page to automatically repair database problems, please add the following line to your %s file. Once this line is added to your config, reload this page."
+msgstr ""
+
+#. translators: This string should only be translated if wp-config-sample.php is localized. You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
+#: wp-admin/maint/repair.php:51
+msgid "put your unique phrase here"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/maint/repair.php:81
+msgid "Check secret keys"
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: Secret key service URL.
+#: wp-admin/maint/repair.php:85
+msgid "While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href=\"%2$s\">ClassicPress.net secret key service</a>."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/maint/repair.php:91
+msgid "Database repair results"
+msgstr ""
+
+#. translators: %s: Table name.
+#: wp-admin/maint/repair.php:116
+msgid "The %s table is okay."
+msgstr ""
+
+#. translators: 1: Table name, 2: Error message.
+#: wp-admin/maint/repair.php:119
+msgid "The %1$s table is not okay. It is reporting the following error: %2$s. ClassicPress will attempt to repair this table&hellip;"
+msgstr ""
+
+#. translators: %s: Table name.
+#: wp-admin/maint/repair.php:126
+msgid "Successfully repaired the %s table."
+msgstr ""
+
+#. translators: 1: Table name, 2: Error message.
+#: wp-admin/maint/repair.php:129
+msgid "Failed to repair the %1$s table. Error: %2$s"
+msgstr ""
+
+#. translators: %s: Table name.
+#: wp-admin/maint/repair.php:141
+msgid "The %s table is already optimized."
+msgstr ""
+
+#. translators: %s: Table name.
+#: wp-admin/maint/repair.php:148
+msgid "Successfully optimized the %s table."
+msgstr ""
+
+#. translators: 1: Table name. 2: Error message.
+#: wp-admin/maint/repair.php:151
+msgid "Failed to optimize the %1$s table. Error: %2$s"
+msgstr ""
+
+#. translators: %s: URL to "Fixing WordPress" forum.
+#: wp-admin/maint/repair.php:161
+msgid "Some database problems could not be repaired. Please copy-and-paste the following list of errors to the <a href=\"%s\">ClassicPress support forums</a> to get additional assistance."
+msgstr ""
+
+#: wp-admin/maint/repair.php:162
+msgid "https://wordpress.org/support/forum/how-to-and-troubleshooting"
+msgstr ""
+
+#: wp-admin/maint/repair.php:170
+msgid "Repairs complete. Please remove the following line from wp-config.php to prevent this page from being used by unauthorized users."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/maint/repair.php:176
+msgid "ClassicPress database repair"
+msgstr ""
+
+#: wp-admin/maint/repair.php:180
+msgid "One or more database tables are unavailable. To allow ClassicPress to attempt to repair these tables, press the &#8220;Repair Database&#8221; button. Repairing can take a while, so please be patient."
+msgstr ""
+
+#: wp-admin/maint/repair.php:182
+msgid "ClassicPress can automatically look for some common database problems and repair them. Repairing can take a while, so please be patient."
+msgstr ""
+
+#: wp-admin/maint/repair.php:185
+msgid "Repair Database"
+msgstr ""
+
+#: wp-admin/maint/repair.php:186
+msgid "ClassicPress can also attempt to optimize the database. This improves performance in some situations. Repairing and optimizing the database can take a long time and the database will be locked while optimizing."
+msgstr ""
+
+#: wp-admin/maint/repair.php:187
+msgid "Repair and Optimize Database"
+msgstr ""
+
+#: wp-admin/media-new.php:43
+msgid "Upload New Media"
+msgstr ""
+
+#: wp-admin/media-new.php:51
+msgid "You can upload media files here without creating a post first. This allows you to upload files to use with posts and pages later and/or to get a web link for a particular file that you can share. There are three options for uploading files:"
+msgstr ""
+
+#: wp-admin/media-new.php:53
+msgid "<strong>Drag and drop</strong> your files into the area below. Multiple files are allowed."
+msgstr ""
+
+#: wp-admin/media-new.php:54
+msgid "Clicking <strong>Select Files</strong> opens a navigation window showing you files in your operating system. Selecting <strong>Open</strong> after clicking on the file you want activates a progress bar on the uploader screen."
+msgstr ""
+
+#: wp-admin/media-new.php:55
+msgid "Revert to the <strong>Browser Uploader</strong> by clicking the link below the drag and drop box."
+msgstr ""
+
+#: wp-admin/media-new.php:61
+msgid "<a href=\"https://wordpress.org/documentation/article/media-add-new-screen/\">Documentation on Uploading Media Files</a>"
+msgstr ""
+
+#: wp-admin/media-upload.php:39
+msgid "Invalid item ID."
+msgstr ""
+
+#: wp-admin/media.php:23
+#: wp-admin/media.php:62
+msgid "Sorry, you are not allowed to edit this attachment."
+msgstr ""
+
+#: wp-admin/media.php:49
+msgid "Edit Media"
+msgstr ""
+
+#: wp-admin/media.php:68
+msgid "You attempted to edit an attachment that does not exist. Perhaps it was deleted?"
+msgstr ""
+
+#: wp-admin/media.php:71
+msgid "You attempted to edit an item that is not an attachment. Please go back and try again."
+msgstr ""
+
+#: wp-admin/media.php:74
+msgid "You cannot edit this attachment because it is in the Trash. Please move it out of the Trash and try again."
+msgstr ""
+
+#. translators: Add new file.
+#: wp-admin/media.php:130
+#: wp-admin/menu.php:69
+#: wp-admin/upload.php:175
+#: wp-admin/upload.php:373
+msgctxt "file"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/menu-header.php:296
+#: wp-admin/js/common.js:1989
+msgid "Collapse Main menu"
+msgstr ""
+
+#: wp-admin/menu-header.php:298
+msgid "Collapse menu"
+msgstr ""
+
+#: wp-admin/menu-header.php:304
+msgid "Main menu"
+msgstr ""
+
+#: wp-admin/menu-header.php:305
+msgid "Skip to main content"
+msgstr ""
+
+#: wp-admin/menu-header.php:306
+msgid "Skip to toolbar"
+msgstr ""
+
+#: wp-admin/menu.php:26
+msgid "Home"
+msgstr ""
+
+#: wp-admin/menu.php:29
+msgid "My Sites"
+msgstr ""
+
+#. translators: %s: Number of pending updates.
+#: wp-admin/menu.php:49
+msgid "Updates %s"
+msgstr ""
+
+#: wp-admin/menu.php:67
+msgid "Library"
+msgstr ""
+
+#: wp-admin/menu.php:81
+msgctxt "admin menu"
+msgid "All Links"
+msgstr ""
+
+#: wp-admin/menu.php:84
+msgid "Link Categories"
+msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-admin/menu.php:98
+msgid "Comments %s"
+msgstr ""
+
+#: wp-admin/menu.php:109
+msgid "All Comments"
+msgstr ""
+
+#: wp-admin/menu.php:188
+msgid "Appearance"
+msgstr ""
+
+#. translators: %s: Number of available theme updates.
+#: wp-admin/menu.php:203
+msgid "Themes %s"
+msgstr ""
+
+#: wp-admin/menu.php:210
+#: wp-admin/nav-menus.php:32
+#: wp-admin/nav-menus.php:700
+msgid "Menus"
+msgstr ""
+
+#: wp-admin/menu.php:240
+msgctxt "theme editor"
+msgid "Editor"
+msgstr ""
+
+#. translators: %s: Number of available plugin updates.
+#: wp-admin/menu.php:256
+msgid "Plugins %s"
+msgstr ""
+
+#: wp-admin/menu.php:258
+msgid "Installed Plugins"
+msgstr ""
+
+#. translators: Add new plugin.
+#: wp-admin/menu.php:262
+#: wp-admin/plugins.php:729
+msgctxt "plugin"
+msgid "Upload"
+msgstr ""
+
+#: wp-admin/menu.php:263
+#: wp-admin/plugins.php:728
+msgctxt "plugin"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/menu.php:264
+msgid "Plugin File Editor"
+msgstr ""
+
+#: wp-admin/menu.php:270
+#: wp-admin/users.php:25
+msgid "Users"
+msgstr ""
+
+#: wp-admin/menu.php:272
+#: wp-admin/menu.php:284
+#: wp-admin/menu.php:287
+#: wp-admin/user-edit.php:40
+#: wp-admin/user/menu.php:14
+msgid "Profile"
+msgstr ""
+
+#: wp-admin/menu.php:277
+msgid "All Users"
+msgstr ""
+
+#: wp-admin/menu.php:279
+#: wp-admin/menu.php:281
+#: wp-admin/user-edit.php:241
+#: wp-admin/users.php:628
+msgctxt "user"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/menu.php:289
+#: wp-admin/menu.php:291
+#: wp-admin/user-new.php:255
+#: wp-admin/user-new.php:377
+#: wp-admin/user-new.php:504
+#: wp-admin/user-new.php:656
+msgid "Add New User"
+msgstr ""
+
+#: wp-admin/menu.php:320
+#: wp-admin/tools.php:43
+msgid "Tools"
+msgstr ""
+
+#: wp-admin/menu.php:321
+msgid "Available Tools"
+msgstr ""
+
+#. translators: %s: Number of critical Site Health checks.
+#: wp-admin/menu.php:325
+msgid "Site Health %s"
+msgstr ""
+
+#: wp-admin/menu.php:329
+msgid "Delete Site"
+msgstr ""
+
+#: wp-admin/menu.php:332
+msgid "Network Setup"
+msgstr ""
+
+#: wp-admin/menu.php:335
+#: wp-admin/options.php:22
+msgid "Settings"
+msgstr ""
+
+#: wp-admin/menu.php:336
+msgctxt "settings screen"
+msgid "General"
+msgstr ""
+
+#: wp-admin/menu.php:337
+msgid "Writing"
+msgstr ""
+
+#: wp-admin/menu.php:338
+msgid "Reading"
+msgstr ""
+
+#: wp-admin/menu.php:341
+msgid "Permalinks"
+msgstr ""
+
+#: wp-admin/nav-menus.php:19
+msgid "Your theme does not support navigation menus or widgets."
+msgstr ""
+
+#: wp-admin/nav-menus.php:26
+#: wp-admin/themes.php:15
+#: wp-admin/widgets.php:18
+msgid "Sorry, you are not allowed to edit theme options on this site."
+msgstr ""
+
+#: wp-admin/nav-menus.php:284
+msgid "The menu item has been successfully deleted."
+msgstr ""
+
+#: wp-admin/nav-menus.php:307
+msgid "The menu has been successfully deleted."
+msgstr ""
+
+#: wp-admin/nav-menus.php:329
+msgid "Selected menus have been successfully deleted."
+msgstr ""
+
+#: wp-admin/nav-menus.php:403
+#: wp-admin/nav-menus.php:425
+msgid "Please enter a valid menu name."
+msgstr ""
+
+#: wp-admin/nav-menus.php:471
+msgid "Menu locations updated."
+msgstr ""
+
+#: wp-admin/nav-menus.php:502
+msgid "Move up one"
+msgstr ""
+
+#: wp-admin/nav-menus.php:503
+msgid "Move down one"
+msgstr ""
+
+#: wp-admin/nav-menus.php:504
+msgid "Move to the top"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-admin/nav-menus.php:506
+msgid "Move under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-admin/nav-menus.php:508
+msgid "Move out from under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-admin/nav-menus.php:510
+msgid "Under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-admin/nav-menus.php:512
+msgid "Out from under %s"
+msgstr ""
+
+#. translators: 1: Item name, 2: Item position, 3: Total number of items.
+#: wp-admin/nav-menus.php:514
+msgid "%1$s. Menu item %2$d of %3$d."
+msgstr ""
+
+#. translators: 1: Item name, 2: Item position, 3: Parent item name.
+#: wp-admin/nav-menus.php:516
+msgid "%1$s. Sub item number %2$d under %3$s."
+msgstr ""
+
+#. translators: %s: Item name.
+#: wp-admin/nav-menus.php:518
+msgid "item %s"
+msgstr ""
+
+#. translators: %s: Item name.
+#: wp-admin/nav-menus.php:520
+msgid "Deleted menu item: %s."
+msgstr ""
+
+#: wp-admin/nav-menus.php:521
+msgid "Menu item added"
+msgstr ""
+
+#: wp-admin/nav-menus.php:522
+msgid "Menu item removed"
+msgstr ""
+
+#: wp-admin/nav-menus.php:523
+msgid "Menu item moved up"
+msgstr ""
+
+#: wp-admin/nav-menus.php:524
+msgid "Menu item moved down"
+msgstr ""
+
+#: wp-admin/nav-menus.php:525
+msgid "Menu item moved to the top"
+msgstr ""
+
+#: wp-admin/nav-menus.php:526
+msgid "Menu item moved out of submenu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:527
+msgid "Menu item is now a sub-item"
+msgstr ""
+
+#: wp-admin/nav-menus.php:528
+msgid "menu position"
+msgstr ""
+
+#: wp-admin/nav-menus.php:529
+msgid "moved to"
+msgstr ""
+
+#. translators: %s: URL to Widgets screen.
+#: wp-admin/nav-menus.php:622
+msgid "Your theme does not natively support menus, but you can use them in sidebars by adding a &#8220;Navigation Menu&#8221; widget on the <a href=\"%s\">Widgets</a> screen."
+msgstr ""
+
+#: wp-admin/nav-menus.php:628
+msgid "This screen is used for managing your navigation menus."
+msgstr ""
+
+#. translators: 1: URL to Widgets screen, 2 and 3: The names of the default themes.
+#: wp-admin/nav-menus.php:631
+msgid "Menus can be displayed in locations defined by your theme, even used in sidebars by adding a &#8220;Navigation Menu&#8221; widget on the <a href=\"%1$s\">Widgets</a> screen. If your theme does not support the navigation menus feature (the default themes, %2$s and %3$s, do), you can learn about adding this support by following the documentation link to the side."
+msgstr ""
+
+#: wp-admin/nav-menus.php:636
+#: wp-admin/themes.php:133
+msgid "From this screen you can:"
+msgstr ""
+
+#: wp-admin/nav-menus.php:637
+msgid "Create, edit, and delete menus"
+msgstr ""
+
+#: wp-admin/nav-menus.php:638
+msgid "Add, organize, and modify individual menu items"
+msgstr ""
+
+#: wp-admin/nav-menus.php:648
+msgid "The menu management box at the top of the screen is used to control which menu is opened in the editor below."
+msgstr ""
+
+#: wp-admin/nav-menus.php:649
+msgid "To edit an existing menu, <strong>choose a menu from the dropdown and click Select</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:650
+msgid "If you have not yet created any menus, <strong>click the &#8217;create a new menu&#8217; link</strong> to get started"
+msgstr ""
+
+#: wp-admin/nav-menus.php:651
+msgid "You can assign theme locations to individual menus by <strong>selecting the desired settings</strong> at the bottom of the menu editor. To assign menus to all theme locations at once, <strong>visit the Manage Locations tab</strong> at the top of the screen."
+msgstr ""
+
+#: wp-admin/nav-menus.php:656
+msgid "Menu Management"
+msgstr ""
+
+#: wp-admin/nav-menus.php:661
+msgid "Each navigation menu may contain a mix of links to pages, categories, custom URLs or other content types. Menu links are added by selecting items from the expanding boxes in the left-hand column below."
+msgstr ""
+
+#: wp-admin/nav-menus.php:662
+msgid "<strong>Clicking the arrow to the right of any menu item</strong> in the editor will reveal a standard group of settings. Additional settings such as link target, CSS classes, link relationships, and link descriptions can be enabled and disabled via the Screen Options tab."
+msgstr ""
+
+#: wp-admin/nav-menus.php:663
+msgid "Add one or several items at once by <strong>selecting the checkbox next to each item and clicking Add to Menu</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:664
+msgid "To add a custom link, <strong>expand the Custom Links section, enter a URL and link text, and click Add to Menu</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:665
+msgid "To reorganize menu items, <strong>drag and drop items with your mouse or use your keyboard</strong>. Drag or move a menu item a little to the right to make it a submenu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:666
+msgid "Delete a menu item by <strong>expanding it and clicking the Remove link</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:671
+msgid "Editing Menus"
+msgstr ""
+
+#: wp-admin/nav-menus.php:676
+msgid "This screen is used for globally assigning menus to locations defined by your theme."
+msgstr ""
+
+#: wp-admin/nav-menus.php:677
+msgid "To assign menus to one or more theme locations, <strong>select a menu from each location&#8217;s dropdown</strong>. When you are finished, <strong>click Save Changes</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:678
+msgid "To edit a menu currently assigned to a theme location, <strong>click the adjacent &#8217;Edit&#8217; link</strong>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:679
+msgid "To add a new menu instead of assigning an existing one, <strong>click the &#8217;Use new menu&#8217; link</strong>. Your new menu will be automatically assigned to that theme location"
+msgstr ""
+
+#: wp-admin/nav-menus.php:692
+msgid "<a href=\"https://wordpress.org/documentation/article/appearance-menus-screen/\">Documentation on Menus</a>"
+msgstr ""
+
+#: wp-admin/nav-menus.php:715
+#: wp-admin/widgets-form.php:393
+msgid "Manage with Live Preview"
+msgstr ""
+
+#: wp-admin/nav-menus.php:730
+#: wp-admin/options-privacy.php:161
+#: wp-admin/privacy-policy-guide.php:44
+#: wp-admin/site-health.php:131
+msgid "Secondary menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:731
+msgid "Edit Menus"
+msgstr ""
+
+#: wp-admin/nav-menus.php:742
+msgid "Manage Locations"
+msgstr ""
+
+#: wp-admin/nav-menus.php:755
+msgid "Your theme supports one menu. Select which menu you would like to use."
+msgstr ""
+
+#. translators: %s: Number of menus.
+#: wp-admin/nav-menus.php:759
+msgid "Your theme supports %s menu. Select which menu appears in each location."
+msgid_plural "Your theme supports %s menus. Select which menu appears in each location."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/nav-menus.php:773
+msgid "Theme Location"
+msgstr ""
+
+#: wp-admin/nav-menus.php:774
+msgid "Assigned Menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:783
+msgid "Select a Menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:814
+msgctxt "menu"
+msgid "Edit"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/nav-menus.php:817
+msgid "Edit selected menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:838
+msgctxt "menu"
+msgid "Use new menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:864
+msgid "Create your first menu below."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/nav-menus.php:868
+msgid "Fill in the Menu Name and click the Create Menu button to create your first menu."
+msgstr ""
+
+#. translators: %s: URL to create a new menu.
+#: wp-admin/nav-menus.php:877
+msgid "Edit your menu below, or <a href=\"%s\">create a new menu</a>. Do not forget to save your changes!"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/nav-menus.php:892
+#: wp-admin/nav-menus.php:962
+msgid "Click the Save Menu button to save your changes."
+msgstr ""
+
+#: wp-admin/nav-menus.php:899
+msgid "Select a menu to edit:"
+msgstr ""
+
+#. translators: %s: URL to create a new menu.
+#: wp-admin/nav-menus.php:947
+msgid "or <a href=\"%s\">create a new menu</a>. Do not forget to save your changes!"
+msgstr ""
+
+#: wp-admin/nav-menus.php:986
+msgid "Add menu items"
+msgstr ""
+
+#: wp-admin/nav-menus.php:994
+msgid "Menu structure"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1017
+msgid "Menu Name"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1020
+#: wp-admin/nav-menus.php:1157
+msgid "Create Menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1020
+#: wp-admin/nav-menus.php:1157
+msgid "Save Menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1035
+msgid "Edit your default menu by adding or removing items. Drag the items into the order you prefer. Click Create Menu to save your changes."
+msgstr ""
+
+#: wp-admin/nav-menus.php:1037
+msgid "Drag the items into the order you prefer. Click the arrow on the left of the item to reveal additional configuration options."
+msgstr ""
+
+#: wp-admin/nav-menus.php:1048
+#: wp-admin/nav-menus.php:1083
+msgid "Bulk Select"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1064
+msgid "Give your menu a name, then click Create Menu."
+msgstr ""
+
+#: wp-admin/nav-menus.php:1085
+msgid "Remove Selected Items"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1087
+msgid "List of menu items selected for deletion:"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1094
+msgid "Menu Settings"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1110
+msgid "Auto add pages"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1112
+msgid "Automatically add new top-level pages to this menu"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1119
+msgid "Display location"
+msgstr ""
+
+#. translators: %s: Menu name.
+#: wp-admin/nav-menus.php:1139
+msgctxt "menu location"
+msgid "(Currently set to: %s)"
+msgstr ""
+
+#: wp-admin/nav-menus.php:1182
+msgid "Delete Menu"
+msgstr ""
+
+#: wp-admin/options-discussion.php:12
+#: wp-admin/options-general.php:16
+#: wp-admin/options-media.php:13
+#: wp-admin/options-permalink.php:13
+#: wp-admin/options-reading.php:13
+#: wp-admin/options-writing.php:13
+#: wp-admin/options.php:51
+msgid "Sorry, you are not allowed to manage options for this site."
+msgstr ""
+
+#: wp-admin/options-discussion.php:25
+msgid "This screen provides many options for controlling the management and display of comments and links to your posts/pages. So many, in fact, they will not all fit here! :) Use the documentation links to get information on what each discussion setting does."
+msgstr ""
+
+#: wp-admin/options-discussion.php:26
+#: wp-admin/options-general.php:41
+#: wp-admin/options-media.php:29
+#: wp-admin/options-permalink.php:26
+#: wp-admin/options-permalink.php:46
+#: wp-admin/options-permalink.php:55
+#: wp-admin/options-reading.php:37
+#: wp-admin/options-writing.php:25
+msgid "You must click the Save Changes button at the bottom of the screen for new settings to take effect."
+msgstr ""
+
+#: wp-admin/options-discussion.php:32
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-discussion-screen/\">Documentation on Discussion Settings</a>"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:47
+#: wp-admin/options-discussion.php:51
+msgid "Default post settings"
+msgstr ""
+
+#: wp-admin/options-discussion.php:56
+msgid "Attempt to notify any blogs linked to from the post"
+msgstr ""
+
+#: wp-admin/options-discussion.php:60
+msgid "Allow link notifications from other blogs (pingbacks and trackbacks) on new posts"
+msgstr ""
+
+#: wp-admin/options-discussion.php:64
+msgid "Allow people to submit comments on new posts"
+msgstr ""
+
+#: wp-admin/options-discussion.php:66
+msgid "Individual posts may override these settings. Changes here will only be applied to new posts."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:70
+#: wp-admin/options-discussion.php:74
+msgid "Other comment settings"
+msgstr ""
+
+#: wp-admin/options-discussion.php:77
+msgid "Comment author must fill out name and email"
+msgstr ""
+
+#: wp-admin/options-discussion.php:81
+msgid "Users must be registered and logged in to comment"
+msgstr ""
+
+#: wp-admin/options-discussion.php:84
+msgid "(Signup has been disabled. Only members of this site can comment.)"
+msgstr ""
+
+#. translators: %s: Number of days.
+#: wp-admin/options-discussion.php:95
+msgid "Automatically close comments on posts older than %s days"
+msgstr ""
+
+#: wp-admin/options-discussion.php:104
+msgid "Show comments cookies opt-in checkbox, allowing comment author cookies to be set"
+msgstr ""
+
+#. translators: %s: Number of levels.
+#: wp-admin/options-discussion.php:131
+msgid "Enable threaded (nested) comments %s levels deep"
+msgstr ""
+
+#: wp-admin/options-discussion.php:143
+msgid "last"
+msgstr ""
+
+#: wp-admin/options-discussion.php:147
+msgid "first"
+msgstr ""
+
+#. translators: 1: Form field control for number of top level comments per page, 2: Form field control for the 'first' or 'last' page.
+#: wp-admin/options-discussion.php:150
+msgid "Break comments into pages with %1$s top level comments per page and the %2$s page displayed by default"
+msgstr ""
+
+#: wp-admin/options-discussion.php:164
+msgid "older"
+msgstr ""
+
+#: wp-admin/options-discussion.php:168
+msgid "newer"
+msgstr ""
+
+#. translators: %s: Form field control for 'older' or 'newer' comments.
+#: wp-admin/options-discussion.php:171
+msgid "Comments should be displayed with the %s comments at the top of each page"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:178
+#: wp-admin/options-discussion.php:182
+msgid "Email me whenever"
+msgstr ""
+
+#: wp-admin/options-discussion.php:187
+msgid "Anyone posts a comment"
+msgstr ""
+
+#: wp-admin/options-discussion.php:191
+msgid "A comment is held for moderation"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:195
+#: wp-admin/options-discussion.php:199
+msgid "Before a comment appears"
+msgstr ""
+
+#: wp-admin/options-discussion.php:204
+msgid "Comment must be manually approved"
+msgstr ""
+
+#: wp-admin/options-discussion.php:206
+msgid "Comment author must have a previously approved comment"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:210
+#: wp-admin/options-discussion.php:214
+msgid "Comment Moderation"
+msgstr ""
+
+#. translators: %s: Number of links.
+#: wp-admin/options-discussion.php:221
+msgid "Hold a comment in the queue if it contains %s or more links. (A common characteristic of comment spam is a large number of hyperlinks.)"
+msgstr ""
+
+#: wp-admin/options-discussion.php:227
+msgid "When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be held in the <a href=\"edit-comments.php?comment_status=moderated\">moderation queue</a>. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;ClassicPress&#8221;."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:234
+#: wp-admin/options-discussion.php:238
+msgid "Disallowed Comment Keys"
+msgstr ""
+
+#: wp-admin/options-discussion.php:241
+msgid "When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be put in the Trash. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;ClassicPress&#8221;."
+msgstr ""
+
+#: wp-admin/options-discussion.php:250
+msgid "Avatars"
+msgstr ""
+
+#: wp-admin/options-discussion.php:252
+msgid "An avatar is an image that can be associated with a user across multiple websites. In this area, you can choose to display avatars of users who interact with the site."
+msgstr ""
+
+#: wp-admin/options-discussion.php:266
+msgid "Avatar Display"
+msgstr ""
+
+#: wp-admin/options-discussion.php:270
+msgid "Show Avatars"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:275
+#: wp-admin/options-discussion.php:279
+msgid "Maximum Rating"
+msgstr ""
+
+#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
+#: wp-admin/options-discussion.php:286
+msgid "G &#8212; Suitable for all audiences"
+msgstr ""
+
+#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
+#: wp-admin/options-discussion.php:288
+msgid "PG &#8212; Possibly offensive, usually for audiences 13 and above"
+msgstr ""
+
+#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
+#: wp-admin/options-discussion.php:290
+msgid "R &#8212; Intended for adult audiences above 17"
+msgstr ""
+
+#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
+#: wp-admin/options-discussion.php:292
+msgid "X &#8212; Even more mature than above"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-discussion.php:303
+#: wp-admin/options-discussion.php:307
+msgid "Default Avatar"
+msgstr ""
+
+#: wp-admin/options-discussion.php:312
+msgid "For users without a custom avatar of their own, you can either display a generic logo or a generated one based on their email address."
+msgstr ""
+
+#: wp-admin/options-discussion.php:317
+msgid "Mystery Person"
+msgstr ""
+
+#: wp-admin/options-discussion.php:318
+msgid "Blank"
+msgstr ""
+
+#: wp-admin/options-discussion.php:319
+msgid "Gravatar Logo"
+msgstr ""
+
+#: wp-admin/options-discussion.php:320
+msgid "Identicon (Generated)"
+msgstr ""
+
+#: wp-admin/options-discussion.php:321
+msgid "Wavatar (Generated)"
+msgstr ""
+
+#: wp-admin/options-discussion.php:322
+msgid "MonsterID (Generated)"
+msgstr ""
+
+#: wp-admin/options-discussion.php:323
+msgid "Retro (Generated)"
+msgstr ""
+
+#: wp-admin/options-discussion.php:324
+msgid "RoboHash (Generated)"
+msgstr ""
+
+#: wp-admin/options-general.php:20
+msgid "General Settings"
+msgstr ""
+
+#. translators: Date and time format for exact current time, mainly about timezones, see https://www.php.net/manual/datetime.format.php
+#: wp-admin/options-general.php:23
+msgctxt "timezone date format"
+msgid "Y-m-d H:i:s"
+msgstr ""
+
+#: wp-admin/options-general.php:31
+msgid "The fields on this screen determine some of the basics of your site setup."
+msgstr ""
+
+#: wp-admin/options-general.php:32
+msgid "Most themes show the site title at the top of every page, in the title bar of the browser, and as the identifying name for syndicated feeds. Many themes also show the tagline."
+msgstr ""
+
+#: wp-admin/options-general.php:35
+msgid "The ClassicPress URL and the site URL can be the same (example.com) or different; for example, having the ClassicPress core files (example.com/classicpress) in a subdirectory instead of the root directory."
+msgstr ""
+
+#: wp-admin/options-general.php:36
+msgid "If you want site visitors to be able to register themselves, as opposed to by the site administrator, check the membership box. A default user role can be set for all new users, whether self-registered or registered by the site admin."
+msgstr ""
+
+#: wp-admin/options-general.php:39
+msgid "You can set the language, and the translation files will be automatically downloaded and installed (available if your filesystem is writable)."
+msgstr ""
+
+#: wp-admin/options-general.php:40
+msgid "UTC means Coordinated Universal Time."
+msgstr ""
+
+#: wp-admin/options-general.php:53
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-general-screen/\">Documentation on General Settings</a>"
+msgstr ""
+
+#. translators: Site tagline.
+#: wp-admin/options-general.php:75
+msgid "Just another ClassicPress site"
+msgstr ""
+
+#. translators: %s: Network title.
+#: wp-admin/options-general.php:78
+msgid "Just another %s site"
+msgstr ""
+
+#: wp-admin/options-general.php:82
+msgid "Tagline"
+msgstr ""
+
+#: wp-admin/options-general.php:84
+msgid "In a few words, explain what this site is about."
+msgstr ""
+
+#. translators: %s: The selected image filename.
+#: wp-admin/options-general.php:119
+#: wp-admin/js/site-icon.js:161
+msgid "App icon preview: The current image has no alternative text. The file name is: %s"
+msgstr ""
+
+#. translators: %s: The selected image filename.
+#: wp-admin/options-general.php:125
+#: wp-admin/js/site-icon.js:168
+msgid "Browser icon preview: The current image has no alternative text. The file name is: %s"
+msgstr ""
+
+#. translators: %s: The selected image alt text.
+#: wp-admin/options-general.php:132
+#: wp-admin/js/site-icon.js:150
+msgid "App icon preview: Current image: %s"
+msgstr ""
+
+#. translators: %s: The selected image alt text.
+#: wp-admin/options-general.php:138
+#: wp-admin/js/site-icon.js:155
+msgid "Browser icon preview: Current image: %s"
+msgstr ""
+
+#: wp-admin/options-general.php:165
+#: wp-admin/options-general.php:174
+msgid "Choose a Site Icon"
+msgstr ""
+
+#: wp-admin/options-general.php:166
+#: wp-admin/options-general.php:172
+msgid "Change Site Icon"
+msgstr ""
+
+#: wp-admin/options-general.php:167
+msgid "Set as Site Icon"
+msgstr ""
+
+#: wp-admin/options-general.php:182
+msgid "Remove Site Icon"
+msgstr ""
+
+#. translators: %s: Site Icon size in pixels.
+#: wp-admin/options-general.php:189
+msgid "The Site Icon is what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. It should be square and at least %s pixels."
+msgstr ""
+
+#: wp-admin/options-general.php:212
+msgid "ClassicPress Address (URL)"
+msgstr ""
+
+#: wp-admin/options-general.php:217
+msgid "Site Address (URL)"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/options-general.php:224
+msgid "Enter the same address here unless you <a href=\"%s\">want your site home page to be different from your ClassicPress installation directory</a>."
+msgstr ""
+
+#: wp-admin/options-general.php:225
+msgid "https://wordpress.org/documentation/article/giving-wordpress-its-own-directory/"
+msgstr ""
+
+#: wp-admin/options-general.php:236
+msgid "Administration Email Address"
+msgstr ""
+
+#: wp-admin/options-general.php:238
+msgid "This address is used for admin purposes. If you change this, an email will be sent to your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>"
+msgstr ""
+
+#. translators: %s: New admin email.
+#: wp-admin/options-general.php:248
+msgid "There is a pending change of the admin email to %s."
+msgstr ""
+
+#: wp-admin/options-general.php:285
+#: wp-admin/options-general.php:288
+msgid "Custom Login Image"
+msgstr ""
+
+#: wp-admin/options-general.php:290
+msgid "If you choose an image here and enable this option, then that image will be shown at the top of the login page instead of the ClassicPress logo."
+msgstr ""
+
+#: wp-admin/options-general.php:292
+#: wp-admin/options-general.php:644
+msgid "Learn more."
+msgstr ""
+
+#: wp-admin/options-general.php:297
+msgid "No custom image: use the <strong>ClassicPress logo</strong>"
+msgstr ""
+
+#: wp-admin/options-general.php:307
+msgid "Use my custom image as a <strong>logo</strong>"
+msgstr ""
+
+#: wp-admin/options-general.php:317
+msgid "Use my custom image as a <strong>banner</strong>"
+msgstr ""
+
+#: wp-admin/options-general.php:323
+msgid "Clear Image"
+msgstr ""
+
+#: wp-admin/options-general.php:327
+msgid "Changing the custom login image requires JavaScript to be enabled."
+msgstr ""
+
+#: wp-admin/options-general.php:345
+msgid "Anyone can register"
+msgstr ""
+
+#: wp-admin/options-general.php:350
+msgid "New User Default Role"
+msgstr ""
+
+#. translators: 1: WPLANG, 2: wp-config.php
+#: wp-admin/options-general.php:392
+msgid "The %1$s constant in your %2$s file is no longer needed."
+msgstr ""
+
+#. translators: %s: UTC abbreviation
+#: wp-admin/options-general.php:436
+msgid "Choose either a city in the same timezone as you or a %s (Coordinated Universal Time) time offset."
+msgstr ""
+
+#. translators: %s: UTC time.
+#: wp-admin/options-general.php:447
+msgid "Universal time is %s."
+msgstr ""
+
+#. translators: %s: Local time.
+#: wp-admin/options-general.php:457
+msgid "Local time is %s."
+msgstr ""
+
+#: wp-admin/options-general.php:473
+msgid "This timezone is currently in daylight saving time."
+msgstr ""
+
+#: wp-admin/options-general.php:475
+msgid "This timezone is currently in standard time."
+msgstr ""
+
+#. translators: %s: Date and time.
+#: wp-admin/options-general.php:488
+msgid "Daylight saving time begins on: %s."
+msgstr ""
+
+#. translators: %s: Date and time.
+#: wp-admin/options-general.php:490
+msgid "Standard time begins on: %s."
+msgstr ""
+
+#: wp-admin/options-general.php:496
+msgid "This timezone does not observe daylight saving time."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:507
+#: wp-admin/options-general.php:512
+msgid "Date Format"
+msgstr ""
+
+#: wp-admin/options-general.php:539
+#: wp-admin/options-general.php:587
+msgid "Custom:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:541
+msgid "enter a custom date format in the following field"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:545
+msgid "Custom date format:"
+msgstr ""
+
+#: wp-admin/options-general.php:549
+#: wp-admin/options-general.php:597
+msgid "Preview:"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:556
+#: wp-admin/options-general.php:561
+msgid "Time Format"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:589
+msgid "enter a custom time format in the following field"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-general.php:593
+msgid "Custom time format:"
+msgstr ""
+
+#: wp-admin/options-general.php:600
+msgid "<a href=\"https://wordpress.org/documentation/article/customize-date-and-time-format/\">Documentation on date and time formatting</a>."
+msgstr ""
+
+#: wp-admin/options-general.php:606
+msgid "Week Starts On"
+msgstr ""
+
+#: wp-admin/options-general.php:624
+msgid "Blocks Compatibility"
+msgstr ""
+
+#: wp-admin/options-general.php:630
+msgctxt "Block Compatibility"
+msgid "Off"
+msgstr ""
+
+#: wp-admin/options-general.php:631
+msgctxt "Block Compatibility"
+msgid "On"
+msgstr ""
+
+#: wp-admin/options-general.php:632
+msgctxt "Block Compatibility"
+msgid "Troubleshooting"
+msgstr ""
+
+#: wp-admin/options-general.php:642
+msgid "ClassicPress is incompatible with the block editor. When blocks compatibility is turned on (default), it allows more plugins and themes to work but block-related features will not work. "
+msgstr ""
+
+#: wp-admin/options-head.php:15
+#: wp-admin/options.php:349
+msgid "Settings saved."
+msgstr ""
+
+#: wp-admin/options-media.php:17
+msgid "Media Settings"
+msgstr ""
+
+#: wp-admin/options-media.php:20
+msgid "You can set maximum sizes for images inserted into your written content; you can also insert an image as Full Size."
+msgstr ""
+
+#: wp-admin/options-media.php:26
+msgid "Uploading Files allows you to choose the folder and path for storing your uploaded files."
+msgstr ""
+
+#: wp-admin/options-media.php:41
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-media-screen/\">Documentation on Media Settings</a>"
+msgstr ""
+
+#: wp-admin/options-media.php:55
+msgid "Image sizes"
+msgstr ""
+
+#: wp-admin/options-media.php:56
+msgid "The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-media.php:60
+#: wp-admin/options-media.php:64
+msgid "Thumbnail size"
+msgstr ""
+
+#: wp-admin/options-media.php:67
+msgid "Width"
+msgstr ""
+
+#: wp-admin/options-media.php:70
+msgid "Height"
+msgstr ""
+
+#: wp-admin/options-media.php:74
+msgid "Crop thumbnail to exact dimensions (normally thumbnails are proportional)"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-media.php:79
+#: wp-admin/options-media.php:83
+msgid "Medium size"
+msgstr ""
+
+#: wp-admin/options-media.php:86
+#: wp-admin/options-media.php:102
+msgid "Max Width"
+msgstr ""
+
+#: wp-admin/options-media.php:89
+#: wp-admin/options-media.php:105
+msgid "Max Height"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-media.php:95
+#: wp-admin/options-media.php:99
+msgid "Large size"
+msgstr ""
+
+#: wp-admin/options-media.php:119
+msgid "Embeds"
+msgstr ""
+
+#: wp-admin/options-media.php:126
+msgid "Uploading Files"
+msgstr ""
+
+#: wp-admin/options-media.php:138
+msgid "Store uploads in this folder"
+msgstr ""
+
+#. translators: %s: wp-content/uploads
+#: wp-admin/options-media.php:143
+msgid "Default is %s"
+msgstr ""
+
+#: wp-admin/options-media.php:150
+msgid "Full URL path to files"
+msgstr ""
+
+#: wp-admin/options-media.php:152
+msgid "Configuring this is optional. By default, it should be blank."
+msgstr ""
+
+#: wp-admin/options-media.php:163
+msgid "Organize my uploads into month- and year-based folders"
+msgstr ""
+
+#: wp-admin/options-permalink.php:17
+#: wp-admin/options-permalink.php:33
+msgid "Permalink Settings"
+msgstr ""
+
+#: wp-admin/options-permalink.php:24
+msgid "Permalinks are the permanent URLs to your individual pages and blog posts, as well as your category and tag archives. A permalink is the web address used to link to your content. The URL to each post should be permanent, and never change &#8212; hence the name permalink."
+msgstr ""
+
+#: wp-admin/options-permalink.php:25
+msgid "This screen allows you to choose your permalink structure. You can choose from common settings or create custom URL structures."
+msgstr ""
+
+#: wp-admin/options-permalink.php:34
+msgid "Permalinks can contain useful information, such as the post date, title, or other elements. You can choose from any of the suggested permalink formats, or you can craft your own if you select Custom Structure."
+msgstr ""
+
+#. translators: %s: Percent sign (%).
+#: wp-admin/options-permalink.php:37
+msgid "If you pick an option other than Plain, your general URL path with structure tags (terms surrounded by %s) will also appear in the custom structure field and your path can be further modified there."
+msgstr ""
+
+#. translators: 1: %category%, 2: %tag%
+#: wp-admin/options-permalink.php:42
+msgid "When you assign multiple categories or tags to a post, only one can show up in the permalink: the lowest numbered category. This applies if your custom structure includes %1$s or %2$s."
+msgstr ""
+
+#: wp-admin/options-permalink.php:53
+msgid "Custom Structures"
+msgstr ""
+
+#: wp-admin/options-permalink.php:54
+msgid "The Optional fields let you customize the &#8220;category&#8221; and &#8220;tag&#8221; base names that will appear in archive URLs. For example, the page listing all posts in the &#8220;Uncategorized&#8221; category could be <code>/topics/uncategorized</code> instead of <code>/category/uncategorized</code>."
+msgstr ""
+
+#: wp-admin/options-permalink.php:60
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-permalinks-screen/\">Documentation on Permalinks Settings</a>"
+msgstr ""
+
+#: wp-admin/options-permalink.php:61
+msgid "<a href=\"https://wordpress.org/documentation/article/customize-permalinks/\">Documentation on Using Permalinks</a>"
+msgstr ""
+
+#: wp-admin/options-permalink.php:64
+msgid "<a href=\"https://wordpress.org/documentation/article/nginx/\">Documentation on Nginx configuration</a>."
+msgstr ""
+
+#: wp-admin/options-permalink.php:176
+msgid "Permalink structure updated."
+msgstr ""
+
+#. translators: %s: web.config
+#. translators: %s: .htaccess
+#: wp-admin/options-permalink.php:183
+#: wp-admin/options-permalink.php:196
+msgid "You should update your %s file now."
+msgstr ""
+
+#. translators: %s: web.config
+#: wp-admin/options-permalink.php:189
+msgid "Permalink structure updated. Remove write access on %s file now!"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/options-permalink.php:226
+msgid "ClassicPress offers you the ability to create a custom URL structure for your permalinks and archives. Custom URL structures can improve the aesthetics, usability, and forward-compatibility of your links. A <a href=\"%s\">number of tags are available</a>, and here are some examples to get you started."
+msgstr ""
+
+#: wp-admin/options-permalink.php:227
+msgid "https://wordpress.org/support/article/using-permalinks/"
+msgstr ""
+
+#: wp-admin/options-permalink.php:246
+msgid "Plain"
+msgstr ""
+
+#: wp-admin/options-permalink.php:252
+msgid "Day and name"
+msgstr ""
+
+#: wp-admin/options-permalink.php:254
+#: wp-admin/options-permalink.php:260
+#: wp-admin/options-permalink.php:272
+msgctxt "sample permalink structure"
+msgid "sample-post"
+msgstr ""
+
+#: wp-admin/options-permalink.php:258
+msgid "Month and name"
+msgstr ""
+
+#: wp-admin/options-permalink.php:264
+msgid "Numeric"
+msgstr ""
+
+#: wp-admin/options-permalink.php:265
+#: wp-admin/options-permalink.php:266
+msgctxt "sample permalink base"
+msgid "archives"
+msgstr ""
+
+#: wp-admin/options-permalink.php:270
+msgid "Post name"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:280
+msgid "%s (The year of the post, four digits, for example 2004.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:282
+msgid "%s (Month of the year, for example 05.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:284
+msgid "%s (Day of the month, for example 28.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:286
+msgid "%s (Hour of the day, for example 15.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:288
+msgid "%s (Minute of the hour, for example 43.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:290
+msgid "%s (Second of the minute, for example 33.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:292
+msgid "%s (The unique ID of the post, for example 423.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:294
+msgid "%s (The sanitized post title (slug).)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:296
+msgid "%s (Category slug. Nested sub-categories appear as nested directories in the URL.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:298
+msgid "%s (A sanitized version of the author name.)"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:311
+msgid "%s added to permalink structure"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:313
+msgid "%s removed from permalink structure"
+msgstr ""
+
+#. translators: %s: Permalink structure tag.
+#: wp-admin/options-permalink.php:315
+msgid "%s (already used in permalink structure)"
+msgstr ""
+
+#: wp-admin/options-permalink.php:317
+msgid "Common Settings"
+msgstr ""
+
+#. translators: %s: %postname%
+#: wp-admin/options-permalink.php:322
+msgid "Select the permalink structure for your website. Including the %s tag makes links easy to understand, and can help your posts rank higher in search engines."
+msgstr ""
+
+#: wp-admin/options-permalink.php:365
+msgid "Custom Structure"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-permalink.php:370
+msgid "Customize permalink structure by selecting available tags"
+msgstr ""
+
+#: wp-admin/options-permalink.php:386
+msgid "Available tags:"
+msgstr ""
+
+#: wp-admin/options-permalink.php:412
+msgid "Optional"
+msgstr ""
+
+#. translators: %s: Placeholder that must come at the start of the URL.
+#: wp-admin/options-permalink.php:417
+msgid "If you like, you may enter custom structures for your category and tag URLs here. For example, using <code>topics</code> as your category base would make your category links like <code>%s/topics/uncategorized/</code>. If you leave these blank the defaults will be used."
+msgstr ""
+
+#. translators: Prefix for category permalinks.
+#: wp-admin/options-permalink.php:427
+msgid "Category base"
+msgstr ""
+
+#: wp-admin/options-permalink.php:439
+msgid "Tag base"
+msgstr ""
+
+#. translators: 1: web.config, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A, 5: Element code.
+#: wp-admin/options-permalink.php:466
+msgid "<strong>Error:</strong> Your %1$s file is not <a href=\"%2$s\">writable</a>, so updating it automatically was not possible. This is the URL rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file."
+msgstr ""
+
+#: wp-admin/options-permalink.php:468
+#: wp-admin/options-permalink.php:500
+#: wp-admin/options-permalink.php:536
+msgid "https://wordpress.org/support/article/changing-file-permissions/"
+msgstr ""
+
+#: wp-admin/options-permalink.php:478
+#: wp-admin/options-permalink.php:510
+#: wp-admin/options-permalink.php:545
+msgid "Rewrite rules:"
+msgstr ""
+
+#. translators: %s: web.config
+#: wp-admin/options-permalink.php:489
+msgid "If you temporarily make your %s file writable to generate rewrite rules automatically, do not forget to revert the permissions after the rule has been saved."
+msgstr ""
+
+#. translators: 1: Documentation URL, 2: web.config, 3: Ctrl + A, 4: ⌘ + A
+#: wp-admin/options-permalink.php:499
+msgid "<strong>Error:</strong> The root directory of your site is not <a href=\"%1$s\">writable</a>, so creating a file automatically was not possible. This is the URL rewrite rule you should have in your %2$s file. Create a new file called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file."
+msgstr ""
+
+#. translators: %s: web.config
+#: wp-admin/options-permalink.php:521
+msgid "If you temporarily make your site&#8217;s root directory writable to generate the %s file automatically, do not forget to revert the permissions after the file has been created."
+msgstr ""
+
+#. translators: 1: .htaccess, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A
+#: wp-admin/options-permalink.php:534
+msgid "<strong>Error:</strong> Your %1$s file is not <a href=\"%2$s\">writable</a>, so updating it automatically was not possible. These are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all."
+msgstr ""
+
+#: wp-admin/options-privacy.php:13
+#: wp-admin/privacy-policy-guide.php:13
+msgid "Sorry, you are not allowed to manage privacy options on this site."
+msgstr ""
+
+#: wp-admin/options-privacy.php:40
+msgid "The Privacy screen lets you either build a new privacy-policy page or choose one you already have to show."
+msgstr ""
+
+#: wp-admin/options-privacy.php:41
+msgid "This screen includes suggestions to help you write your own privacy policy. However, it is your responsibility to use these resources correctly, to provide the information required by your privacy policy, and to keep this information current and accurate."
+msgstr ""
+
+#: wp-admin/options-privacy.php:47
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-privacy-screen/\">Documentation on Privacy Settings</a>"
+msgstr ""
+
+#: wp-admin/options-privacy.php:57
+#: wp-admin/privacy.php:25
+msgid "Privacy Policy page updated successfully."
+msgstr ""
+
+#. translators: %s: URL to Customizer -> Menus.
+#: wp-admin/options-privacy.php:74
+msgid "Privacy Policy page setting updated successfully. Remember to <a href=\"%s\">update your menus</a>!"
+msgstr ""
+
+#: wp-admin/options-privacy.php:102
+#: wp-admin/privacy.php:75
+msgid "Unable to create a Privacy Policy page."
+msgstr ""
+
+#: wp-admin/options-privacy.php:126
+#: wp-admin/privacy.php:99
+msgid "The currently selected Privacy Policy page does not exist. Please create or select a new page."
+msgstr ""
+
+#. translators: %s: URL to Pages Trash.
+#: wp-admin/options-privacy.php:136
+msgid "The currently selected Privacy Policy page is in the Trash. Please create or select a new Privacy Policy page or <a href=\"%s\">restore the current page</a>."
+msgstr ""
+
+#. translators: Tab heading for Site Health Status page.
+#: wp-admin/options-privacy.php:165
+#: wp-admin/privacy-policy-guide.php:48
+msgctxt "Privacy Settings"
+msgid "Settings"
+msgstr ""
+
+#. translators: Tab heading for Site Health Status page.
+#: wp-admin/options-privacy.php:172
+#: wp-admin/privacy-policy-guide.php:55
+msgctxt "Privacy Settings"
+msgid "Policy Guide"
+msgstr ""
+
+#: wp-admin/options-privacy.php:181
+#: wp-admin/privacy-policy-guide.php:64
+msgid "The Privacy Settings require JavaScript."
+msgstr ""
+
+#: wp-admin/options-privacy.php:185
+#: wp-admin/privacy.php:120
+msgid "Privacy Settings"
+msgstr ""
+
+#: wp-admin/options-privacy.php:187
+msgid "As a website owner, you may need to follow national or international privacy laws. For example, you may need to create and display a privacy policy."
+msgstr ""
+
+#: wp-admin/options-privacy.php:188
+#: wp-admin/privacy.php:131
+msgid "If you already have a Privacy Policy page, please select it below. If not, please create one."
+msgstr ""
+
+#: wp-admin/options-privacy.php:191
+msgid "The new page will include help and suggestions for your privacy policy."
+msgstr ""
+
+#: wp-admin/options-privacy.php:192
+msgid "However, it is your responsibility to use those resources correctly, to provide the information that your privacy policy requires, and to keep that information current and accurate."
+msgstr ""
+
+#: wp-admin/options-privacy.php:195
+msgid "After your Privacy Policy page is set, you should edit it."
+msgstr ""
+
+#: wp-admin/options-privacy.php:196
+msgid "You should also review your privacy policy from time to time, especially after installing or updating any themes or plugins. There may be changes or new suggested information for you to consider adding to your policy."
+msgstr ""
+
+#. translators: 1: URL to edit Privacy Policy page, 2: URL to view Privacy Policy page.
+#. translators: 1: URL to edit page, 2: URL to view page
+#: wp-admin/options-privacy.php:215
+#: wp-admin/privacy.php:160
+msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">view</a> your Privacy Policy page content."
+msgstr ""
+
+#. translators: 1: URL to edit Privacy Policy page, 2: URL to preview Privacy Policy page.
+#. translators: 1: URL to edit page, 2: URL to preview page
+#: wp-admin/options-privacy.php:222
+#: wp-admin/privacy.php:163
+msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">preview</a> your Privacy Policy page content."
+msgstr ""
+
+#. translators: 1: Privacy Policy guide URL, 2: Additional link attributes, 3: Accessibility text.
+#: wp-admin/options-privacy.php:233
+msgid "Need help putting together your new Privacy Policy page? <a href=\"%1$s\" %2$s>Check out our privacy policy guide%3$s</a> for recommendations on what content to include, along with policies suggested by your plugins and theme."
+msgstr ""
+
+#: wp-admin/options-privacy.php:259
+msgid "Create a new Privacy Policy page"
+msgstr ""
+
+#: wp-admin/options-privacy.php:261
+#: wp-admin/privacy.php:241
+msgid "There are no pages."
+msgstr ""
+
+#: wp-admin/options-privacy.php:271
+msgid "Create"
+msgstr ""
+
+#: wp-admin/options-privacy.php:282
+#: wp-admin/privacy.php:190
+msgid "Change your Privacy Policy page"
+msgstr ""
+
+#: wp-admin/options-privacy.php:284
+#: wp-admin/privacy.php:192
+msgid "Select a Privacy Policy page"
+msgstr ""
+
+#: wp-admin/options-privacy.php:305
+#: wp-admin/privacy.php:229
+msgid "Use This Page"
+msgstr ""
+
+#: wp-admin/options-reading.php:17
+msgid "Reading Settings"
+msgstr ""
+
+#: wp-admin/options-reading.php:26
+msgid "This screen contains the settings that affect the display of your content."
+msgstr ""
+
+#. translators: %s: URL to create a new page.
+#: wp-admin/options-reading.php:29
+msgid "You can choose what&#8217;s displayed on the homepage of your site. It can be posts in reverse chronological order (classic blog), or a fixed/static page. To set a static homepage, you first need to create two <a href=\"%s\">Pages</a>. One will become the homepage, and the other will be where your posts are displayed."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/options-reading.php:34
+msgid "You can also control the display of your content in RSS feeds, including the maximum number of posts to display and whether to show full text or an excerpt. <a href=\"%s\">Learn more about feeds</a>."
+msgstr ""
+
+#: wp-admin/options-reading.php:35
+#: wp-admin/options-reading.php:184
+msgid "https://wordpress.org/documentation/article/wordpress-feeds/"
+msgstr ""
+
+#: wp-admin/options-reading.php:45
+msgid "You can choose whether or not your site will be crawled by robots, ping services, and spiders. If you want those services to ignore your site, click the checkbox next to &#8220;Discourage search engines from indexing this site&#8221; and click the Save Changes button at the bottom of the screen."
+msgstr ""
+
+#: wp-admin/options-reading.php:46
+msgid "Note that even when set to discourage search engines, your site is still visible on the web and not all search engines adhere to this directive."
+msgstr ""
+
+#: wp-admin/options-reading.php:47
+msgid "When this setting is in effect, a reminder is shown in the At a Glance box of the Dashboard that says, &#8220;Search engines discouraged&#8221;, to remind you that you have directed search engines to not crawl your site."
+msgstr ""
+
+#: wp-admin/options-reading.php:53
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-reading-screen/\">Documentation on Reading Settings</a>"
+msgstr ""
+
+#: wp-admin/options-reading.php:68
+msgid "Encoding for pages and feeds"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-reading.php:87
+#: wp-admin/options-reading.php:92
+msgid "Your homepage displays"
+msgstr ""
+
+#: wp-admin/options-reading.php:97
+msgid "Your latest posts"
+msgstr ""
+
+#. translators: %s: URL to Pages screen.
+#: wp-admin/options-reading.php:105
+msgid "A <a href=\"%s\">static page</a> (select below)"
+msgstr ""
+
+#. translators: %s: Select field to choose the front page.
+#: wp-admin/options-reading.php:116
+msgid "Homepage: %s"
+msgstr ""
+
+#. translators: %s: Select field to choose the page for posts.
+#: wp-admin/options-reading.php:133
+msgid "Posts page: %s"
+msgstr ""
+
+#: wp-admin/options-reading.php:148
+msgid "<strong>Warning:</strong> these pages should not be the same!"
+msgstr ""
+
+#: wp-admin/options-reading.php:151
+msgid "<strong>Warning:</strong> these pages should not be the same as your Privacy Policy page!"
+msgstr ""
+
+#: wp-admin/options-reading.php:157
+msgid "Blog pages show at most"
+msgstr ""
+
+#: wp-admin/options-reading.php:159
+msgid "posts"
+msgstr ""
+
+#: wp-admin/options-reading.php:163
+msgid "Syndication feeds show the most recent"
+msgstr ""
+
+#: wp-admin/options-reading.php:164
+msgid "items"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-reading.php:167
+#: wp-admin/options-reading.php:172
+msgid "For each post in a feed, include"
+msgstr ""
+
+#: wp-admin/options-reading.php:176
+msgid "Full text"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/options-reading.php:183
+msgid "Your theme determines how content is displayed in browsers. <a href=\"%s\">Learn more about feeds</a>."
+msgstr ""
+
+#: wp-admin/options-writing.php:17
+msgid "Writing Settings"
+msgstr ""
+
+#: wp-admin/options-writing.php:24
+msgid "You can submit content in several different ways; this screen holds the settings for all of them. The top section controls the editor within the dashboard, while the rest control external publishing methods. For more information on any of these methods, use the documentation links."
+msgstr ""
+
+#: wp-admin/options-writing.php:34
+msgid "Post Via Email"
+msgstr ""
+
+#: wp-admin/options-writing.php:35
+msgid "Post via email settings allow you to send your ClassicPress installation an email with the content of your post. You must set up a secret email account with POP3 access to use this, and any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret."
+msgstr ""
+
+#: wp-admin/options-writing.php:45
+#: wp-admin/options-writing.php:207
+msgid "Update Services"
+msgstr ""
+
+#: wp-admin/options-writing.php:46
+msgid "If desired, ClassicPress will automatically alert various services of your new posts."
+msgstr ""
+
+#: wp-admin/options-writing.php:53
+msgid "<a href=\"https://wordpress.org/documentation/article/settings-writing-screen/\">Documentation on Writing Settings</a>"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/options-writing.php:69
+#: wp-admin/options-writing.php:73
+msgid "Formatting"
+msgstr ""
+
+#: wp-admin/options-writing.php:78
+msgid "Convert emoticons like <code>:-)</code> and <code>:-P</code> to graphics on display"
+msgstr ""
+
+#: wp-admin/options-writing.php:79
+msgid "ClassicPress should correct invalidly nested XHTML automatically"
+msgstr ""
+
+#: wp-admin/options-writing.php:84
+msgid "Default Post Category"
+msgstr ""
+
+#: wp-admin/options-writing.php:104
+msgid "Default Post Format"
+msgstr ""
+
+#: wp-admin/options-writing.php:118
+msgid "Default Link Category"
+msgstr ""
+
+#: wp-admin/options-writing.php:146
+msgid "Post via email"
+msgstr ""
+
+#. translators: 1, 2, 3: Examples of random email addresses.
+#: wp-admin/options-writing.php:151
+msgid "To post to ClassicPress by email, you must set up a secret email account with POP3 access. Any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret. Here are three random strings you could use: %1$s, %2$s, %3$s."
+msgstr ""
+
+#: wp-admin/options-writing.php:161
+msgid "Mail Server"
+msgstr ""
+
+#: wp-admin/options-writing.php:163
+msgid "Port"
+msgstr ""
+
+#: wp-admin/options-writing.php:168
+msgid "Login Name"
+msgstr ""
+
+#: wp-admin/options-writing.php:178
+msgid "Default Mail Category"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/options-writing.php:215
+msgid "When you publish a new post, ClassicPress automatically notifies the following site update services. For more about this, see the <a href=\"%s\">Update Services</a> documentation article. Separate multiple service URLs with line breaks."
+msgstr ""
+
+#: wp-admin/options-writing.php:216
+#: wp-admin/options-writing.php:230
+msgid "https://wordpress.org/documentation/article/update-services/"
+msgstr ""
+
+#. translators: 1: Documentation URL, 2: URL to Reading Settings screen.
+#: wp-admin/options-writing.php:229
+msgid "ClassicPress is not notifying any <a href=\"%1$s\">Update Services</a> because of your site&#8217;s <a href=\"%2$s\">visibility settings</a>."
+msgstr ""
+
+#: wp-admin/options.php:227
+msgid "Please consider writing more inclusive code."
+msgstr ""
+
+#. translators: %s: The options page name.
+#: wp-admin/options.php:252
+msgid "<strong>Error:</strong> The %s options page is not in the allowed options list."
+msgstr ""
+
+#: wp-admin/options.php:260
+msgid "Sorry, you are not allowed to modify unregistered settings for this site."
+msgstr ""
+
+#. translators: %s: The option/setting.
+#: wp-admin/options.php:311
+msgid "The %s setting is unregistered. Unregistered settings are deprecated. See https://developer.wordpress.org/plugins/settings/settings-api/"
+msgstr ""
+
+#: wp-admin/options.php:340
+msgid "Settings save failed."
+msgstr ""
+
+#: wp-admin/options.php:363
+msgid "All Settings"
+msgstr ""
+
+#: wp-admin/options.php:366
+msgid "This page allows direct access to your site settings. You can break things here. Please be cautious!"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:22
+msgid "Edit Plugins"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:127
+msgid "You can use the plugin file editor to make changes to any of your plugins&#8217; individual PHP files. Be aware that if you make changes, plugins updates will overwrite your customizations."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:128
+msgid "Choose a plugin to edit from the dropdown menu and click the Select button. Click once on any file name to load it in the editor, and make your changes. Do not forget to save your changes (Update File) when you are finished."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:129
+msgid "The documentation menu below the editor lists the PHP functions recognized in the plugin file. Clicking Look Up takes you to a web page about that particular function."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:130
+#: wp-admin/theme-editor.php:33
+msgid "When using a keyboard to navigate:"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:132
+#: wp-admin/theme-editor.php:35
+msgid "In the editing area, the Tab key enters a tab character."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:133
+#: wp-admin/theme-editor.php:36
+msgid "To move away from this area, press the Esc key followed by the Tab key."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:134
+#: wp-admin/theme-editor.php:37
+msgid "Screen reader users: when in forms mode, you may need to press the Esc key twice."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:136
+msgid "If you want to make changes but do not want them to be overwritten when the plugin is updated, you may be ready to think about writing your own plugin. For information on how to edit plugins, write your own from scratch, or just better understand their anatomy, check out the links below."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:137
+#: wp-admin/theme-editor.php:46
+msgid "Any edits to files from this screen will be reflected on all sites in the network."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:143
+msgid "<a href=\"https://wordpress.org/documentation/article/plugins-editor-screen/\">Documentation on Editing Plugins</a>"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:144
+msgid "<a href=\"https://developer.wordpress.org/plugins/\">Documentation on Writing Plugins</a>"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:170
+#: wp-admin/theme-editor.php:169
+msgid "Function Name&hellip;"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:191
+#: wp-admin/theme-editor.php:198
+msgid "There was an error while trying to update the file. You may need to fix something and try updating again."
+msgstr ""
+
+#. translators: %s: Plugin file name.
+#: wp-admin/plugin-editor.php:203
+msgid "Editing %s (active)"
+msgstr ""
+
+#. translators: %s: Plugin file name.
+#: wp-admin/plugin-editor.php:206
+msgid "Browsing %s (active)"
+msgstr ""
+
+#. translators: %s: Plugin file name.
+#: wp-admin/plugin-editor.php:211
+msgid "Editing %s (inactive)"
+msgstr ""
+
+#. translators: %s: Plugin file name.
+#: wp-admin/plugin-editor.php:214
+msgid "Browsing %s (inactive)"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:222
+msgid "Select plugin to edit:"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:245
+msgid "Plugin Files"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:266
+#: wp-admin/theme-editor.php:290
+msgid "Selected file content:"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:275
+#: wp-admin/theme-editor.php:299
+msgid "Documentation:"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:277
+#: wp-admin/theme-editor.php:301
+msgid "Look Up"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:285
+msgid "<strong>Warning:</strong> Making changes to active plugins is not recommended."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:290
+#: wp-admin/theme-editor.php:320
+msgid "Update File"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:330
+#: wp-admin/theme-editor.php:364
+msgid "Heads up!"
+msgstr ""
+
+#: wp-admin/plugin-editor.php:331
+msgid "You appear to be making direct edits to your plugin in the ClassicPress dashboard. Editing plugins directly is not recommended as it may introduce incompatibilities that break your site and your changes may be lost in future updates."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:332
+msgid "If you absolutely have to make direct edits to this plugin, use a file manager to create a copy with a new name and hang on to the original. That way, you can re-enable a functional version if something goes wrong."
+msgstr ""
+
+#: wp-admin/plugin-editor.php:336
+#: wp-admin/theme-editor.php:385
+msgid "I understand"
+msgstr ""
+
+#: wp-admin/plugin-install.php:51
+msgid "Add Plugins"
+msgstr ""
+
+#. translators: %s: https://wordpress.org/plugins
+#: wp-admin/plugin-install.php:97
+msgid "Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the <a href=\"%s\">ClassicPress Plugin Directory</a> are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!"
+msgstr ""
+
+#: wp-admin/plugin-install.php:100
+msgid "You can find new plugins to install by searching or browsing the directory right here in your own Plugins section."
+msgstr ""
+
+#: wp-admin/plugin-install.php:100
+#: wp-admin/plugins.php:546
+#: wp-admin/theme-install.php:113
+#: wp-admin/themes.php:138
+msgid "The search results will be updated as you type."
+msgstr ""
+
+#: wp-admin/plugin-install.php:107
+msgid "Adding Plugins"
+msgstr ""
+
+#: wp-admin/plugin-install.php:109
+msgid "If you know what you are looking for, Search is your best bet. The Search screen has options to search the ClassicPress Plugin Directory for a particular Term, Author, or Tag. You can also search the directory by selecting popular tags. Tags in larger type mean more plugins have been labeled with that tag."
+msgstr ""
+
+#: wp-admin/plugin-install.php:110
+msgid "If you just want to get an idea of what&#8217;s available, you can browse Featured and Popular plugins by using the links above the plugins list. These sections rotate regularly."
+msgstr ""
+
+#: wp-admin/plugin-install.php:111
+msgid "You can also browse a user&#8217;s favorite plugins, by using the Favorites link above the plugins list and entering their WordPress.org username."
+msgstr ""
+
+#: wp-admin/plugin-install.php:112
+msgid "If you want to install a plugin that you&#8217;ve downloaded elsewhere, click the Upload Plugin button above the plugins list. You will be prompted to upload the .zip package, and once uploaded, you can activate the new plugin."
+msgstr ""
+
+#: wp-admin/plugin-install.php:118
+msgid "<a href=\"https://wordpress.org/documentation/article/plugins-add-new-screen/\">Documentation on Installing Plugins</a>"
+msgstr ""
+
+#: wp-admin/plugin-install.php:124
+#: wp-admin/plugins.php:594
+msgid "Filter plugins list"
+msgstr ""
+
+#: wp-admin/plugin-install.php:125
+#: wp-admin/plugins.php:595
+msgid "Plugins list navigation"
+msgstr ""
+
+#: wp-admin/plugin-install.php:126
+#: wp-admin/plugins.php:596
+msgid "Plugins list"
+msgstr ""
+
+#: wp-admin/plugin-install.php:148
+msgid "Browse Plugins"
+msgstr ""
+
+#: wp-admin/plugins.php:48
+#: wp-admin/plugins.php:176
+msgid "Sorry, you are not allowed to activate this plugin."
+msgstr ""
+
+#: wp-admin/plugins.php:92
+msgid "Sorry, you are not allowed to activate plugins for this site."
+msgstr ""
+
+#: wp-admin/plugins.php:157
+#: wp-admin/update-core.php:330
+#: wp-admin/update-core.php:467
+#: wp-admin/update-core.php:999
+#: wp-admin/update-core.php:1004
+msgid "Update Plugins"
+msgstr ""
+
+#: wp-admin/plugins.php:199
+msgid "Sorry, you are not allowed to deactivate this plugin."
+msgstr ""
+
+#: wp-admin/plugins.php:226
+msgid "Sorry, you are not allowed to deactivate plugins for this site."
+msgstr ""
+
+#: wp-admin/plugins.php:341
+msgid "Delete Plugin"
+msgstr ""
+
+#: wp-admin/plugins.php:343
+msgid "This plugin may be active on other sites in the network."
+msgstr ""
+
+#: wp-admin/plugins.php:345
+msgid "You are about to remove the following plugin:"
+msgstr ""
+
+#: wp-admin/plugins.php:347
+msgid "Delete Plugins"
+msgstr ""
+
+#: wp-admin/plugins.php:349
+msgid "These plugins may be active on other sites in the network."
+msgstr ""
+
+#: wp-admin/plugins.php:351
+msgid "You are about to remove the following plugins:"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Plugin author.
+#: wp-admin/plugins.php:361
+msgid "%1$s by %2$s (will also <strong>delete its data</strong>)"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: Plugin author.
+#: wp-admin/plugins.php:365
+msgctxt "plugin"
+msgid "%1$s by %2$s"
+msgstr ""
+
+#: wp-admin/plugins.php:375
+msgid "Are you sure you want to delete these files and data?"
+msgstr ""
+
+#: wp-admin/plugins.php:377
+msgid "Are you sure you want to delete these files?"
+msgstr ""
+
+#: wp-admin/plugins.php:393
+msgid "Yes, delete these files and data"
+msgstr ""
+
+#: wp-admin/plugins.php:393
+msgid "Yes, delete these files"
+msgstr ""
+
+#: wp-admin/plugins.php:401
+msgid "No, return me to the plugin list"
+msgstr ""
+
+#: wp-admin/plugins.php:432
+msgid "Sorry, you are not allowed to resume this plugin."
+msgstr ""
+
+#: wp-admin/plugins.php:450
+msgid "Sorry, you are not allowed to manage plugins automatic updates."
+msgstr ""
+
+#: wp-admin/plugins.php:454
+msgid "Please connect to your network admin to manage plugins automatic updates."
+msgstr ""
+
+#: wp-admin/plugins.php:545
+msgid "Plugins extend and expand the functionality of ClassicPress. Once a plugin is installed, you may activate it or deactivate it here."
+msgstr ""
+
+#: wp-admin/plugins.php:546
+msgid "The search for installed plugins will search for terms in their name, description, or author."
+msgstr ""
+
+#. translators: %s: WordPress Plugin Directory URL.
+#: wp-admin/plugins.php:549
+msgid "If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href=\"%s\">ClassicPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!"
+msgstr ""
+
+#: wp-admin/plugins.php:557
+msgid "Troubleshooting"
+msgstr ""
+
+#: wp-admin/plugins.php:559
+msgid "Most of the time, plugins play nicely with the core of ClassicPress and with other plugins. Sometimes, though, a plugin&#8217;s code will get in the way of another plugin, causing compatibility issues. If your site starts doing strange things, this may be the problem. Try deactivating all your plugins and re-activating them in various combinations until you isolate which one(s) caused the issue."
+msgstr ""
+
+#. translators: %s: WP_PLUGIN_DIR constant value.
+#: wp-admin/plugins.php:562
+msgid "If something goes wrong with a plugin and you cannot use ClassicPress, delete or rename that file in the %s directory and it will be automatically deactivated."
+msgstr ""
+
+#: wp-admin/plugins.php:576
+msgid "Auto-updates can be enabled or disabled for each individual plugin. Plugins with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system."
+msgstr ""
+
+#: wp-admin/plugins.php:577
+msgid "Auto-updates are only available for plugins recognized by WordPress.org or ClassicPress.net, or that include a compatible update system."
+msgstr ""
+
+#: wp-admin/plugins.php:578
+#: wp-admin/themes.php:192
+msgid "Please note: Third-party themes and plugins, or custom code, may override ClassicPress scheduling."
+msgstr ""
+
+#: wp-admin/plugins.php:582
+#: wp-admin/themes.php:202
+msgid "<a href=\"https://wordpress.org/documentation/article/plugins-themes-auto-updates/\">Documentation on Auto-updates</a>"
+msgstr ""
+
+#: wp-admin/plugins.php:587
+msgid "<a href=\"https://wordpress.org/documentation/article/manage-plugins/\">Documentation on Managing Plugins</a>"
+msgstr ""
+
+#: wp-admin/plugins.php:601
+#: wp-admin/update-core.php:303
+#: wp-admin/update-core.php:322
+msgid "Plugins"
+msgstr ""
+
+#. translators: 1: Plugin file, 2: Error message.
+#: wp-admin/plugins.php:612
+msgid "The plugin %1$s has been deactivated due to an error: %2$s"
+msgstr ""
+
+#. translators: %d: Number of characters.
+#: wp-admin/plugins.php:627
+msgid "The plugin generated %d character of <strong>unexpected output</strong> during activation."
+msgid_plural "The plugin generated %d characters of <strong>unexpected output</strong> during activation."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/plugins.php:634
+msgid "If you notice &#8220;headers already sent&#8221; messages, problems with syndication feeds or other issues, try deactivating or removing this plugin."
+msgstr ""
+
+#: wp-admin/plugins.php:636
+msgid "Plugin could not be resumed because it triggered a <strong>fatal error</strong>."
+msgstr ""
+
+#: wp-admin/plugins.php:638
+msgid "Plugin could not be activated because it triggered a <strong>fatal error</strong>."
+msgstr ""
+
+#. translators: %s: Error message.
+#: wp-admin/plugins.php:677
+msgid "Plugin could not be deleted due to an error: %s"
+msgstr ""
+
+#: wp-admin/plugins.php:688
+msgid "The selected plugin has been deleted."
+msgstr ""
+
+#: wp-admin/plugins.php:690
+msgid "The selected plugins have been deleted."
+msgstr ""
+
+#: wp-admin/plugins.php:697
+msgid "Plugin activated."
+msgstr ""
+
+#: wp-admin/plugins.php:699
+msgid "Selected plugins activated."
+msgstr ""
+
+#: wp-admin/plugins.php:701
+msgid "Plugin deactivated."
+msgstr ""
+
+#: wp-admin/plugins.php:703
+msgid "Selected plugins deactivated."
+msgstr ""
+
+#: wp-admin/plugins.php:705
+msgid "All selected plugins are up to date."
+msgstr ""
+
+#: wp-admin/plugins.php:707
+msgid "Plugin resumed."
+msgstr ""
+
+#: wp-admin/plugins.php:709
+msgid "Plugin will be auto-updated."
+msgstr ""
+
+#: wp-admin/plugins.php:711
+msgid "Plugin will no longer be auto-updated."
+msgstr ""
+
+#: wp-admin/plugins.php:713
+msgid "Selected plugins will be auto-updated."
+msgstr ""
+
+#: wp-admin/plugins.php:715
+msgid "Selected plugins will no longer be auto-updated."
+msgstr ""
+
+#: wp-admin/plugins.php:765
+msgid "Search Installed Plugins"
+msgstr ""
+
+#: wp-admin/post.php:47
+msgid "A post type mismatch has been detected."
+msgstr ""
+
+#: wp-admin/post.php:82
+msgid "Unable to submit this form, please refresh and try again."
+msgstr ""
+
+#: wp-admin/post.php:143
+msgid "You cannot edit this item because it is in the Trash. Please restore it and try again."
+msgstr ""
+
+#: wp-admin/post.php:245
+msgid "The item you are trying to move to the Trash no longer exists."
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/post.php:260
+msgid "You cannot move this item to the Trash. %s is currently editing."
+msgstr ""
+
+#: wp-admin/post.php:282
+msgid "The item you are trying to restore from the Trash no longer exists."
+msgstr ""
+
+#: wp-admin/post.php:311
+msgid "This item has already been deleted."
+msgstr ""
+
+#: wp-admin/press-this.php:44
+msgid "Activate Press This"
+msgstr ""
+
+#. translators: %s: URL to Press This bookmarklet on the main site.
+#: wp-admin/press-this.php:68
+msgid "Press This is not installed. Please install Press This from <a href=\"%s\">the main site</a>."
+msgstr ""
+
+#: wp-admin/press-this.php:74
+msgid "The Press This plugin is required."
+msgstr ""
+
+#: wp-admin/press-this.php:75
+#: wp-admin/press-this.php:81
+msgid "Installation Required"
+msgstr ""
+
+#: wp-admin/press-this.php:80
+msgid "Press This is not available. Please contact your site administrator."
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:21
+#: wp-admin/privacy-policy-guide.php:68
+#: wp-admin/privacy-policy-guide.php:77
+msgid "Privacy Policy Guide"
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:69
+msgid "Introduction"
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:70
+msgid "This text template will help you to create your web site&#8217;s privacy policy."
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:71
+msgid "The template contains a suggestion of sections you most likely will need. Under each section heading you will find a short summary of what information you should provide, which will help you to get started. Some sections include suggested policy content, others will have to be completed with information from your theme and plugins."
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:72
+msgid "Please edit your privacy policy content, making sure to delete the summaries, and adding any information from your theme and plugins. Once you publish your policy page, remember to add it to your navigation menu."
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:73
+msgid "It is your responsibility to write a comprehensive privacy policy, to make sure it reflects all national and international legal requirements on privacy, and to keep your policy current and accurate."
+msgstr ""
+
+#: wp-admin/privacy-policy-guide.php:89
+msgid "Policies"
+msgstr ""
+
+#: wp-admin/privacy.php:13
+msgid "Sorry, you are not allowed to manage privacy on this site."
+msgstr ""
+
+#. translators: %s: URL to Customizer -> Menus
+#: wp-admin/privacy.php:42
+msgid "Privacy Policy page updated successfully. Remember to <a href=\"%s\">update your menus</a>!"
+msgstr ""
+
+#. translators: URL to Pages Trash
+#: wp-admin/privacy.php:109
+msgid "The currently selected Privacy Policy page is in the trash. Please create or select a new Privacy Policy page or <a href=\"%s\">restore the current page</a>."
+msgstr ""
+
+#: wp-admin/privacy.php:128
+msgid "Privacy Policy page"
+msgstr ""
+
+#: wp-admin/privacy.php:130
+msgid "As a website owner, you may need to follow national or international privacy laws. For example, you may need to create and display a Privacy Policy."
+msgstr ""
+
+#: wp-admin/privacy.php:134
+msgid "The new page will include help and suggestions for your Privacy Policy."
+msgstr ""
+
+#: wp-admin/privacy.php:135
+msgid "However, it is your responsibility to use those resources correctly, to provide the information that your Privacy Policy requires, and to keep that information current and accurate."
+msgstr ""
+
+#: wp-admin/privacy.php:138
+msgid "After your Privacy Policy page is set, we suggest that you edit it."
+msgstr ""
+
+#: wp-admin/privacy.php:139
+msgid "We would also suggest reviewing your Privacy Policy from time to time, especially after installing or updating any themes or plugins. There may be changes or new suggested information for you to consider adding to your policy."
+msgstr ""
+
+#: wp-admin/privacy.php:173
+msgid "Need help putting together your new Privacy Policy page? <a href=\"%1$s\" %2$s>Check out our guide%3$s</a> for recommendations on what content to include, along with policies suggested by your plugins and theme."
+msgstr ""
+
+#: wp-admin/privacy.php:213
+msgid "Select an existing page:"
+msgstr ""
+
+#: wp-admin/privacy.php:239
+msgid "Or:"
+msgstr ""
+
+#: wp-admin/privacy.php:248
+msgid "Create New Page"
+msgstr ""
+
+#. translators: %s: Post title.
+#: wp-admin/revision.php:109
+msgid "Compare Revisions of &#8220;%s&#8221;"
+msgstr ""
+
+#: wp-admin/revision.php:110
+msgid "&larr; Go to editor"
+msgstr ""
+
+#: wp-admin/revision.php:141
+msgid "This screen is used for managing your content revisions."
+msgstr ""
+
+#: wp-admin/revision.php:142
+msgid "Revisions are saved copies of your post or page, which are periodically created as you update your content. The red text on the left shows the content that was removed. The green text on the right shows the content that was added."
+msgstr ""
+
+#: wp-admin/revision.php:143
+msgid "From this screen you can review, compare, and restore revisions:"
+msgstr ""
+
+#: wp-admin/revision.php:144
+msgid "To navigate between revisions, <strong>drag the slider handle left or right</strong> or <strong>use the Previous or Next buttons</strong>."
+msgstr ""
+
+#: wp-admin/revision.php:145
+msgid "Compare two different revisions by <strong>selecting the &#8220;Compare any two revisions&#8221; box</strong> to the side."
+msgstr ""
+
+#: wp-admin/revision.php:146
+msgid "To restore a revision, <strong>click Restore This Revision</strong>."
+msgstr ""
+
+#: wp-admin/revision.php:157
+msgid "<a href=\"https://wordpress.org/documentation/article/revisions/\">Revisions Management</a>"
+msgstr ""
+
+#: wp-admin/revision.php:179
+msgid "Revision by "
+msgstr ""
+
+#: wp-admin/revision.php:181
+msgid "Autosave by "
+msgstr ""
+
+#: wp-admin/revision.php:183
+msgid "Current Revision by "
+msgstr ""
+
+#: wp-admin/revision.php:209
+msgid "Earlier Revision"
+msgstr ""
+
+#: wp-admin/revision.php:214
+msgid "Later Revision"
+msgstr ""
+
+#. translators: %s: wp-config-sample.php
+#: wp-admin/setup-config.php:52
+msgid "Sorry, I need a %s file to work from. Please re-upload this file to your ClassicPress installation."
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: install.php
+#: wp-admin/setup-config.php:63
+msgid "The file %1$s already exists. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href=\"%2$s\">installing now</a>."
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: install.php
+#: wp-admin/setup-config.php:76
+msgid "The file %1$s already exists one level above your ClassicPress installation. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href=\"%2$s\">installing now</a>."
+msgstr ""
+
+#: wp-admin/setup-config.php:111
+msgid "ClassicPress &rsaquo; Setup Configuration File"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/setup-config.php:163
+msgid "Before getting started"
+msgstr ""
+
+#: wp-admin/setup-config.php:166
+msgid "Welcome to ClassicPress. Before getting started, you will need to know the following items."
+msgstr ""
+
+#: wp-admin/setup-config.php:170
+msgid "Database password"
+msgstr ""
+
+#: wp-admin/setup-config.php:172
+msgid "Table prefix (if you want to run more than one ClassicPress in a single database)"
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/setup-config.php:178
+msgid "This information is being used to create a %s file."
+msgstr ""
+
+#. translators: 1: wp-config-sample.php, 2: wp-config.php
+#: wp-admin/setup-config.php:186
+msgid "If for any reason this automatic file creation does not work, do not worry. All this does is fill in the database information to a configuration file. You may also simply open %1$s in a text editor, fill in your information, and save it as %2$s."
+msgstr ""
+
+#. translators: 1: Documentation URL, 2: wp-config.php
+#: wp-admin/setup-config.php:195
+msgid "Need more help? <a href=\"%1$s\">Read the support article on %2$s</a>."
+msgstr ""
+
+#: wp-admin/setup-config.php:196
+msgid "https://wordpress.org/documentation/article/editing-wp-config-php/"
+msgstr ""
+
+#: wp-admin/setup-config.php:201
+msgid "In all likelihood, these items were supplied to you by your web host. If you do not have this information, then you will need to contact them before you can continue. If you are ready&hellip;"
+msgstr ""
+
+#: wp-admin/setup-config.php:203
+msgid "Let&#8217;s go!"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/setup-config.php:218
+msgid "Set up your database connection"
+msgstr ""
+
+#: wp-admin/setup-config.php:222
+msgid "Below you should enter your database connection details. If you are not sure about these, contact your host."
+msgstr ""
+
+#: wp-admin/setup-config.php:225
+msgid "Database Name"
+msgstr ""
+
+#: wp-admin/setup-config.php:227
+msgid "The name of the database you want to use with ClassicPress."
+msgstr ""
+
+#: wp-admin/setup-config.php:231
+msgctxt "example username"
+msgid "username"
+msgstr ""
+
+#: wp-admin/setup-config.php:232
+msgid "Your database username."
+msgstr ""
+
+#: wp-admin/setup-config.php:236
+msgctxt "example password"
+msgid "password"
+msgstr ""
+
+#: wp-admin/setup-config.php:237
+msgid "Your database password."
+msgstr ""
+
+#: wp-admin/setup-config.php:240
+msgid "Database Host"
+msgstr ""
+
+#. translators: %s: localhost
+#: wp-admin/setup-config.php:245
+msgid "You should be able to get this info from your web host, if %s does not work."
+msgstr ""
+
+#: wp-admin/setup-config.php:250
+msgid "Table Prefix"
+msgstr ""
+
+#: wp-admin/setup-config.php:252
+msgid "If you want to run multiple ClassicPress installations in a single database, change this."
+msgstr ""
+
+#: wp-admin/setup-config.php:260
+msgid "Submit"
+msgstr ""
+
+#: wp-admin/setup-config.php:291
+msgid "<strong>Error:</strong> \"Table Prefix\" must not be empty."
+msgstr ""
+
+#: wp-admin/setup-config.php:296
+msgid "<strong>Error:</strong> \"Table Prefix\" can only contain numbers, letters, and underscores."
+msgstr ""
+
+#: wp-admin/setup-config.php:330
+msgid "<strong>Error:</strong> \"Table Prefix\" is invalid."
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/setup-config.php:410
+#: wp-admin/setup-config.php:479
+msgid "Unable to write to %s file."
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/setup-config.php:416
+msgid "You can create the %s file manually and paste the following text into it."
+msgstr ""
+
+#. translators: %s: wp-config.php
+#: wp-admin/setup-config.php:428
+msgid "Configuration rules for %s:"
+msgstr ""
+
+#: wp-admin/setup-config.php:432
+msgid "After you&#8217;ve done that, click &#8220;Run the installation&#8221;."
+msgstr ""
+
+#: wp-admin/setup-config.php:433
+#: wp-admin/setup-config.php:498
+msgid "Run the installation"
+msgstr ""
+
+#. translators: 1: wp-config.php, 2: Documentation URL.
+#: wp-admin/setup-config.php:472
+msgid "You need to make the file %1$s writable before you can save your changes. See <a href=\"%2$s\">Changing File Permissions</a> for more information."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/setup-config.php:493
+msgid "Successful database connection"
+msgstr ""
+
+#: wp-admin/setup-config.php:496
+msgid "All right, sparky! You&#8217;ve made it through this part of the installation. ClassicPress can now communicate with your database. If you are ready, time now to&hellip;"
+msgstr ""
+
+#: wp-admin/site-health-info.php:24
+#: wp-admin/site-health.php:218
+msgid "The Site Health check requires JavaScript."
+msgstr ""
+
+#: wp-admin/site-health-info.php:37
+msgid "Site Health Info"
+msgstr ""
+
+#. translators: %s: URL to Site Health Status page.
+#: wp-admin/site-health-info.php:43
+msgid "This page can show you every detail about the configuration of your ClassicPress website. For any improvements that could be made, see the <a href=\"%s\">Site Health Status</a> page."
+msgstr ""
+
+#: wp-admin/site-health-info.php:47
+msgid "If you want to export a handy list of all the information on this page, you can use the button below to copy it to the clipboard. You can then paste it in a text file and save it to your device, or paste it in an email exchange with a support engineer or theme/plugin developer for example."
+msgstr ""
+
+#: wp-admin/site-health-info.php:53
+msgid "Copy site info to clipboard"
+msgstr ""
+
+#. translators: Tab heading for Site Health Status page.
+#: wp-admin/site-health.php:16
+msgctxt "Site Health"
+msgid "Status"
+msgstr ""
+
+#. translators: Tab heading for Site Health Info page.
+#: wp-admin/site-health.php:18
+msgctxt "Site Health"
+msgid "Info"
+msgstr ""
+
+#. translators: %s: The currently displayed tab.
+#: wp-admin/site-health.php:43
+msgid "Site Health - %s"
+msgstr ""
+
+#: wp-admin/site-health.php:48
+msgid "Sorry, you are not allowed to access site health information."
+msgstr ""
+
+#: wp-admin/site-health.php:62
+msgid "Sorry, you are not allowed to update this site to HTTPS."
+msgstr ""
+
+#: wp-admin/site-health.php:66
+msgid "It looks like HTTPS is not supported for your website at this point."
+msgstr ""
+
+#: wp-admin/site-health.php:82
+msgid "This screen allows you to obtain a health diagnosis of your site, and displays an overall rating of the status of your installation."
+msgstr ""
+
+#: wp-admin/site-health.php:83
+msgid "In the Status tab, you can see critical information about your ClassicPress configuration, along with anything else that requires your attention."
+msgstr ""
+
+#: wp-admin/site-health.php:84
+msgid "In the Info tab, you will find all the details about the configuration of your ClassicPress site, server, and database. There is also an export feature that allows you to copy all of the information about your site to the clipboard, to help solve problems on your site when obtaining support."
+msgstr ""
+
+#: wp-admin/site-health.php:90
+msgid "<a href=\"https://wordpress.org/documentation/article/site-health-screen/\">Documentation on Site Health tool</a>"
+msgstr ""
+
+#: wp-admin/site-health.php:101
+msgid "Site Health"
+msgstr ""
+
+#: wp-admin/site-health.php:109
+msgid "Site URLs switched to HTTPS."
+msgstr ""
+
+#: wp-admin/site-health.php:113
+msgid "Site URLs could not be switched to HTTPS."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/site-health.php:166
+msgid "Toggle extra menu items"
+msgstr ""
+
+#: wp-admin/site-health.php:228
+msgid "Great job!"
+msgstr ""
+
+#: wp-admin/site-health.php:232
+msgid "Everything is running smoothly here."
+msgstr ""
+
+#: wp-admin/site-health.php:241
+msgid "The site health check shows information about your ClassicPress configuration and items that may need your attention."
+msgstr ""
+
+#. translators: %s: Number of critical issues found.
+#: wp-admin/site-health.php:247
+#: wp-admin/js/site-health.js:150
+msgid "%s critical issue"
+msgid_plural "%s critical issues"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/site-health.php:251
+msgid "Critical issues are items that may have a high impact on your sites performance or security, and resolving these issues should be prioritized."
+msgstr ""
+
+#. translators: %s: Number of recommended improvements.
+#: wp-admin/site-health.php:260
+#: wp-admin/js/site-health.js:155
+msgid "%s recommended improvement"
+msgid_plural "%s recommended improvements"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/site-health.php:264
+msgid "Recommended items are considered beneficial to your site, although not as important to prioritize as a critical issue, they may include improvements to things such as; Performance, user experience, and more."
+msgstr ""
+
+#: wp-admin/site-health.php:272
+msgid "Passed tests"
+msgstr ""
+
+#. translators: %s: Number of items with no issues.
+#: wp-admin/site-health.php:281
+#: wp-admin/js/site-health.js:160
+msgid "%s item with no issues detected"
+msgid_plural "%s items with no issues detected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/theme-editor.php:22
+msgid "Edit Themes"
+msgstr ""
+
+#: wp-admin/theme-editor.php:30
+msgid "You can use the theme file editor to edit the individual CSS and PHP files which make up your theme."
+msgstr ""
+
+#: wp-admin/theme-editor.php:31
+msgid "Begin by choosing a theme to edit from the dropdown menu and clicking the Select button. A list then appears of the theme&#8217;s template files. Clicking once on any file name causes the file to appear in the large Editor box."
+msgstr ""
+
+#: wp-admin/theme-editor.php:32
+msgid "For PHP files, you can use the documentation dropdown to select from functions recognized in that file. Look Up takes you to a web page with reference material about that particular function."
+msgstr ""
+
+#: wp-admin/theme-editor.php:39
+msgid "After typing in your edits, click Update File."
+msgstr ""
+
+#: wp-admin/theme-editor.php:40
+msgid "<strong>Advice:</strong> Think very carefully about your site crashing if you are live-editing the theme currently in use."
+msgstr ""
+
+#. translators: %s: Link to documentation on child themes.
+#: wp-admin/theme-editor.php:43
+msgid "Upgrading to a newer version of the same theme will override changes made here. To avoid this, consider creating a <a href=\"%s\">child theme</a> instead."
+msgstr ""
+
+#: wp-admin/theme-editor.php:52
+msgid "<a href=\"https://developer.wordpress.org/themes/\">Documentation on Theme Development</a>"
+msgstr ""
+
+#: wp-admin/theme-editor.php:53
+msgid "<a href=\"https://wordpress.org/documentation/article/appearance-theme-file-editor-screen/\">Documentation on Editing Themes</a>"
+msgstr ""
+
+#: wp-admin/theme-editor.php:54
+msgid "<a href=\"https://wordpress.org/documentation/article/editing-files/\">Documentation on Editing Files</a>"
+msgstr ""
+
+#: wp-admin/theme-editor.php:55
+msgid "<a href=\"https://developer.wordpress.org/themes/basics/template-tags/\">Documentation on Template Tags</a>"
+msgstr ""
+
+#: wp-admin/theme-editor.php:205
+msgid "Did you know?"
+msgstr ""
+
+#. translators: %s: Link to Custom CSS section in the Customizer.
+#: wp-admin/theme-editor.php:210
+msgid "There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href=\"%s\">built-in CSS editor</a>."
+msgstr ""
+
+#: wp-admin/theme-editor.php:231
+msgid "Select theme to edit:"
+msgstr ""
+
+#: wp-admin/theme-editor.php:252
+msgid "This theme is broken."
+msgstr ""
+
+#: wp-admin/theme-editor.php:257
+msgid "Theme Files"
+msgstr ""
+
+#. translators: %s: Link to edit parent theme.
+#: wp-admin/theme-editor.php:264
+msgid "This child theme inherits templates from a parent theme, %s."
+msgstr ""
+
+#: wp-admin/theme-editor.php:313
+msgid "This is a file in your current parent theme."
+msgstr ""
+
+#: wp-admin/theme-editor.php:367
+msgid "You appear to be making direct edits to your theme in the ClassicPress dashboard. It is not recommended! Editing your theme directly could break your site and your changes may be lost in future updates."
+msgstr ""
+
+#. translators: %s: Link to documentation on child themes.
+#: wp-admin/theme-editor.php:375
+msgid "If you need to tweak more than your theme&#8217;s CSS, you might want to try <a href=\"%s\">making a child theme</a>."
+msgstr ""
+
+#: wp-admin/theme-editor.php:381
+msgid "If you decide to go ahead with direct edits anyway, use a file manager to create a copy with a new name and hang on to the original. That way, you can re-enable a functional version if something goes wrong."
+msgstr ""
+
+#: wp-admin/theme-install.php:25
+msgid "Add Themes"
+msgstr ""
+
+#: wp-admin/theme-install.php:57
+#: wp-admin/themes.php:232
+msgid "Add New Theme"
+msgstr ""
+
+#: wp-admin/theme-install.php:58
+msgid "Search Themes"
+msgstr ""
+
+#: wp-admin/theme-install.php:59
+msgid "Search themes..."
+msgstr ""
+
+#: wp-admin/theme-install.php:60
+#: wp-admin/theme-install.php:165
+#: wp-admin/theme-install.php:167
+#: wp-admin/update.php:340
+msgid "Upload Theme"
+msgstr ""
+
+#: wp-admin/theme-install.php:61
+msgid "Back"
+msgstr ""
+
+#. translators: %s: Support forums URL.
+#: wp-admin/theme-install.php:64
+msgid "An unexpected error occurred. Something may be wrong with WordPress.org, ClassicPress.net, or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
+msgstr ""
+
+#. translators: %d: Number of themes.
+#: wp-admin/theme-install.php:69
+#: wp-admin/themes.php:236
+msgid "Number of Themes found: %d"
+msgstr ""
+
+#: wp-admin/theme-install.php:70
+#: wp-admin/theme-install.php:245
+#: wp-admin/themes.php:237
+#: wp-admin/themes.php:583
+msgid "No themes found. Try a different search."
+msgstr ""
+
+#: wp-admin/theme-install.php:72
+msgid "Expand Sidebar"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/theme-install.php:74
+msgid "Select one or more Theme features to filter by"
+msgstr ""
+
+#. translators: %s: Theme Directory URL.
+#: wp-admin/theme-install.php:110
+msgid "You can find additional themes for your site by using the Theme Browser/Installer on this screen, which will display themes from the <a href=\"%s\">ClassicPress Theme Directory</a>. These themes are designed and developed by third parties, are available free of charge, and are compatible with the license WordPress uses."
+msgstr ""
+
+#: wp-admin/theme-install.php:113
+msgid "You can Search for themes by keyword, author, or tag, or can get more specific and search by criteria listed in the feature filter."
+msgstr ""
+
+#: wp-admin/theme-install.php:114
+msgid "Alternately, you can browse the themes that are Popular or Latest. When you find a theme you like, you can preview it or install it."
+msgstr ""
+
+#. translators: %s: /wp-content/themes
+#: wp-admin/theme-install.php:117
+msgid "You can Upload a theme manually if you have already downloaded its ZIP archive onto your computer (make sure it is from a trusted and original source). You can also do it the old-fashioned way and copy a downloaded theme&#8217;s folder via FTP into your %s directory."
+msgstr ""
+
+#: wp-admin/theme-install.php:130
+msgid "Once you have generated a list of themes, you can preview and install any of them. Click on the thumbnail of the theme you are interested in previewing. It will open up in a full-screen Preview page to give you a better idea of how that theme will look."
+msgstr ""
+
+#: wp-admin/theme-install.php:131
+msgid "To install the theme so you can preview it with your site&#8217;s content and customize its theme options, click the \"Install\" button at the top of the left-hand pane. The theme files will be downloaded to your website automatically. When this is complete, the theme is now available for activation, which you can do by clicking the \"Activate\" link, or by navigating to your Manage Themes screen and clicking the \"Live Preview\" link under any installed theme&#8217;s thumbnail image."
+msgstr ""
+
+#: wp-admin/theme-install.php:136
+msgid "Previewing and Installing"
+msgstr ""
+
+#: wp-admin/theme-install.php:143
+msgid "<a href=\"https://wordpress.org/documentation/article/appearance-themes-screen/#install-themes\">Documentation on Adding New Themes</a>"
+msgstr ""
+
+#: wp-admin/theme-install.php:144
+msgid "<a href=\"https://wordpress.org/documentation/article/block-themes/\">Documentation on Block Themes</a>"
+msgstr ""
+
+#: wp-admin/theme-install.php:174
+msgid "The Theme Installer screen requires JavaScript."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/theme-install.php:184
+msgid "Filter themes list"
+msgstr ""
+
+#: wp-admin/theme-install.php:194
+msgctxt "themes"
+msgid "Popular"
+msgstr ""
+
+#: wp-admin/theme-install.php:204
+#: wp-admin/theme-install.php:226
+msgid "Apply Filters"
+msgstr ""
+
+#: wp-admin/theme-install.php:205
+#: wp-admin/theme-install.php:227
+msgid "Clear current filters"
+msgstr ""
+
+#: wp-admin/theme-install.php:205
+#: wp-admin/theme-install.php:227
+#: wp-admin/js/color-picker.js:154
+msgid "Clear"
+msgstr ""
+
+#: wp-admin/theme-install.php:230
+msgid "Filtering by:"
+msgstr ""
+
+#: wp-admin/theme-install.php:232
+msgid "Edit Filters"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/theme-install.php:239
+msgid "Themes list"
+msgstr ""
+
+#: wp-admin/theme-install.php:348
+msgctxt "theme"
+msgid "Details &amp; Preview"
+msgstr ""
+
+#: wp-admin/theme-install.php:370
+#: wp-admin/theme-install.php:445
+msgctxt "theme"
+msgid "Activated"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/theme-install.php:383
+#: wp-admin/themes.php:567
+#: wp-admin/themes.php:927
+#: wp-admin/themes.php:1157
+msgctxt "theme"
+msgid "Cannot Activate %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/theme-install.php:405
+msgctxt "theme"
+msgid "Cannot Install %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/theme-install.php:427
+msgid "Previous theme"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/theme-install.php:433
+msgid "Next theme"
+msgstr ""
+
+#: wp-admin/theme-install.php:484
+msgid "This theme has not been rated yet."
+msgstr ""
+
+#: wp-admin/themes.php:43
+msgid "Sorry, you are not allowed to resume this theme."
+msgstr ""
+
+#: wp-admin/themes.php:86
+msgid "Sorry, you are not allowed to enable themes automatic updates."
+msgstr ""
+
+#: wp-admin/themes.php:106
+msgid "Sorry, you are not allowed to disable themes automatic updates."
+msgstr ""
+
+#: wp-admin/themes.php:127
+#: wp-admin/themes.php:250
+#: wp-admin/update-core.php:480
+#: wp-admin/update-core.php:493
+msgid "Themes"
+msgstr ""
+
+#: wp-admin/themes.php:132
+msgid "This screen is used for managing your installed themes. Aside from the default theme(s) included with your WordPress installation, themes are designed and developed by third parties."
+msgstr ""
+
+#: wp-admin/themes.php:134
+msgid "Hover or tap to see Activate and Live Preview buttons"
+msgstr ""
+
+#: wp-admin/themes.php:135
+msgid "Click on the theme to see the theme name, version, author, description, tags, and the Delete link"
+msgstr ""
+
+#: wp-admin/themes.php:136
+msgid "Click Customize for the active theme or Live Preview for any other theme to see a live preview"
+msgstr ""
+
+#: wp-admin/themes.php:137
+msgid "The active theme is displayed highlighted as the first theme."
+msgstr ""
+
+#: wp-admin/themes.php:138
+msgid "The search for installed themes will search for terms in their name, description, author, or tag."
+msgstr ""
+
+#: wp-admin/themes.php:152
+msgid "Installing themes on Multisite can only be done from the Network Admin section."
+msgstr ""
+
+#. translators: %s: https://wordpress.org/themes
+#: wp-admin/themes.php:156
+msgid "If you would like to see more themes to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional themes from the <a href=\"%s\">ClassicPress Theme Directory</a>. Themes in the WordPress Theme Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!"
+msgstr ""
+
+#: wp-admin/themes.php:164
+msgid "Adding Themes"
+msgstr ""
+
+#: wp-admin/themes.php:173
+msgid "Tap or hover on any theme then click the Live Preview button to see a live preview of that theme and change theme options in a separate, full-screen view. You can also find a Live Preview button at the bottom of the theme details screen. Any installed theme can be previewed and customized in this way."
+msgstr ""
+
+#: wp-admin/themes.php:174
+msgid "The theme being previewed is fully interactive &mdash; navigate to different pages to see how the theme handles posts, archives, and other page templates. The settings may differ depending on what theme features the theme being previewed supports. To accept the new settings and activate the theme all in one step, click the Activate &amp; Publish button above the menu."
+msgstr ""
+
+#: wp-admin/themes.php:175
+msgid "When previewing on smaller monitors, you can use the collapse icon at the bottom of the left-hand pane. This will hide the pane, giving you more room to preview your site in the new theme. To bring the pane back, click on the collapse icon again."
+msgstr ""
+
+#: wp-admin/themes.php:180
+msgid "Previewing and Customizing"
+msgstr ""
+
+#: wp-admin/themes.php:191
+msgid "Auto-updates can be enabled or disabled for each individual theme. Themes with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system."
+msgstr ""
+
+#: wp-admin/themes.php:207
+msgid "<a href=\"https://wordpress.org/documentation/article/work-with-themes/\">Documentation on Using Themes</a>"
+msgstr ""
+
+#: wp-admin/themes.php:208
+msgid "<a href=\"https://wordpress.org/documentation/article/appearance-themes-screen/\">Documentation on Managing Themes</a>"
+msgstr ""
+
+#: wp-admin/themes.php:228
+msgid ""
+"Are you sure you want to delete this theme?\n"
+"\n"
+"Click 'Cancel' to go back, 'OK' to confirm the delete."
+msgstr ""
+
+#: wp-admin/themes.php:233
+msgid "Search Installed Themes"
+msgstr ""
+
+#: wp-admin/themes.php:234
+msgid "Search installed themes..."
+msgstr ""
+
+#: wp-admin/themes.php:251
+msgid "&hellip;"
+msgstr ""
+
+#: wp-admin/themes.php:255
+msgctxt "theme"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/themes.php:264
+msgid "The active theme is broken. Reverting to the default theme."
+msgstr ""
+
+#: wp-admin/themes.php:269
+msgid "Settings saved and theme activated."
+msgstr ""
+
+#: wp-admin/themes.php:269
+#: wp-admin/themes.php:273
+msgid "Visit site"
+msgstr ""
+
+#: wp-admin/themes.php:273
+msgid "New theme activated."
+msgstr ""
+
+#: wp-admin/themes.php:278
+msgid "Theme deleted."
+msgstr ""
+
+#: wp-admin/themes.php:282
+msgid "You cannot delete a theme while it has an active child theme."
+msgstr ""
+
+#: wp-admin/themes.php:286
+msgid "Theme resumed."
+msgstr ""
+
+#: wp-admin/themes.php:290
+msgid "Theme could not be resumed because it triggered a <strong>fatal error</strong>."
+msgstr ""
+
+#: wp-admin/themes.php:294
+msgid "Theme will be auto-updated."
+msgstr ""
+
+#: wp-admin/themes.php:298
+msgid "Theme will no longer be auto-updated."
+msgstr ""
+
+#: wp-admin/themes.php:401
+#: wp-admin/themes.php:752
+msgid "New version available. <button class=\"button-link\" type=\"button\">Update now</button>"
+msgstr ""
+
+#: wp-admin/themes.php:403
+#: wp-admin/themes.php:754
+msgid "New version available."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/themes.php:523
+#: wp-admin/themes.php:882
+msgctxt "theme"
+msgid "View Theme Details for %s"
+msgstr ""
+
+#: wp-admin/themes.php:525
+#: wp-admin/themes.php:581
+#: wp-admin/themes.php:884
+msgid "Theme Details"
+msgstr ""
+
+#: wp-admin/themes.php:536
+#: wp-admin/themes.php:895
+msgctxt "theme"
+msgid "Active:"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/themes.php:547
+#: wp-admin/themes.php:906
+msgctxt "theme"
+msgid "Customize %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/themes.php:560
+#: wp-admin/themes.php:920
+msgctxt "theme"
+msgid "Live Preview %s"
+msgstr ""
+
+#: wp-admin/themes.php:592
+msgid "Broken Themes"
+msgstr ""
+
+#: wp-admin/themes.php:593
+msgid "The following themes are installed but incomplete."
+msgstr ""
+
+#: wp-admin/themes.php:602
+msgctxt "theme name"
+msgid "Name"
+msgstr ""
+
+#: wp-admin/themes.php:669
+msgid "Install Parent Theme"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/themes.php:1169
+msgctxt "theme"
+msgid "Delete %s"
+msgstr ""
+
+#: wp-admin/tools.php:49
+msgid "Categories have hierarchy, meaning that you can nest sub-categories. Tags do not have hierarchy and cannot be nested. Sometimes people start out using one on their posts, then later realize that the other would work better for their content."
+msgstr ""
+
+#: wp-admin/tools.php:50
+msgid "The Categories and Tags Converter link on this screen will take you to the Import screen, where that Converter is one of the plugins you can install. Once that plugin is installed, the Activate Plugin &amp; Run Importer link will take you to a screen where you can choose to convert tags into categories or vice versa."
+msgstr ""
+
+#: wp-admin/tools.php:56
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-screen/\">Documentation on Tools</a>"
+msgstr ""
+
+#. translators: %s: URL to Import screen.
+#: wp-admin/tools.php:78
+msgid "If you want to convert your categories to tags (or vice versa), use the <a href=\"%s\">Categories and Tags Converter</a> available from the Import screen."
+msgstr ""
+
+#: wp-admin/update-core.php:23
+#: wp-admin/update-core.php:945
+#: wp-admin/update-core.php:981
+#: wp-admin/update-core.php:1022
+#: wp-admin/update-core.php:1063
+msgid "Sorry, you are not allowed to update this site."
+msgstr ""
+
+#. translators: %s: ClassicPress version.
+#: wp-admin/update-core.php:71
+msgid "Update to latest %s nightly"
+msgstr ""
+
+#: wp-admin/update-core.php:78
+msgid "You are using a development version of ClassicPress. You can update to the latest nightly build automatically:"
+msgstr ""
+
+#: wp-admin/update-core.php:81
+msgid "If you need to re-install version %s, you can do so here:"
+msgstr ""
+
+#: wp-admin/update-core.php:82
+msgid "Re-install Now"
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number
+#: wp-admin/update-core.php:94
+msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s."
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number
+#: wp-admin/update-core.php:97
+msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s."
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number
+#: wp-admin/update-core.php:100
+msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s."
+msgstr ""
+
+#. translators: 1: ClassicPress version number, 2: ClassicPress version number including locale if necessary
+#: wp-admin/update-core.php:102
+msgid "You can update to <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %2$s</a> automatically:"
+msgstr ""
+
+#: wp-admin/update-core.php:130
+msgid "Hide this update"
+msgstr ""
+
+#: wp-admin/update-core.php:132
+msgid "Bring back this update"
+msgstr ""
+
+#: wp-admin/update-core.php:138
+msgid "This localized version contains both the translation and various other localization fixes."
+msgstr ""
+
+#. translators: %s: WordPress version.
+#: wp-admin/update-core.php:143
+msgid "You are about to install ClassicPress %s <strong>in English (US)</strong>. There is a chance this update will break your translation. You may prefer to wait for the localized version to be released."
+msgstr ""
+
+#: wp-admin/update-core.php:165
+#: wp-admin/update-core.php:184
+msgid "Show hidden updates"
+msgstr ""
+
+#: wp-admin/update-core.php:166
+msgid "Hide hidden updates"
+msgstr ""
+
+#: wp-admin/update-core.php:213
+msgid "You are running a development version of ClassicPress."
+msgstr ""
+
+#: wp-admin/update-core.php:216
+msgid "Development versions of ClassicPress do not receive automatic updates."
+msgstr ""
+
+#: wp-admin/update-core.php:220
+msgid "Unable to determine whether a ClassicPress update is available."
+msgstr ""
+
+#: wp-admin/update-core.php:223
+msgid "You may be running a customized build of ClassicPress, or your server may be having internet connectivity problems."
+msgstr ""
+
+#: wp-admin/update-core.php:228
+msgid "You have the latest version of ClassicPress."
+msgstr ""
+
+#: wp-admin/update-core.php:243
+msgid "Future security updates will be applied automatically."
+msgstr ""
+
+#: wp-admin/update-core.php:250
+msgid "<strong>Important:</strong> before updating, please <a href=\"%1$s\">back up your database and files</a>. For help with updates, visit the <a href=\"%2$s\">Updating ClassicPress</a> documentation page."
+msgstr ""
+
+#: wp-admin/update-core.php:257
+msgid "An updated version of ClassicPress is available."
+msgstr ""
+
+#: wp-admin/update-core.php:266
+msgid "BETA TESTERS:"
+msgstr ""
+
+#: wp-admin/update-core.php:266
+msgid "This site is set up to install updates of future beta versions automatically."
+msgstr ""
+
+#: wp-admin/update-core.php:281
+msgid "While your site is being updated, it will be in maintenance mode. As soon as your updates are complete, this mode will be deactivated."
+msgstr ""
+
+#. translators: 1: URL to About screen, 2: WordPress version.
+#: wp-admin/update-core.php:285
+msgid "<a href=\"%1$s\">Learn more about ClassicPress %2$s</a>."
+msgstr ""
+
+#: wp-admin/update-core.php:304
+msgid "Your plugins are all up to date."
+msgstr ""
+
+#: wp-admin/update-core.php:327
+msgid "The following plugins have new versions available. Check the ones you want to update and then click &#8220;Update Plugins&#8221;."
+msgstr ""
+
+#: wp-admin/update-core.php:362
+#: wp-admin/update-core.php:375
+msgid "Expected compatibility with ClassicPress %1$s: 100%%."
+msgstr ""
+
+#: wp-admin/update-core.php:363
+#: wp-admin/update-core.php:367
+#: wp-admin/update-core.php:370
+#: wp-admin/update-core.php:376
+#: wp-admin/update-core.php:380
+#: wp-admin/update-core.php:383
+msgid "More info."
+msgstr ""
+
+#: wp-admin/update-core.php:366
+msgid "Expected Compatibility with ClassicPress %1$s: %2$d%% (%3$d \"works\" votes out of %4$d total)."
+msgstr ""
+
+#: wp-admin/update-core.php:369
+#: wp-admin/update-core.php:382
+msgid "Expected compatibility with ClassicPress %1$s: Unknown."
+msgstr ""
+
+#: wp-admin/update-core.php:379
+msgid "Expected compatibility with ClassicPress %1$s: %2$d%% (%3$d \"works\" votes out of %4$d total)."
+msgstr ""
+
+#: wp-admin/update-core.php:391
+msgid "This update doesn&#8217;t work with your version of PHP."
+msgstr ""
+
+#: wp-admin/update-core.php:394
+msgid "<a href=\"%s\">Learn more about updating PHP.</a>"
+msgstr ""
+
+#. translators: %s: Plugin version.
+#: wp-admin/update-core.php:419
+msgid "View version %s details."
+msgstr ""
+
+#. translators: 1: Plugin version, 2: New version.
+#. translators: 1: Theme version, 2: New version.
+#: wp-admin/update-core.php:442
+#: wp-admin/update-core.php:616
+msgid "You have version %1$s installed. Update to %2$s."
+msgstr ""
+
+#: wp-admin/update-core.php:481
+msgid "Your themes are all up to date."
+msgstr ""
+
+#: wp-admin/update-core.php:498
+msgid "The following themes have new versions available. Check the ones you want to update and then click &#8220;Update Themes&#8221;."
+msgstr ""
+
+#. translators: %s: Link to documentation on child themes.
+#: wp-admin/update-core.php:503
+msgid "<strong>Please Note:</strong> Any customizations you have made to theme files will be lost. Please consider using <a href=\"%s\">child themes</a> for modifications."
+msgstr ""
+
+#: wp-admin/update-core.php:510
+#: wp-admin/update-core.php:641
+#: wp-admin/update-core.php:1040
+#: wp-admin/update-core.php:1045
+msgid "Update Themes"
+msgstr ""
+
+#: wp-admin/update-core.php:537
+msgid "This update does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#: wp-admin/update-core.php:571
+msgid "This update does not work with your version of ClassicPress."
+msgstr ""
+
+#: wp-admin/update-core.php:580
+msgid "This update does not work with your version of PHP."
+msgstr ""
+
+#: wp-admin/update-core.php:655
+#: wp-admin/update-core.php:663
+msgid "Translations"
+msgstr ""
+
+#: wp-admin/update-core.php:665
+msgid "New translations are available."
+msgstr ""
+
+#: wp-admin/update-core.php:706
+msgid "Update ClassicPress"
+msgstr ""
+
+#: wp-admin/update-core.php:754
+msgid "It's possible that an update started, but the server encountered a temporary issue and could not continue."
+msgstr ""
+
+#: wp-admin/update-core.php:759
+msgid "Or, you may have clicked the update button multiple times."
+msgstr ""
+
+#: wp-admin/update-core.php:764
+msgid "Please wait <strong>15 minutes</strong> and try again."
+msgstr ""
+
+#. translators: URL to support forum
+#: wp-admin/update-core.php:771
+msgid "If you see this message after waiting 15 minutes and trying the update again, please make a post on our <a href=\"%s\">support forum</a>."
+msgstr ""
+
+#: wp-admin/update-core.php:779
+msgid "Installation Failed"
+msgstr ""
+
+#: wp-admin/update-core.php:836
+#: wp-admin/update-core.php:879
+msgid "ClassicPress Updates"
+msgstr ""
+
+#: wp-admin/update-core.php:839
+msgid "On this screen, you can update to the latest version of ClassicPress, as well as update your themes, plugins, and translations from the ClassicPress.net repositories."
+msgstr ""
+
+#: wp-admin/update-core.php:840
+msgid "If an update is available, you&#8127;ll see a notification appear in the Toolbar and navigation menu."
+msgstr ""
+
+#: wp-admin/update-core.php:850
+msgid "<strong>ClassicPress</strong> &mdash; Updating your ClassicPress installation is a simple one-click procedure: just <strong>click on the &#8220;Update Now&#8221; button</strong> when you are notified that a new version is available."
+msgstr ""
+
+#: wp-admin/update-core.php:850
+msgid "In most cases, ClassicPress will automatically apply maintenance and security updates in the background for you."
+msgstr ""
+
+#: wp-admin/update-core.php:851
+msgid "<strong>Themes and Plugins</strong> &mdash; To update individual themes or plugins from this screen, use the checkboxes to make your selection, then <strong>click on the appropriate &#8220;Update&#8221; button</strong>. To update all of your themes or plugins at once, you can check the box at the top of the section to select all before clicking the update button."
+msgstr ""
+
+#: wp-admin/update-core.php:854
+msgid "<strong>Translations</strong> &mdash; The files translating ClassicPress into your language are updated for you whenever any other updates occur. But if these files are out of date, you can <strong>click the &#8220;Update Translations&#8221;</strong> button."
+msgstr ""
+
+#: wp-admin/update-core.php:860
+msgid "How to Update"
+msgstr ""
+
+#: wp-admin/update-core.php:867
+msgid "<a href=\"https://codex.wordpress.org/Dashboard_Updates_Screen\">Documentation on Updating ClassicPress</a>"
+msgstr ""
+
+#: wp-admin/update-core.php:880
+msgid "Here you can find information about updates, set auto-updates and see what plugins or themes need updating."
+msgstr ""
+
+#: wp-admin/update-core.php:886
+msgid "Please select one or more themes to update."
+msgstr ""
+
+#: wp-admin/update-core.php:888
+msgid "Please select one or more plugins to update."
+msgstr ""
+
+#. translators: Current version of WordPress.
+#: wp-admin/update-core.php:902
+msgid "Current version: %s"
+msgstr ""
+
+#. translators: 1: Date, 2: Time.
+#: wp-admin/update-core.php:907
+msgid "Last checked on %1$s at %2$s."
+msgstr ""
+
+#. translators: 1: Date, 2: Time.
+#: wp-admin/update-core.php:907
+msgid "g:i a T"
+msgstr ""
+
+#: wp-admin/update-core.php:908
+msgid "Check again."
+msgstr ""
+
+#: wp-admin/update.php:90
+msgid "Plugin Reactivation"
+msgstr ""
+
+#: wp-admin/update.php:92
+msgid "Plugin reactivated successfully."
+msgstr ""
+
+#: wp-admin/update.php:96
+msgid "Plugin failed to reactivate due to a fatal error."
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/update.php:159
+msgid "Installing Plugin: %s"
+msgstr ""
+
+#: wp-admin/update.php:182
+#: wp-admin/update.php:334
+msgid "Only .zip archives may be uploaded."
+msgstr ""
+
+#. translators: %s: File name.
+#: wp-admin/update.php:195
+msgid "Installing plugin from uploaded file: %s"
+msgstr ""
+
+#: wp-admin/update.php:308
+msgid "Install Themes"
+msgstr ""
+
+#. translators: %s: Theme name and version.
+#: wp-admin/update.php:315
+msgid "Installing Theme: %s"
+msgstr ""
+
+#. translators: %s: File name.
+#: wp-admin/update.php:347
+msgid "Installing theme from uploaded file: %s"
+msgstr ""
+
+#: wp-admin/upgrade.php:65
+msgid "ClassicPress &rsaquo; Update"
+msgstr ""
+
+#: wp-admin/upgrade.php:73
+msgid "No Update Required"
+msgstr ""
+
+#: wp-admin/upgrade.php:74
+msgid "Your ClassicPress database is already up to date!"
+msgstr ""
+
+#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required PHP version number, 4: Minimum required MySQL version number, 5: Current PHP version number, 6: Current MySQL version number.
+#: wp-admin/upgrade.php:100
+msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires PHP version %3$s or higher and MySQL version %4$s or higher. You are running PHP version %5$s and MySQL version %6$s."
+msgstr ""
+
+#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required PHP version number, 4: Current PHP version number.
+#: wp-admin/upgrade.php:111
+msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires PHP version %3$s or higher. You are running version %4$s."
+msgstr ""
+
+#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required MySQL version number, 4: Current MySQL version number.
+#: wp-admin/upgrade.php:120
+msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires MySQL version %3$s or higher. You are running version %4$s."
+msgstr ""
+
+#: wp-admin/upgrade.php:140
+msgid "Database Update Required"
+msgstr ""
+
+#: wp-admin/upgrade.php:141
+msgid "ClassicPress has been updated! Next and final step is to update your database to the newest version."
+msgstr ""
+
+#: wp-admin/upgrade.php:142
+msgid "The database update process may take a little while, so please be patient."
+msgstr ""
+
+#: wp-admin/upgrade.php:143
+msgid "Update ClassicPress Database"
+msgstr ""
+
+#: wp-admin/upgrade.php:153
+msgid "Update Complete"
+msgstr ""
+
+#: wp-admin/upgrade.php:154
+msgid "Your ClassicPress database has been successfully updated!"
+msgstr ""
+
+#: wp-admin/upload.php:26
+msgid "Media file attached."
+msgstr ""
+
+#. translators: %s: Number of media files.
+#: wp-admin/upload.php:29
+msgid "%s media file attached."
+msgid_plural "%s media files attached."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/upload.php:39
+msgid "Media file detached."
+msgstr ""
+
+#. translators: %s: Number of media files.
+#: wp-admin/upload.php:42
+msgid "%s media file detached."
+msgid_plural "%s media files detached."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/upload.php:52
+#: wp-admin/upload.php:90
+msgid "Media file permanently deleted."
+msgstr ""
+
+#. translators: %s: Number of media files.
+#: wp-admin/upload.php:55
+msgid "%s media file permanently deleted."
+msgid_plural "%s media files permanently deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/upload.php:65
+#: wp-admin/upload.php:92
+msgid "Media file moved to the Trash."
+msgstr ""
+
+#. translators: %s: Number of media files.
+#: wp-admin/upload.php:68
+msgid "%s media file moved to the Trash."
+msgid_plural "%s media files moved to the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/upload.php:79
+#: wp-admin/upload.php:93
+msgid "Media file restored from the Trash."
+msgstr ""
+
+#. translators: %s: Number of media files.
+#: wp-admin/upload.php:82
+msgid "%s media file restored from the Trash."
+msgid_plural "%s media files restored from the Trash."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/upload.php:91
+msgid "Error saving media file."
+msgstr ""
+
+#: wp-admin/upload.php:140
+msgid "All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first."
+msgstr ""
+
+#: wp-admin/upload.php:141
+#: wp-admin/upload.php:323
+msgid "You can view your media in a simple visual grid or a list with columns. Switch between these views using the icons to the left above the media."
+msgstr ""
+
+#: wp-admin/upload.php:142
+msgid "To delete media items, click the Bulk Select button at the top of the screen. Select any items you wish to delete, then click the Delete Selected button. Clicking the Cancel Selection button takes you back to viewing your media."
+msgstr ""
+
+#: wp-admin/upload.php:149
+msgid "Attachment Details"
+msgstr ""
+
+#: wp-admin/upload.php:151
+msgid "Clicking an item will display an Attachment Details dialog, which allows you to preview media and make quick edits. Any changes you make to the attachment details will be automatically saved."
+msgstr ""
+
+#: wp-admin/upload.php:152
+msgid "Use the arrow buttons at the top of the dialog, or the left and right arrow keys on your keyboard, to navigate between media items quickly."
+msgstr ""
+
+#: wp-admin/upload.php:153
+msgid "You can also delete individual items and access the extended edit screen from the details dialog."
+msgstr ""
+
+#: wp-admin/upload.php:159
+#: wp-admin/upload.php:352
+msgid "<a href=\"https://wordpress.org/documentation/article/media-library-screen/\">Documentation on Media Library</a>"
+msgstr ""
+
+#. translators: %s: List view URL.
+#: wp-admin/upload.php:191
+msgid "The grid view for the Media Library requires JavaScript. <a href=\"%s\">Switch to the list view</a>."
+msgstr ""
+
+#: wp-admin/upload.php:321
+msgid "All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first. You can use the Screen Options tab to customize the display of this screen."
+msgstr ""
+
+#: wp-admin/upload.php:322
+msgid "You can narrow the list by file type/status or by date using the dropdown menus above the media table."
+msgstr ""
+
+#: wp-admin/upload.php:331
+msgid "Hovering over a row reveals action links that allow you to manage media items. You can perform the following actions:"
+msgstr ""
+
+#: wp-admin/upload.php:333
+msgid "<strong>Edit</strong> takes you to a simple screen to edit that individual file&#8217;s metadata. You can also reach that screen by clicking on the media file name or thumbnail."
+msgstr ""
+
+#: wp-admin/upload.php:334
+msgid "<strong>Delete Permanently</strong> will delete the file from the media library (as well as from any posts to which it is currently attached)."
+msgstr ""
+
+#: wp-admin/upload.php:335
+msgid "<strong>View</strong> will take you to a public display page for that file."
+msgstr ""
+
+#: wp-admin/upload.php:336
+msgid "<strong>Copy URL</strong> copies the URL for the media file to your clipboard."
+msgstr ""
+
+#: wp-admin/upload.php:337
+msgid "<strong>Download file</strong> downloads the original media file to your device."
+msgstr ""
+
+#: wp-admin/upload.php:344
+msgid "Attaching Files"
+msgstr ""
+
+#: wp-admin/upload.php:346
+msgid "If a media file has not been attached to any content, you will see that in the Uploaded To column, and can click on Attach to launch a small popup that will allow you to search for existing content and attach the file."
+msgstr ""
+
+#: wp-admin/upload.php:358
+msgid "Filter media items list"
+msgstr ""
+
+#: wp-admin/upload.php:359
+msgid "Media items list navigation"
+msgstr ""
+
+#: wp-admin/upload.php:360
+msgid "Media items list"
+msgstr ""
+
+#: wp-admin/user-edit.php:27
+#: wp-admin/user-edit.php:29
+msgid "Invalid user ID."
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/user-edit.php:44
+msgid "Edit User %s"
+msgstr ""
+
+#: wp-admin/user-edit.php:59
+msgid "Your profile contains information about you (your &#8220;account&#8221;) as well as some personal options related to using ClassicPress."
+msgstr ""
+
+#: wp-admin/user-edit.php:60
+msgid "You can change your password, turn on keyboard shortcuts, change the color scheme of your ClassicPress administration screens, and turn off the WYSIWYG (Visual) editor, among other things. You can hide the Toolbar (formerly called the Admin Bar) from the front end of your site, however it cannot be disabled on the admin screens."
+msgstr ""
+
+#: wp-admin/user-edit.php:61
+msgid "You can select the language you wish to use while using the ClassicPress administration screen without affecting the language site visitors see."
+msgstr ""
+
+#: wp-admin/user-edit.php:62
+msgid "Your username cannot be changed, but you can use other fields to enter your real name or a nickname, and change which name to display on your posts."
+msgstr ""
+
+#: wp-admin/user-edit.php:63
+msgid "You can log out of other devices, such as your phone or a public computer, by clicking the Log Out Everywhere Else button."
+msgstr ""
+
+#: wp-admin/user-edit.php:64
+msgid "Required fields are indicated; the rest are optional. Profile information will only be displayed if your theme is set up to do so."
+msgstr ""
+
+#: wp-admin/user-edit.php:65
+msgid "Remember to click the Update Profile button when you are finished."
+msgstr ""
+
+#: wp-admin/user-edit.php:77
+msgid "<a href=\"https://wordpress.org/documentation/article/users-your-profile-screen/\">Documentation on User Profiles</a>"
+msgstr ""
+
+#: wp-admin/user-edit.php:103
+#: wp-admin/user-edit.php:135
+#: wp-admin/user-edit.php:194
+#: wp-admin/users.php:114
+#: wp-admin/users.php:144
+#: wp-admin/users.php:243
+msgid "Sorry, you are not allowed to edit this user."
+msgstr ""
+
+#: wp-admin/user-edit.php:204
+msgid "This user has super admin privileges."
+msgstr ""
+
+#: wp-admin/user-edit.php:210
+msgid "Profile updated."
+msgstr ""
+
+#: wp-admin/user-edit.php:212
+msgid "User updated."
+msgstr ""
+
+#: wp-admin/user-edit.php:215
+msgid "&larr; Go to Users"
+msgstr ""
+
+#: wp-admin/user-edit.php:223
+msgid "Error while saving the new email address. Please try again."
+msgstr ""
+
+#: wp-admin/user-edit.php:243
+#: wp-admin/users.php:630
+msgctxt "user"
+msgid "Add Existing"
+msgstr ""
+
+#: wp-admin/user-edit.php:279
+msgid "Personal Options"
+msgstr ""
+
+#: wp-admin/user-edit.php:286
+msgid "Visual Editor"
+msgstr ""
+
+#: wp-admin/user-edit.php:289
+msgid "Disable the visual editor when writing"
+msgstr ""
+
+#: wp-admin/user-edit.php:310
+msgid "Syntax Highlighting"
+msgstr ""
+
+#: wp-admin/user-edit.php:313
+msgid "Disable syntax highlighting when editing code"
+msgstr ""
+
+#: wp-admin/user-edit.php:343
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: wp-admin/user-edit.php:347
+msgid "Enable keyboard shortcuts for comment moderation."
+msgstr ""
+
+#: wp-admin/user-edit.php:355
+msgid "Toolbar"
+msgstr ""
+
+#: wp-admin/user-edit.php:359
+msgid "Show Toolbar when viewing site"
+msgstr ""
+
+#. translators: The user language selection field label.
+#: wp-admin/user-edit.php:372
+#: wp-admin/user-new.php:560
+msgid "Language"
+msgstr ""
+
+#: wp-admin/user-edit.php:433
+msgid "Usernames cannot be changed."
+msgstr ""
+
+#: wp-admin/user-edit.php:466
+msgid "Grant this user super admin privileges for the Network."
+msgstr ""
+
+#: wp-admin/user-edit.php:468
+msgid "Super admin privileges cannot be removed because this user has the network admin email."
+msgstr ""
+
+#: wp-admin/user-edit.php:475
+#: wp-admin/user-new.php:541
+msgid "First Name"
+msgstr ""
+
+#: wp-admin/user-edit.php:480
+#: wp-admin/user-new.php:545
+msgid "Last Name"
+msgstr ""
+
+#: wp-admin/user-edit.php:485
+msgid "Nickname"
+msgstr ""
+
+#: wp-admin/user-edit.php:491
+msgid "Display name publicly as"
+msgstr ""
+
+#: wp-admin/user-edit.php:529
+msgid "Contact Info"
+msgstr ""
+
+#: wp-admin/user-edit.php:538
+msgid "If you change this, an email will be sent at your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>"
+msgstr ""
+
+#. translators: %s: New email.
+#: wp-admin/user-edit.php:549
+msgid "There is a pending change of your email to %s."
+msgstr ""
+
+#: wp-admin/user-edit.php:576
+#: wp-admin/user-new.php:549
+msgid "Website"
+msgstr ""
+
+#: wp-admin/user-edit.php:618
+msgid "About Yourself"
+msgstr ""
+
+#: wp-admin/user-edit.php:618
+msgid "About the user"
+msgstr ""
+
+#: wp-admin/user-edit.php:630
+msgid "Biographical Info"
+msgstr ""
+
+#: wp-admin/user-edit.php:632
+msgid "Share a little biographical information to fill out your profile. This may be shown publicly."
+msgstr ""
+
+#: wp-admin/user-edit.php:641
+msgid "Profile Picture"
+msgstr ""
+
+#. translators: %s: Gravatar URL.
+#: wp-admin/user-edit.php:649
+msgid "<a href=\"%s\" rel=\"noreferrer\">You can change your profile picture on Gravatar</a>."
+msgstr ""
+
+#: wp-admin/user-edit.php:650
+msgid "https://en.gravatar.com/"
+msgstr ""
+
+#: wp-admin/user-edit.php:687
+msgid "Account Management"
+msgstr ""
+
+#: wp-admin/user-edit.php:691
+msgid "New Password"
+msgstr ""
+
+#: wp-admin/user-edit.php:694
+msgid "Set New Password"
+msgstr ""
+
+#: wp-admin/user-edit.php:703
+msgid "Cancel password change"
+msgstr ""
+
+#: wp-admin/user-edit.php:712
+msgid "Repeat New Password"
+msgstr ""
+
+#: wp-admin/user-edit.php:716
+msgid "Type your new password again."
+msgstr ""
+
+#: wp-admin/user-edit.php:718
+msgid "Type the new password again."
+msgstr ""
+
+#: wp-admin/user-edit.php:736
+msgid "Password Reset"
+msgstr ""
+
+#: wp-admin/user-edit.php:740
+msgid "Send Reset Link"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/user-edit.php:747
+msgid "Send %s a link to reset their password. This will not change their password, nor will it force a change."
+msgstr ""
+
+#: wp-admin/user-edit.php:758
+#: wp-admin/user-edit.php:768
+#: wp-admin/user-edit.php:778
+msgid "Sessions"
+msgstr ""
+
+#: wp-admin/user-edit.php:760
+#: wp-admin/user-edit.php:770
+msgid "Log Out Everywhere Else"
+msgstr ""
+
+#: wp-admin/user-edit.php:762
+msgid "You are only logged in at this location."
+msgstr ""
+
+#: wp-admin/user-edit.php:772
+msgid "Did you lose your phone or leave your account logged in at a public computer? You can log out everywhere else, and stay logged in here."
+msgstr ""
+
+#: wp-admin/user-edit.php:780
+msgid "Log Out Everywhere"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: wp-admin/user-edit.php:784
+msgid "Log %s out of all locations."
+msgstr ""
+
+#: wp-admin/user-edit.php:794
+msgid "Application Passwords"
+msgstr ""
+
+#: wp-admin/user-edit.php:795
+msgid "Application passwords allow authentication via non-interactive systems, such as XML-RPC or the REST API, without providing your actual password. Application passwords can be easily revoked. They cannot be used for traditional logins to your website."
+msgstr ""
+
+#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
+#: wp-admin/user-edit.php:807
+msgid "Application passwords grant access to <a href=\"%1$s\">the %2$s site in this installation that you have permissions on</a>."
+msgid_plural "Application passwords grant access to <a href=\"%1$s\">all %2$s sites in this installation that you have permissions on</a>."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
+#: wp-admin/user-edit.php:815
+msgid "Application passwords grant access to <a href=\"%1$s\">the %2$s site on the network as you have Super Admin rights</a>."
+msgid_plural "Application passwords grant access to <a href=\"%1$s\">all %2$s sites on the network as you have Super Admin rights</a>."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/user-edit.php:839
+msgid "Required to create an Application Password, but not to update the user."
+msgstr ""
+
+#: wp-admin/user-edit.php:853
+msgid "Add New Application Password"
+msgstr ""
+
+#: wp-admin/user-edit.php:857
+msgid "Your website appears to use Basic Authentication, which is not currently compatible with Application Passwords."
+msgstr ""
+
+#: wp-admin/user-edit.php:869
+msgid "The application password feature requires HTTPS, which is not enabled on this site."
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-admin/user-edit.php:874
+msgid "If this is a development website you can <a href=\"%s\" target=\"_blank\">set the environment type accordingly</a> to enable application passwords."
+msgstr ""
+
+#: wp-admin/user-edit.php:875
+msgid "https://developer.wordpress.org/apis/wp-config-php/#wp-environment-type"
+msgstr ""
+
+#: wp-admin/user-edit.php:924
+msgid "Additional Capabilities"
+msgstr ""
+
+#: wp-admin/user-edit.php:928
+msgid "Capabilities"
+msgstr ""
+
+#. translators: %s: Capability name.
+#: wp-admin/user-edit.php:942
+msgid "Denied: %s"
+msgstr ""
+
+#: wp-admin/user-edit.php:956
+msgid "Update Profile"
+msgstr ""
+
+#: wp-admin/user-edit.php:956
+msgid "Update User"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/user-edit.php:1003
+#: wp-admin/js/application-passwords.js:203
+#: wp-admin/js/common.js:1109
+msgid "Dismiss this notice."
+msgstr ""
+
+#: wp-admin/user-new.php:16
+#: wp-admin/user-new.php:56
+msgid "Sorry, you are not allowed to add users to this network."
+msgstr ""
+
+#: wp-admin/user-new.php:23
+#: wp-admin/user-new.php:189
+msgid "Sorry, you are not allowed to create users."
+msgstr ""
+
+#. translators: 1: Site title, 2: Site URL, 3: User role, 4: Activation URL.
+#: wp-admin/user-new.php:122
+msgid ""
+"Hi,\n"
+"\n"
+"You've been invited to join '%1$s' at\n"
+"%2$s with the role of %3$s.\n"
+"\n"
+"Please click the following link to confirm the invite:\n"
+"%4$s"
+msgstr ""
+
+#. translators: Joining confirmation notification email subject. %s: Site title.
+#: wp-admin/user-new.php:135
+msgid "[%s] Joining Confirmation"
+msgstr ""
+
+#: wp-admin/user-new.php:263
+msgid "To add a new user to your site, fill in the form on this screen and click the Add New User button at the bottom."
+msgstr ""
+
+#: wp-admin/user-new.php:266
+msgid "Because this is a multisite installation, you may add accounts that already exist on the Network by specifying a username or email, and defining a role. For more options, such as specifying a password, you have to be a Network Administrator and use the hover link under an existing user&#8217;s name to Edit the user profile under Network Admin > All Users."
+msgstr ""
+
+#: wp-admin/user-new.php:267
+msgid "New users will receive an email letting them know they&#8217;ve been added as a user for your site. This email will also contain their password. Check the box if you do not want the user to receive a welcome email."
+msgstr ""
+
+#: wp-admin/user-new.php:269
+msgid "New users are automatically assigned a password, which they can change after logging in. You can view or edit the assigned password by clicking the Show Password button. The username cannot be changed once the user has been added."
+msgstr ""
+
+#: wp-admin/user-new.php:271
+msgid "By default, new users will receive an email letting them know they&#8217;ve been added as a user for your site. This email will also contain a password reset link. Uncheck the box if you do not want to send the new user a welcome email."
+msgstr ""
+
+#: wp-admin/user-new.php:274
+msgid "Remember to click the Add New User button at the bottom of this screen when you are finished."
+msgstr ""
+
+#: wp-admin/user-new.php:287
+msgid "User Roles"
+msgstr ""
+
+#: wp-admin/user-new.php:288
+msgid "Here is a basic overview of the different user roles and the permissions associated with each one:"
+msgstr ""
+
+#: wp-admin/user-new.php:290
+msgid "Subscribers can read comments/comment/receive newsletters, etc. but cannot create regular site content."
+msgstr ""
+
+#: wp-admin/user-new.php:291
+msgid "Contributors can write and manage their posts but not publish posts or upload media files."
+msgstr ""
+
+#: wp-admin/user-new.php:292
+msgid "Authors can publish and manage their own posts, and are able to upload files."
+msgstr ""
+
+#: wp-admin/user-new.php:293
+msgid "Editors can publish posts, manage posts as well as manage other people&#8217;s posts, etc."
+msgstr ""
+
+#: wp-admin/user-new.php:294
+msgid "Administrators have access to all the administration features."
+msgstr ""
+
+#: wp-admin/user-new.php:301
+msgid "<a href=\"https://wordpress.org/documentation/article/users-add-new-screen/\">Documentation on Adding New Users</a>"
+msgstr ""
+
+#: wp-admin/user-new.php:336
+msgid "Invitation email sent to new user. A confirmation link must be clicked before their account is created."
+msgstr ""
+
+#: wp-admin/user-new.php:339
+msgid "Invitation email sent to user. A confirmation link must be clicked for them to be added to your site."
+msgstr ""
+
+#: wp-admin/user-new.php:342
+msgid "User has been added to your site."
+msgstr ""
+
+#: wp-admin/user-new.php:345
+#: wp-admin/users.php:560
+msgid "Edit user"
+msgstr ""
+
+#: wp-admin/user-new.php:351
+msgid "That user is already a member of this site."
+msgstr ""
+
+#: wp-admin/user-new.php:354
+msgid "That user could not be added to this site."
+msgstr ""
+
+#: wp-admin/user-new.php:357
+msgid "User has been created, but could not be added to this site."
+msgstr ""
+
+#: wp-admin/user-new.php:360
+msgid "The requested user does not exist."
+msgstr ""
+
+#: wp-admin/user-new.php:363
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: wp-admin/user-new.php:368
+msgid "User added."
+msgstr ""
+
+#: wp-admin/user-new.php:379
+#: wp-admin/user-new.php:418
+#: wp-admin/user-new.php:497
+msgid "Add Existing User"
+msgstr ""
+
+#: wp-admin/user-new.php:421
+msgid "Enter the email address of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite."
+msgstr ""
+
+#: wp-admin/user-new.php:425
+msgid "Enter the email address or username of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite."
+msgstr ""
+
+#: wp-admin/user-new.php:426
+msgid "Email or Username"
+msgstr ""
+
+#: wp-admin/user-new.php:475
+#: wp-admin/user-new.php:642
+msgid "Skip Confirmation Email"
+msgstr ""
+
+#: wp-admin/user-new.php:478
+#: wp-admin/user-new.php:645
+msgid "Add the user without sending an email that requires their confirmation."
+msgstr ""
+
+#: wp-admin/user-new.php:507
+msgid "Create a brand new user and add them to this site."
+msgstr ""
+
+#: wp-admin/user-new.php:588
+msgid "Generate password"
+msgstr ""
+
+#: wp-admin/user-new.php:606
+msgid "Type the password again."
+msgstr ""
+
+#: wp-admin/user-new.php:619
+msgid "Send User Notification"
+msgstr ""
+
+#: wp-admin/user-new.php:622
+msgid "Send the new user an email about their account."
+msgstr ""
+
+#: wp-admin/users.php:16
+msgid "Sorry, you are not allowed to list users."
+msgstr ""
+
+#: wp-admin/users.php:35
+msgid "This screen lists all the existing users for your site. Each user has one of five defined roles as set by the site admin: Site Administrator, Editor, Author, Contributor, or Subscriber. Users with roles other than Administrator will see fewer options in the dashboard navigation when they are logged in, based on their role."
+msgstr ""
+
+#: wp-admin/users.php:36
+msgid "To add a new user for your site, click the Add New button at the top of the screen or Add New in the Users menu section."
+msgstr ""
+
+#: wp-admin/users.php:44
+msgid "You can customize the display of this screen in a number of ways:"
+msgstr ""
+
+#: wp-admin/users.php:46
+msgid "You can hide/display columns based on your needs and decide how many users to list per screen using the Screen Options tab."
+msgstr ""
+
+#: wp-admin/users.php:47
+msgid "You can filter the list of users by User Role using the text links above the users list to show All, Administrator, Editor, Author, Contributor, or Subscriber. The default view is to show all users. Unused User Roles are not listed."
+msgstr ""
+
+#: wp-admin/users.php:48
+msgid "You can view all posts made by a user by clicking on the number under the Posts column."
+msgstr ""
+
+#: wp-admin/users.php:53
+msgid "Hovering over a row in the users list will display action links that allow you to manage users. You can perform the following actions:"
+msgstr ""
+
+#: wp-admin/users.php:55
+msgid "<strong>Edit</strong> takes you to the editable profile screen for that user. You can also reach that screen by clicking on the username."
+msgstr ""
+
+#: wp-admin/users.php:58
+msgid "<strong>Remove</strong> allows you to remove a user from your site. It does not delete their content. You can also remove multiple users at once by using bulk actions."
+msgstr ""
+
+#: wp-admin/users.php:60
+msgid "<strong>Delete</strong> brings you to the Delete Users screen for confirmation, where you can permanently remove a user from your site and delete their content. You can also delete multiple users at once by using bulk actions."
+msgstr ""
+
+#: wp-admin/users.php:63
+msgid "<strong>View</strong> takes you to a public author archive which lists all the posts published by the user."
+msgstr ""
+
+#: wp-admin/users.php:66
+msgid "<strong>Send password reset</strong> sends the user an email with a link to set a new password."
+msgstr ""
+
+#: wp-admin/users.php:82
+msgid "<a href=\"https://wordpress.org/documentation/article/users-screen/\">Documentation on Managing Users</a>"
+msgstr ""
+
+#: wp-admin/users.php:83
+msgid "<a href=\"https://wordpress.org/documentation/article/roles-and-capabilities/\">Descriptions of Roles and Capabilities</a>"
+msgstr ""
+
+#: wp-admin/users.php:89
+msgid "Filter users list"
+msgstr ""
+
+#: wp-admin/users.php:90
+msgid "Users list navigation"
+msgstr ""
+
+#: wp-admin/users.php:91
+msgid "Users list"
+msgstr ""
+
+#: wp-admin/users.php:158
+msgid "One of the selected users is not a member of this site."
+msgstr ""
+
+#: wp-admin/users.php:172
+#: wp-admin/users.php:270
+msgid "User deletion is not allowed from this screen."
+msgstr ""
+
+#: wp-admin/users.php:192
+#: wp-admin/users.php:281
+msgid "Sorry, you are not allowed to delete users."
+msgstr ""
+
+#: wp-admin/users.php:200
+msgid "Sorry, you are not allowed to delete that user."
+msgstr ""
+
+#: wp-admin/users.php:231
+msgid "Sorry, you are not allowed to edit users."
+msgstr ""
+
+#: wp-admin/users.php:326
+msgid "Delete Users"
+msgstr ""
+
+#: wp-admin/users.php:329
+msgid "Please select an option."
+msgstr ""
+
+#: wp-admin/users.php:334
+msgid "You have specified this user for deletion:"
+msgstr ""
+
+#: wp-admin/users.php:336
+msgid "You have specified these users for deletion:"
+msgstr ""
+
+#. translators: 1: User ID, 2: User login.
+#: wp-admin/users.php:346
+msgid "ID #%1$s: %2$s <strong>The current user will not be deleted.</strong>"
+msgstr ""
+
+#. translators: 1: User ID, 2: User login.
+#: wp-admin/users.php:349
+#: wp-admin/users.php:487
+msgid "ID #%1$s: %2$s"
+msgstr ""
+
+#: wp-admin/users.php:363
+msgid "What should be done with content owned by this user?"
+msgstr ""
+
+#: wp-admin/users.php:365
+msgid "What should be done with content owned by these users?"
+msgstr ""
+
+#: wp-admin/users.php:369
+msgid "Delete all content."
+msgstr ""
+
+#: wp-admin/users.php:372
+msgid "Attribute all content to:"
+msgstr ""
+
+#: wp-admin/users.php:397
+msgid "Confirm Deletion"
+msgstr ""
+
+#: wp-admin/users.php:399
+msgid "There are no valid users selected for deletion."
+msgstr ""
+
+#: wp-admin/users.php:411
+#: wp-admin/users.php:443
+msgid "You cannot remove users."
+msgstr ""
+
+#: wp-admin/users.php:420
+#: wp-admin/users.php:452
+msgid "Sorry, you are not allowed to remove users."
+msgstr ""
+
+#: wp-admin/users.php:468
+msgid "Remove Users from Site"
+msgstr ""
+
+#: wp-admin/users.php:471
+msgid "You have specified this user for removal:"
+msgstr ""
+
+#: wp-admin/users.php:473
+msgid "You have specified these users for removal:"
+msgstr ""
+
+#. translators: 1: User ID, 2: User login.
+#: wp-admin/users.php:484
+msgid "ID #%1$s: %2$s <strong>Sorry, you are not allowed to remove this user.</strong>"
+msgstr ""
+
+#: wp-admin/users.php:495
+msgid "Confirm Removal"
+msgstr ""
+
+#: wp-admin/users.php:497
+msgid "There are no valid users selected for removal."
+msgstr ""
+
+#: wp-admin/users.php:539
+msgid "User deleted."
+msgstr ""
+
+#. translators: %s: Number of users.
+#: wp-admin/users.php:542
+msgid "%s user deleted."
+msgid_plural "%s users deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/users.php:547
+msgid "New user created."
+msgstr ""
+
+#: wp-admin/users.php:569
+msgid "Password reset link sent."
+msgstr ""
+
+#. translators: %s: Number of users.
+#: wp-admin/users.php:572
+msgid "Password reset links sent to %s user."
+msgid_plural "Password reset links sent to %s users."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/users.php:577
+msgid "Changed roles."
+msgstr ""
+
+#: wp-admin/users.php:580
+msgid "The current user&#8217;s role must have user editing capabilities."
+msgstr ""
+
+#: wp-admin/users.php:581
+msgid "Other user roles have been changed."
+msgstr ""
+
+#: wp-admin/users.php:584
+msgid "You cannot delete the current user."
+msgstr ""
+
+#: wp-admin/users.php:585
+msgid "Other users have been deleted."
+msgstr ""
+
+#: wp-admin/users.php:588
+msgid "User removed from this site."
+msgstr ""
+
+#: wp-admin/users.php:591
+msgid "You cannot remove the current user."
+msgstr ""
+
+#: wp-admin/users.php:592
+msgid "Other users have been removed."
+msgstr ""
+
+#: wp-admin/widgets-form.php:45
+msgid "Widgets are independent sections of content that can be placed into any widgetized area provided by your theme (commonly called sidebars). To populate your sidebars/widget areas with individual widgets, drag and drop the title bars into the desired area. By default, only the first widget area is expanded. To populate additional widget areas, click on their title bars to expand them."
+msgstr ""
+
+#: wp-admin/widgets-form.php:46
+msgid "The Available Widgets section contains all the widgets you can choose from. Once you drag a widget into a sidebar, it will open to allow you to configure its settings. When you are happy with the widget settings, click the Save button and the widget will go live on your site. If you click Delete, it will remove the widget."
+msgstr ""
+
+#: wp-admin/widgets-form.php:52
+msgid "Removing and Reusing"
+msgstr ""
+
+#: wp-admin/widgets-form.php:54
+msgid "If you want to remove the widget but save its setting for possible future use, just drag it into the Inactive Widgets area. You can add them back anytime from there. This is especially helpful when you switch to a theme with fewer or different widget areas."
+msgstr ""
+
+#: wp-admin/widgets-form.php:55
+msgid "Widgets may be used multiple times. You can give each widget a title, to display on your site, but it&#8217;s not required."
+msgstr ""
+
+#: wp-admin/widgets-form.php:56
+msgid "Enabling Accessibility Mode, via Screen Options, allows you to use Add and Edit buttons instead of using drag and drop."
+msgstr ""
+
+#: wp-admin/widgets-form.php:62
+msgid "Missing Widgets"
+msgstr ""
+
+#: wp-admin/widgets-form.php:64
+msgid "Many themes show some sidebar widgets by default until you edit your sidebars, but they are not automatically displayed in your sidebar management tool. After you make your first widget change, you can re-add the default widgets by adding them from the Available Widgets area."
+msgstr ""
+
+#: wp-admin/widgets-form.php:65
+msgid "When changing themes, there is often some variation in the number and setup of widget areas/sidebars and sometimes these conflicts make the transition a bit less smooth. If you changed themes and seem to be missing widgets, scroll down on this screen to the Inactive Widgets area, where all of your widgets and their settings will have been saved."
+msgstr ""
+
+#: wp-admin/widgets-form.php:71
+msgid "<a href=\"https://wordpress.org/documentation/article/appearance-widgets-screen-classic-editor/\">Documentation on Widgets</a>"
+msgstr ""
+
+#: wp-admin/widgets-form.php:91
+msgid "Inactive Sidebar (not used)"
+msgstr ""
+
+#: wp-admin/widgets-form.php:94
+msgid "This sidebar is no longer available and does not show anywhere on your site. Remove each of the widgets below to fully remove this inactive sidebar."
+msgstr ""
+
+#: wp-admin/widgets-form.php:110
+msgid "Inactive Widgets"
+msgstr ""
+
+#: wp-admin/widgets-form.php:113
+msgid "Drag widgets here to remove them from the sidebar but keep their settings."
+msgstr ""
+
+#. translators: %s: Widget name.
+#: wp-admin/widgets-form.php:282
+msgid "Widget %s"
+msgstr ""
+
+#: wp-admin/widgets-form.php:297
+msgid "Select both the sidebar for this widget and the position of the widget in that sidebar."
+msgstr ""
+
+#: wp-admin/widgets-form.php:299
+msgid "Position"
+msgstr ""
+
+#: wp-admin/widgets-form.php:344
+msgid "Save Widget"
+msgstr ""
+
+#: wp-admin/widgets-form.php:362
+#: wp-admin/js/inline-edit-post.js:612
+#: wp-admin/js/inline-edit-tax.js:227
+msgid "Changes saved."
+msgstr ""
+
+#: wp-admin/widgets-form.php:367
+msgid "Error in displaying the widget settings form."
+msgstr ""
+
+#: wp-admin/widgets-form.php:400
+msgid "Enable accessibility mode"
+msgstr ""
+
+#: wp-admin/widgets-form.php:400
+msgid "Disable accessibility mode"
+msgstr ""
+
+#: wp-admin/widgets-form.php:425
+msgid "Available Widgets"
+msgstr ""
+
+#: wp-admin/widgets-form.php:428
+msgid "To activate a widget drag it to a sidebar or click on it. To deactivate a widget and delete its settings, drag it back."
+msgstr ""
+
+#: wp-admin/widgets-form.php:466
+msgid "Clear Inactive Widgets"
+msgstr ""
+
+#: wp-admin/widgets-form.php:476
+msgid "This will clear all items from the inactive widgets list. You will not be able to restore any customizations."
+msgstr ""
+
+#: wp-admin/widgets-form.php:546
+msgid "Add Widget"
+msgstr ""
+
+#: wp-admin/widgets.php:24
+msgid "The theme you are currently using is not widget-aware, meaning that it has no sidebars that you are able to change. For information on making your theme widget-aware, please <a href=\"https://developer.wordpress.org/themes/functionality/widgets/\">follow these instructions</a>."
+msgstr ""
+
+#: wp-admin/js/application-passwords.js:85
+msgid "Are you sure you want to revoke this password? This action cannot be undone."
+msgstr ""
+
+#: wp-admin/js/application-passwords.js:108
+msgid "Application password revoked."
+msgstr ""
+
+#: wp-admin/js/application-passwords.js:116
+msgid "Are you sure you want to revoke all passwords? This action cannot be undone."
+msgstr ""
+
+#: wp-admin/js/application-passwords.js:136
+msgid "All application passwords revoked."
+msgstr ""
+
+#: wp-admin/js/color-picker.js:121
+msgid "Color value"
+msgstr ""
+
+#: wp-admin/js/color-picker.js:139
+msgid "Select Color"
+msgstr ""
+
+#: wp-admin/js/color-picker.js:149
+msgid "Default"
+msgstr ""
+
+#: wp-admin/js/color-picker.js:150
+msgid "Select default color"
+msgstr ""
+
+#: wp-admin/js/color-picker.js:155
+msgid "Clear color"
+msgstr ""
+
+#: wp-admin/js/comment.js:87
+msgid "Submitted on:"
+msgstr ""
+
+#. translators: 1: Deprecated property name, 2: Version number, 3: Alternative property name.
+#: wp-admin/js/common.js:37
+msgid "%1$s is deprecated since version %2$s! Use %3$s instead."
+msgstr ""
+
+#. translators: 1: Deprecated property name, 2: Version number.
+#: wp-admin/js/common.js:45
+msgid "%1$s is deprecated since version %2$s with no alternative available."
+msgstr ""
+
+#: wp-admin/js/common.js:527
+msgid ""
+"You are about to permanently delete these items from your site.\n"
+"This action cannot be undone.\n"
+"'Cancel' to stop, 'OK' to delete."
+msgstr ""
+
+#: wp-admin/js/common.js:1986
+msgid "Expand Main menu"
+msgstr ""
+
+#: wp-admin/js/edit-comments.js:365
+#: wp-admin/js/edit-comments.js:1012
+msgid "Approve and Reply"
+msgstr ""
+
+#: wp-admin/js/edit-comments.js:851
+msgid ""
+"Are you sure you want to edit this comment?\n"
+"The changes you made will be lost."
+msgstr ""
+
+#: wp-admin/js/edit-comments.js:1231
+msgid ""
+"Are you sure you want to do this?\n"
+"The comment changes you made will be lost."
+msgstr ""
+
+#: wp-admin/js/image-edit.js:420
+msgid "Could not load the preview image. Please reload the page and try again."
+msgstr ""
+
+#: wp-admin/js/image-edit.js:629
+msgid "Could not load the preview image."
+msgstr ""
+
+#. translators: %s: Post title.
+#: wp-admin/js/inline-edit-post.js:359
+msgid "Remove &#8220;%s&#8221; from Bulk Edit"
+msgstr ""
+
+#: wp-admin/js/inline-edit-post.js:388
+msgid "Item removed."
+msgstr ""
+
+#: wp-admin/js/inline-edit-post.js:398
+msgid "All selected items have been removed. Select new items to use Bulk Actions."
+msgstr ""
+
+#: wp-admin/js/inline-edit-post.js:622
+#: wp-admin/js/inline-edit-post.js:623
+#: wp-admin/js/inline-edit-tax.js:241
+#: wp-admin/js/inline-edit-tax.js:242
+msgid "Error while saving the changes."
+msgstr ""
+
+#: wp-admin/js/media.js:239
+#: wp-admin/js/post.js:1317
+msgid "The file URL has been copied to your clipboard"
+msgstr ""
+
+#: wp-admin/js/nav-menu.js:695
+msgid ""
+"You are about to permanently delete this menu.\n"
+"'Cancel' to stop, 'OK' to delete."
+msgstr ""
+
+#: wp-admin/js/nav-menu.js:1218
+msgctxt "missing menu item navigation label"
+msgid "(no label)"
+msgstr ""
+
+#. translators: 1: Deprecated function name, 2: Version number, 3: Alternative function name.
+#: wp-admin/js/password-strength-meter.js:66
+msgid "%1$s is deprecated since version %2$s! Use %3$s instead. Please consider writing more inclusive code."
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/js/plugin-install.js:34
+msgid "Plugin: %s"
+msgstr ""
+
+#: wp-admin/js/plugin-install.js:37
+msgid "Plugin details"
+msgstr ""
+
+#: wp-admin/js/post.js:77
+msgid "Show more comments"
+msgstr ""
+
+#: wp-admin/js/post.js:81
+msgid "No more comments found."
+msgstr ""
+
+#: wp-admin/js/post.js:153
+#: wp-admin/js/set-post-thumbnail.js:18
+msgid "Could not set that as the thumbnail image. Try a different attachment."
+msgstr ""
+
+#: wp-admin/js/post.js:483
+msgid "Saving Draft…"
+msgstr ""
+
+#: wp-admin/js/post.js:510
+#: wp-admin/js/theme-plugin-editor.js:71
+msgid "The changes you made will be lost if you navigate away from this page."
+msgstr ""
+
+#: wp-admin/js/post.js:791
+msgid "Schedule for:"
+msgstr ""
+
+#: wp-admin/js/post.js:794
+msgid "Publish on:"
+msgstr ""
+
+#: wp-admin/js/post.js:797
+msgid "Published on:"
+msgstr ""
+
+#: wp-admin/js/post.js:909
+msgid "Password Protected"
+msgstr ""
+
+#: wp-admin/js/post.js:1062
+msgid "Permalink saved"
+msgstr ""
+
+#: wp-admin/js/post.js:1083
+msgid "URL Slug"
+msgstr ""
+
+#: wp-admin/js/postbox.js:25
+msgid "Add boxes from the Screen Options menu"
+msgstr ""
+
+#: wp-admin/js/postbox.js:25
+msgid "Drag boxes here"
+msgstr ""
+
+#: wp-admin/js/postbox.js:62
+msgid "The box is on the first position"
+msgstr ""
+
+#: wp-admin/js/postbox.js:63
+msgid "The box is on the last position"
+msgstr ""
+
+#: wp-admin/js/postbox.js:328
+msgid "The boxes order has been saved."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:80
+msgid "This user&#8217;s personal data export link was sent."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:83
+msgid "This user&#8217;s personal data export file was downloaded."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:93
+msgid "No personal data export file was generated."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:100
+msgid "An error occurred while attempting to export personal data."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:185
+#: wp-admin/js/privacy-tools.js:192
+msgid "No personal data was found for this user."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:194
+msgid "Personal data was found for this user but was not erased."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:199
+msgid "All of the personal data found for this user was erased."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:201
+msgid "Personal data was found for this user but some of the personal data found was not erased."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:211
+msgid "An error occurred while attempting to find and erase personal data."
+msgstr ""
+
+#: wp-admin/js/privacy-tools.js:317
+msgid "The suggested policy text has been copied to your clipboard."
+msgstr ""
+
+#: wp-admin/js/set-post-thumbnail.js:11
+msgid "Saving…"
+msgstr ""
+
+#: wp-admin/js/set-post-thumbnail.js:16
+msgid "Use as featured image"
+msgstr ""
+
+#: wp-admin/js/site-health.js:42
+msgid "Site information has been copied to your clipboard."
+msgstr ""
+
+#: wp-admin/js/site-health.js:227
+msgid "Good"
+msgstr ""
+
+#: wp-admin/js/site-health.js:228
+msgid "All site health tests have finished running. Your site is looking good, and the results are now available on the page."
+msgstr ""
+
+#: wp-admin/js/site-health.js:232
+msgid "Should be improved"
+msgstr ""
+
+#: wp-admin/js/site-health.js:233
+msgid "All site health tests have finished running. There are items that should be addressed, and the results are now available on the page."
+msgstr ""
+
+#: wp-admin/js/site-health.js:291
+#: wp-admin/js/site-health.js:312
+msgid "No details available"
+msgstr ""
+
+#: wp-admin/js/site-health.js:343
+msgid "Unavailable"
+msgstr ""
+
+#: wp-admin/js/site-health.js:382
+msgid "Please wait..."
+msgstr ""
+
+#: wp-admin/js/site-health.js:408
+msgid "All site health tests have finished running."
+msgstr ""
+
+#: wp-admin/js/tags-box.js:170
+msgid "Remove term:"
+msgstr ""
+
+#: wp-admin/js/tags-box.js:340
+msgid "Term removed."
+msgstr ""
+
+#: wp-admin/js/tags-box.js:344
+msgid "Term added."
+msgstr ""
+
+#: wp-admin/js/tags.js:58
+msgid "Sorry, you are not allowed to do that."
+msgstr ""
+
+#: wp-admin/js/theme-plugin-editor.js:230
+msgid "Something went wrong. Your change may not have been saved. Please try again. There is also a chance that you may need to manually fix and upload the file over FTP."
+msgstr ""
+
+#. translators: %s: Error count.
+#: wp-admin/js/theme-plugin-editor.js:401
+msgid "There is %s error which must be fixed before you can update this file."
+msgid_plural "There are %s errors which must be fixed before you can update this file."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Total number of updates available.
+#: wp-admin/js/updates.js:361
+msgid "%s update available"
+msgid_plural "%s updates available"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:467
+#: wp-admin/js/updates.js:475
+msgctxt "plugin"
+msgid "Updating %s..."
+msgstr ""
+
+#: wp-admin/js/updates.js:485
+#: wp-admin/js/updates.js:491
+#: wp-admin/js/updates.js:1182
+#: wp-admin/js/updates.js:1187
+msgid "Updating..."
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:543
+msgctxt "plugin"
+msgid "%s updated!"
+msgstr ""
+
+#: wp-admin/js/updates.js:547
+msgctxt "plugin"
+msgid "Updated!"
+msgstr ""
+
+#: wp-admin/js/updates.js:549
+#: wp-admin/js/updates.js:1248
+msgid "Update completed successfully."
+msgstr ""
+
+#. translators: %s: Error string for a failed update.
+#: wp-admin/js/updates.js:583
+#: wp-admin/js/updates.js:1274
+#: wp-admin/js/updates.js:1963
+msgid "Update failed: %s"
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:601
+#: wp-admin/js/updates.js:626
+msgctxt "plugin"
+msgid "%s update failed."
+msgstr ""
+
+#: wp-admin/js/updates.js:617
+#: wp-admin/js/updates.js:1997
+msgid "Update failed."
+msgstr ""
+
+#: wp-admin/js/updates.js:681
+#: wp-admin/js/updates.js:695
+#: wp-admin/js/updates.js:1332
+#: wp-admin/js/updates.js:1345
+msgid "Installing..."
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:691
+msgctxt "plugin"
+msgid "Installing %s..."
+msgstr ""
+
+#: wp-admin/js/updates.js:697
+#: wp-admin/js/updates.js:1347
+msgid "Installing... please wait."
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:727
+msgctxt "plugin"
+msgid "%s installed!"
+msgstr ""
+
+#: wp-admin/js/updates.js:731
+msgctxt "plugin"
+msgid "Installed!"
+msgstr ""
+
+#: wp-admin/js/updates.js:733
+#: wp-admin/js/updates.js:867
+#: wp-admin/js/updates.js:1386
+msgid "Installation completed successfully."
+msgstr ""
+
+#. translators: %s: Error string for a failed installation.
+#: wp-admin/js/updates.js:798
+#: wp-admin/js/updates.js:886
+#: wp-admin/js/updates.js:1450
+#: wp-admin/js/updates.js:1968
+msgid "Installation failed: %s"
+msgstr ""
+
+#. translators: %s: Plugin name and version.
+#: wp-admin/js/updates.js:822
+msgctxt "plugin"
+msgid "%s installation failed"
+msgstr ""
+
+#. translators: %s: Activation URL.
+#: wp-admin/js/updates.js:849
+msgid "Importer installed successfully. <a href=\"%s\">Run importer</a>"
+msgstr ""
+
+#: wp-admin/js/updates.js:944
+#: wp-admin/js/updates.js:947
+#: wp-admin/js/updates.js:950
+#: wp-admin/js/updates.js:1528
+#: wp-admin/js/updates.js:1531
+#: wp-admin/js/updates.js:1534
+msgid "Deleting..."
+msgstr ""
+
+#: wp-admin/js/updates.js:1077
+msgctxt "plugin"
+msgid "Deleted!"
+msgstr ""
+
+#: wp-admin/js/updates.js:1186
+msgid "Updating... please wait."
+msgstr ""
+
+#: wp-admin/js/updates.js:1211
+msgctxt "theme"
+msgid "Updated!"
+msgstr ""
+
+#. translators: %s: Theme name and version.
+#: wp-admin/js/updates.js:1341
+msgctxt "theme"
+msgid "Installing %s..."
+msgstr ""
+
+#. translators: %s: Theme name and version.
+#: wp-admin/js/updates.js:1380
+msgctxt "theme"
+msgid "%s installed!"
+msgstr ""
+
+#: wp-admin/js/updates.js:1384
+msgctxt "theme"
+msgid "Installed!"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/js/updates.js:1404
+msgctxt "theme"
+msgid "Network Activate %s"
+msgstr ""
+
+#. translators: %s: Theme name and version.
+#: wp-admin/js/updates.js:1491
+msgctxt "theme"
+msgid "%s installation failed"
+msgstr ""
+
+#: wp-admin/js/updates.js:1625
+msgctxt "theme"
+msgid "Deleted!"
+msgstr ""
+
+#. translators: %s: Error string for a failed deletion.
+#: wp-admin/js/updates.js:1647
+#: wp-admin/js/updates.js:1973
+msgid "Deletion failed: %s"
+msgstr ""
+
+#: wp-admin/js/updates.js:1953
+msgid "Connection lost or the server is busy. Please try again later."
+msgstr ""
+
+#: wp-admin/js/updates.js:2021
+msgid "Updates may not complete if you navigate away from this page."
+msgstr ""
+
+#: wp-admin/js/updates.js:2155
+#: wp-admin/js/updates.js:2233
+#: wp-admin/js/updates.js:2276
+msgid "Update canceled."
+msgstr ""
+
+#. translators: %s: Plugin name.
+#: wp-admin/js/updates.js:2302
+msgid "Are you sure you want to delete %s and its data?"
+msgstr ""
+
+#. translators: %s: Plugin name.
+#. translators: %s: Theme name.
+#: wp-admin/js/updates.js:2308
+#: wp-admin/js/updates.js:2365
+msgid "Are you sure you want to delete %s?"
+msgstr ""
+
+#: wp-admin/js/updates.js:2422
+msgid "Please select at least one item to perform this action on."
+msgstr ""
+
+#: wp-admin/js/updates.js:2434
+msgid "Are you sure you want to delete the selected plugins and their data?"
+msgstr ""
+
+#: wp-admin/js/updates.js:2435
+msgid "Caution: These themes may be active on other sites in the network. Are you sure you want to proceed?"
+msgstr ""
+
+#: wp-admin/js/updates.js:2598
+msgid "You do not appear to have any plugins available at this time."
+msgstr ""
+
+#. translators: %s: Number of plugins.
+#: wp-admin/js/updates.js:2603
+#: wp-admin/js/updates.js:2689
+msgid "Number of plugins found: %d"
+msgstr ""
+
+#: wp-admin/js/updates.js:2912
+msgid "Enabling..."
+msgstr ""
+
+#: wp-admin/js/updates.js:2914
+msgid "Disabling..."
+msgstr ""
+
+#: wp-admin/js/updates.js:2938
+#: wp-admin/js/updates.js:3002
+#: wp-admin/js/updates.js:3004
+msgid "The request could not be completed."
+msgstr ""
+
+#: wp-admin/js/user-profile.js:81
+msgid "Show password"
+msgstr ""
+
+#: wp-admin/js/user-profile.js:476
+msgid "Your new password has not been saved."
+msgstr ""
+
+#: wp-admin/js/widgets.js:183
+#: wp-admin/js/widgets.js:464
+#: wp-admin/js/widgets.js:575
+msgid "Saved"
+msgstr ""

--- a/admin-network-en_US.pot
+++ b/admin-network-en_US.pot
@@ -1,0 +1,2546 @@
+# Copyright (C) 2024 ClassicPress
+# This file is distributed under the same license as the ClassicPress package.
+msgid ""
+msgstr ""
+"Project-Id-Version: ClassicPress 2.0.0\n"
+"Report-Msgid-Bugs-To: https://forums.classicpress.net/c/team-discussions/internationalisation/42\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-04-16T12:25:00+00:00\n"
+"X-Generator: WP-CLI 2.10.0\n"
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:38
+#: wp-admin/network/site-info.php:192
+msgid "Archived"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:39
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:720
+#: wp-admin/network/site-info.php:193
+msgctxt "site"
+msgid "Spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:40
+#: wp-admin/network/site-info.php:194
+msgid "Deleted"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:41
+#: wp-admin/network/site-info.php:196
+msgid "Mature"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:206
+msgid "No sites found."
+msgstr ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:221
+msgctxt "sites"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:228
+msgid "Public <span class=\"count\">(%s)</span>"
+msgid_plural "Public <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:234
+msgid "Archived <span class=\"count\">(%s)</span>"
+msgid_plural "Archived <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:240
+msgid "Mature <span class=\"count\">(%s)</span>"
+msgid_plural "Mature <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:246
+msgctxt "sites"
+msgid "Spam <span class=\"count\">(%s)</span>"
+msgid_plural "Spam <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of sites.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:253
+msgid "Deleted <span class=\"count\">(%s)</span>"
+msgid_plural "Deleted <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:285
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:724
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:477
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:639
+#: wp-admin/includes/class-wp-ms-users-list-table.php:114
+#: wp-admin/includes/class-wp-ms-users-list-table.php:531
+msgid "Delete"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:287
+msgctxt "site"
+msgid "Mark as spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:288
+msgctxt "site"
+msgid "Not spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:335
+msgid "Filter"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:358
+msgid "URL"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:359
+#: wp-admin/network/site-info.php:186
+msgid "Last Updated"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:360
+#: wp-admin/network/site-info.php:182
+msgctxt "site"
+msgid "Registered"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:361
+#: wp-admin/includes/ms.php:853
+#: wp-admin/includes/ms.php:1058
+#: wp-admin/network/menu.php:55
+#: wp-admin/network/users.php:34
+#: wp-admin/network/users.php:69
+#: wp-admin/network/users.php:221
+#: wp-admin/network/users.php:283
+msgid "Users"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:365
+msgid "Actions"
+msgstr ""
+
+#. translators: %s: Site URL.
+#. translators: Hidden accessibility text. %s: Theme name
+#. translators: Hidden accessibility text. %s: User login.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:408
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:520
+#: wp-admin/includes/class-wp-ms-users-list-table.php:241
+msgid "Select %s"
+msgstr ""
+
+#. translators: 1: Site title, 2: Site tagline.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:452
+msgid "%1$s &#8211; %2$s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:474
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:495
+#: wp-admin/includes/class-wp-ms-users-list-table.php:342
+msgid "Y/m/d"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:476
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:497
+#: wp-admin/includes/class-wp-ms-users-list-table.php:344
+msgid "Y/m/d g:i:s a"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:479
+msgid "Never"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:616
+msgid "Main"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:702
+#: wp-admin/includes/class-wp-ms-users-list-table.php:404
+#: wp-admin/includes/class-wp-ms-users-list-table.php:527
+msgid "Edit"
+msgstr ""
+
+#. translators: Network menu item.
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:703
+#: wp-admin/my-sites.php:128
+#: wp-admin/network/index.php:21
+#: wp-admin/network/menu.php:11
+#: wp-admin/network/site-info.php:143
+#: wp-admin/network/site-settings.php:95
+#: wp-admin/network/site-themes.php:180
+#: wp-admin/network/site-users.php:225
+msgid "Dashboard"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:706
+msgid "Activate"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:708
+msgid "Deactivate"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:712
+msgid "Unarchive"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:714
+msgctxt "verb; site"
+msgid "Archive"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:718
+msgctxt "site"
+msgid "Not Spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-sites-list-table.php:728
+#: wp-admin/my-sites.php:125
+#: wp-admin/network/site-info.php:143
+#: wp-admin/network/site-settings.php:95
+#: wp-admin/network/site-themes.php:180
+#: wp-admin/network/site-users.php:225
+msgid "Visit"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:318
+msgid "No themes found."
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:320
+msgid "No themes are currently available."
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:330
+msgid "Theme"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:331
+msgid "Description"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:335
+msgid "Automatic Updates"
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:378
+msgctxt "themes"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:387
+msgctxt "themes"
+msgid "Enabled <span class=\"count\">(%s)</span>"
+msgid_plural "Enabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:396
+msgctxt "themes"
+msgid "Disabled <span class=\"count\">(%s)</span>"
+msgid_plural "Disabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:405
+msgctxt "themes"
+msgid "Update Available <span class=\"count\">(%s)</span>"
+msgid_plural "Update Available <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:414
+msgctxt "themes"
+msgid "Broken <span class=\"count\">(%s)</span>"
+msgid_plural "Broken <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:423
+msgid "Auto-updates Enabled <span class=\"count\">(%s)</span>"
+msgid_plural "Auto-updates Enabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:431
+msgid "Auto-updates Disabled <span class=\"count\">(%s)</span>"
+msgid_plural "Auto-updates Disabled <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:467
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:586
+msgid "Enable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:467
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:586
+msgid "Network Enable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:470
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:612
+msgid "Disable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:470
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:612
+msgid "Network Disable"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:474
+msgid "Update"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:483
+msgid "Enable Auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:487
+msgid "Disable Auto-updates"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:576
+msgid "Enable %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:579
+msgid "Network Enable %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:602
+msgid "Disable %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:605
+msgid "Network Disable %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:633
+msgctxt "theme"
+msgid "Delete %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:699
+msgid "Broken Theme:"
+msgstr ""
+
+#. translators: %s: Theme version.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:722
+msgid "Version %s"
+msgstr ""
+
+#. translators: %s: Theme author.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:726
+msgid "By %s"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:730
+msgid "Visit theme site for %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:736
+msgid "Visit Theme Site"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:743
+msgid "Child theme of %s"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:794
+msgid "Auto-updates enabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:796
+msgid "Auto-updates disabled"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:805
+msgid "Disable auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:809
+msgid "Enable auto-updates"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:925
+msgid "Active Theme"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-themes-list-table.php:930
+msgid "Active Child Theme"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:116
+msgctxt "user"
+msgid "Mark as spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:117
+msgctxt "user"
+msgid "Not spam"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:125
+msgid "No users found."
+msgstr ""
+
+#. translators: Number of users.
+#: wp-admin/includes/class-wp-ms-users-list-table.php:144
+msgctxt "users"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: Number of users.
+#: wp-admin/includes/class-wp-ms-users-list-table.php:159
+msgid "Super Admin <span class=\"count\">(%s)</span>"
+msgid_plural "Super Admins <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:193
+#: wp-admin/network/site-users.php:321
+#: wp-admin/network/site-users.php:356
+#: wp-admin/network/user-new.php:126
+msgid "Username"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:194
+msgid "Name"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:195
+#: wp-admin/network/site-users.php:360
+#: wp-admin/network/user-new.php:130
+msgid "Email"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:196
+msgctxt "user"
+msgid "Registered"
+msgstr ""
+
+#. translators: Sites menu item.
+#: wp-admin/includes/class-wp-ms-users-list-table.php:197
+#: wp-admin/network/menu.php:51
+#: wp-admin/network/sites.php:21
+#: wp-admin/network/sites.php:367
+msgid "Sites"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:285
+msgid "Super Admin"
+msgstr ""
+
+#. translators: 1: User's first name, 2: Last name.
+#: wp-admin/includes/class-wp-ms-users-list-table.php:303
+msgctxt "Display name based on first name and last name"
+msgid "%1$s %2$s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/class-wp-ms-users-list-table.php:314
+msgctxt "name"
+msgid "Unknown"
+msgstr ""
+
+#: wp-admin/includes/class-wp-ms-users-list-table.php:420
+msgid "View"
+msgstr ""
+
+#. translators: %s: Allowed space allocation.
+#: wp-admin/includes/ms-deprecated.php:35
+#: wp-admin/includes/ms.php:239
+msgid "Sorry, you have used your space allocation of %s. Please delete some files to upload more files."
+msgstr ""
+
+#. translators: %s: Required disk space in kilobytes.
+#: wp-admin/includes/ms.php:36
+msgid "Not enough space to upload. %s KB needed."
+msgstr ""
+
+#. translators: %s: Maximum allowed file size in kilobytes.
+#: wp-admin/includes/ms.php:41
+#: wp-includes/ms-functions.php:2091
+msgid "This file is too big. Files must be less than %s KB in size."
+msgstr ""
+
+#: wp-admin/includes/ms.php:45
+msgid "You have used your space quota. Please delete files before uploading."
+msgstr ""
+
+#: wp-admin/includes/ms.php:49
+msgid "Back"
+msgstr ""
+
+#. translators: Storage space that's been used. 1: Percentage of used space, 2: Total space allowed in megabytes or gigabytes.
+#: wp-admin/includes/ms.php:265
+msgid "Used: %1$s%% of %2$s"
+msgstr ""
+
+#: wp-admin/includes/ms.php:305
+msgid "Site Upload Space Quota"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/ms.php:311
+#: wp-admin/network/settings.php:410
+msgid "Size in megabytes"
+msgstr ""
+
+#: wp-admin/includes/ms.php:313
+msgid "MB (Leave blank for network default)"
+msgstr ""
+
+#. translators: 1: Site title.
+#: wp-admin/includes/ms.php:575
+#: wp-admin/includes/ms.php:584
+msgid "You attempted to access the \"%1$s\" dashboard, but you do not currently have privileges on this site. If you believe you should be able to access the \"%1$s\" dashboard, please contact your network administrator."
+msgstr ""
+
+#: wp-admin/includes/ms.php:587
+msgid "If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way."
+msgstr ""
+
+#: wp-admin/includes/ms.php:589
+msgid "Your Sites"
+msgstr ""
+
+#: wp-admin/includes/ms.php:595
+msgid "Visit Dashboard"
+msgstr ""
+
+#: wp-admin/includes/ms.php:596
+msgid "View Site"
+msgstr ""
+
+#: wp-admin/includes/ms.php:639
+msgid "American English"
+msgstr ""
+
+#: wp-admin/includes/ms.php:643
+msgid "British English"
+msgstr ""
+
+#: wp-admin/includes/ms.php:652
+msgid "English"
+msgstr ""
+
+#. translators: %s: URL to Upgrade Network screen.
+#: wp-admin/includes/ms.php:696
+msgid "Thank you for Updating! Please visit the <a href=\"%s\">Upgrade Network</a> page to update all your sites."
+msgstr ""
+
+#. translators: My Sites label.
+#: wp-admin/includes/ms.php:759
+msgid "Primary Site"
+msgstr ""
+
+#: wp-admin/includes/ms.php:791
+msgid "Not available"
+msgstr ""
+
+#: wp-admin/includes/ms.php:856
+msgid "You have chosen to delete the user from all networks and sites."
+msgstr ""
+
+#: wp-admin/includes/ms.php:858
+msgid "You have chosen to delete the following users from all networks and sites."
+msgstr ""
+
+#. translators: %s: User login.
+#: wp-admin/includes/ms.php:879
+msgid "Warning! User %s cannot be deleted."
+msgstr ""
+
+#. translators: %s: User login.
+#: wp-admin/includes/ms.php:889
+msgid "Warning! User cannot be deleted. The user %s is a network administrator."
+msgstr ""
+
+#. translators: %s: User login.
+#: wp-admin/includes/ms.php:908
+msgid "What should be done with content owned by %s?"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/includes/ms.php:926
+msgid "Select a user"
+msgstr ""
+
+#. translators: %s: Link to user's site.
+#: wp-admin/includes/ms.php:948
+msgid "Site: %s"
+msgstr ""
+
+#: wp-admin/includes/ms.php:952
+msgid "Delete all content."
+msgstr ""
+
+#: wp-admin/includes/ms.php:954
+msgid "Attribute all content to:"
+msgstr ""
+
+#: wp-admin/includes/ms.php:963
+msgid "User has no sites or content and will be deleted."
+msgstr ""
+
+#: wp-admin/includes/ms.php:978
+msgid "Once you hit &#8220;Confirm Deletion&#8221;, the user will be permanently removed."
+msgstr ""
+
+#: wp-admin/includes/ms.php:980
+msgid "Once you hit &#8220;Confirm Deletion&#8221;, these users will be permanently removed."
+msgstr ""
+
+#: wp-admin/includes/ms.php:984
+msgid "Confirm Deletion"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1053
+msgid "Info"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1063
+#: wp-admin/network/menu.php:78
+#: wp-admin/network/themes.php:338
+msgid "Themes"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1068
+#: wp-admin/network/menu.php:109
+msgid "Settings"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1119
+msgid "Secondary menu"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1134
+#: wp-admin/my-sites.php:44
+#: wp-admin/network/index.php:34
+#: wp-admin/network/settings.php:49
+#: wp-admin/network/site-new.php:23
+#: wp-admin/network/sites.php:29
+#: wp-admin/network/themes.php:298
+#: wp-admin/network/upgrade.php:22
+#: wp-admin/network/user-new.php:20
+#: wp-admin/network/users.php:229
+msgid "Overview"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1136
+msgid "The menu is for editing information specific to individual sites, particularly if the admin area of a site is unavailable."
+msgstr ""
+
+#: wp-admin/includes/ms.php:1137
+msgid "<strong>Info</strong> &mdash; The site URL is rarely edited as this can cause the site to not work properly. The Registered date and Last Updated date are displayed. Network admins can mark a site as archived, spam, deleted and mature, to remove from public listings or disable."
+msgstr ""
+
+#: wp-admin/includes/ms.php:1138
+msgid "<strong>Users</strong> &mdash; This displays the users associated with this site. You can also change their role, reset their password, or remove them from the site. Removing the user from the site does not remove the user from the network."
+msgstr ""
+
+#. translators: %s: URL to Network Themes screen.
+#: wp-admin/includes/ms.php:1141
+msgid "<strong>Themes</strong> &mdash; This area shows themes that are not already enabled across the network. Enabling a theme in this menu makes it accessible to this site. It does not activate the theme, but allows it to show in the site&#8217;s Appearance menu. To enable a theme for the entire network, see the <a href=\"%s\">Network Themes</a> screen."
+msgstr ""
+
+#: wp-admin/includes/ms.php:1144
+msgid "<strong>Settings</strong> &mdash; This page shows a list of all settings associated with this site. Some are created by ClassicPress and others are created by plugins you activate. Note that some fields are grayed out and say Serialized Data. You cannot modify these values due to the way the setting is stored in the database."
+msgstr ""
+
+#: wp-admin/includes/ms.php:1156
+#: wp-admin/my-sites.php:51
+#: wp-admin/network.php:67
+#: wp-admin/network.php:80
+#: wp-admin/network/index.php:55
+#: wp-admin/network/settings.php:63
+#: wp-admin/network/site-new.php:31
+#: wp-admin/network/sites.php:45
+#: wp-admin/network/themes.php:323
+#: wp-admin/network/upgrade.php:31
+#: wp-admin/network/user-new.php:28
+#: wp-admin/network/users.php:241
+msgid "For more information:"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1157
+#: wp-admin/network/site-new.php:32
+#: wp-admin/network/sites.php:46
+msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-sites-screen/\">Documentation on Site Management</a>"
+msgstr ""
+
+#: wp-admin/includes/ms.php:1158
+#: wp-admin/network/index.php:57
+#: wp-admin/network/site-new.php:33
+#: wp-admin/network/sites.php:47
+#: wp-admin/network/user-new.php:30
+#: wp-admin/network/users.php:243
+msgid "<a href=\"https://wordpress.org/support/forum/multisite/\">Support forums</a>"
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:13
+#: wp-admin/my-sites.php:13
+#: wp-admin/network/admin.php:17
+msgid "Multisite support is not enabled."
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:17
+msgid "Sorry, you are not allowed to delete this site."
+msgstr ""
+
+#. translators: %s: Network title.
+#: wp-admin/ms-delete-site.php:26
+msgid "Thank you for using %s, your site has been deleted. Happy trails to you until we meet again."
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:31
+msgid "Sorry, the link you clicked is stale. Please select another option."
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:39
+msgid "Delete Site"
+msgstr ""
+
+#. translators: Do not translate USERNAME, URL_DELETE, SITENAME, SITEURL: those are placeholders.
+#: wp-admin/ms-delete-site.php:58
+msgid ""
+"Hello ###USERNAME###,\n"
+"\n"
+"You recently clicked the 'Delete Site' link on your site and filled in a\n"
+"form on that page.\n"
+"\n"
+"If you really want to delete your site, click the link below. You will not\n"
+"be asked to confirm again so only click this link if you are absolutely certain:\n"
+"###URL_DELETE###\n"
+"\n"
+"If you delete your site, please consider opening a new site here some time in\n"
+"the future! (But remember that your current site and username are gone forever.)\n"
+"\n"
+"Thank you for using the site,\n"
+"All at ###SITENAME###\n"
+"###SITEURL###"
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/ms-delete-site.php:93
+msgid "[%s] Delete My Site"
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:104
+msgid "Thank you. Please check your email for a link to confirm your action. Your site will not be deleted until this link is clicked."
+msgstr ""
+
+#. translators: %s: Network title.
+#: wp-admin/ms-delete-site.php:113
+msgid "If you do not want to use your %s site any more, you can delete it using the form below. When you click <strong>Delete My Site Permanently</strong> you will be sent an email with a link in it. Click on this link to delete your site."
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:118
+msgid "Remember, once deleted your site cannot be restored."
+msgstr ""
+
+#. translators: %s: Site address.
+#: wp-admin/ms-delete-site.php:127
+msgid "I'm sure I want to permanently delete my site, and I am aware I can never get it back or use %s again."
+msgstr ""
+
+#: wp-admin/ms-delete-site.php:132
+msgid "Delete My Site Permanently"
+msgstr ""
+
+#: wp-admin/my-sites.php:17
+#: wp-admin/network/index.php:17
+#: wp-admin/network/settings.php:17
+#: wp-admin/network/site-info.php:32
+#: wp-admin/network/site-settings.php:32
+#: wp-admin/network/site-themes.php:57
+#: wp-admin/network/site-users.php:50
+#: wp-admin/network/sites.php:14
+#: wp-admin/network/sites.php:141
+#: wp-admin/network/upgrade.php:39
+#: wp-admin/network/user-new.php:37
+#: wp-admin/network/users.php:14
+#: wp-admin/network/users.php:24
+#: wp-admin/network/users.php:51
+#: wp-admin/network/users.php:65
+#: wp-admin/network/users.php:160
+msgid "Sorry, you are not allowed to access this page."
+msgstr ""
+
+#: wp-admin/my-sites.php:33
+msgid "The primary site you chose does not exist."
+msgstr ""
+
+#: wp-admin/my-sites.php:38
+msgid "My Sites"
+msgstr ""
+
+#: wp-admin/my-sites.php:46
+msgid "This screen shows an individual user all of their sites in this network, and also allows that user to set a primary site. They can use the links under each site to visit either the front end or the dashboard for that site."
+msgstr ""
+
+#: wp-admin/my-sites.php:52
+msgid "<a href=\"https://codex.wordpress.org/Dashboard_My_Sites_Screen\">Documentation on My Sites</a>"
+msgstr ""
+
+#: wp-admin/my-sites.php:53
+#: wp-admin/network.php:83
+#: wp-admin/network/settings.php:65
+#: wp-admin/network/themes.php:326
+#: wp-admin/network/upgrade.php:33
+msgid "<a href=\"https://wordpress.org/support/forums/\">Support forums</a>"
+msgstr ""
+
+#: wp-admin/my-sites.php:59
+#: wp-admin/network/settings.php:141
+#: wp-admin/network/sites.php:352
+msgid "Settings saved."
+msgstr ""
+
+#: wp-admin/my-sites.php:73
+#: wp-admin/network/menu.php:53
+#: wp-admin/network/sites.php:370
+msgctxt "site"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/my-sites.php:78
+msgid "You must be a member of at least one site to use this page."
+msgstr ""
+
+#: wp-admin/my-sites.php:113
+msgid "Global Settings"
+msgstr ""
+
+#: wp-admin/network.php:19
+msgid "Sorry, you are not allowed to manage options for this site."
+msgstr ""
+
+#: wp-admin/network.php:29
+msgid "The Network creation panel is not for ClassicPress MU networks."
+msgstr ""
+
+#. translators: 1: WP_ALLOW_MULTISITE, 2: wp-config.php
+#: wp-admin/network.php:44
+msgid "You must define the %1$s constant as true in your %2$s file to allow creation of a Network."
+msgstr ""
+
+#: wp-admin/network.php:53
+#: wp-admin/network/menu.php:112
+msgid "Network Setup"
+msgstr ""
+
+#: wp-admin/network.php:57
+msgid "Create a Network of ClassicPress Sites"
+msgstr ""
+
+#: wp-admin/network.php:61
+msgid "This screen allows you to configure a network as having subdomains (<code>site1.example.com</code>) or subdirectories (<code>example.com/site1</code>). Subdomains require wildcard subdomains to be enabled in Apache and DNS records, if your host allows it."
+msgstr ""
+
+#: wp-admin/network.php:62
+msgid "Choose subdomains or subdirectories; this can only be switched afterwards by reconfiguring your installation. Fill out the network details, and click Install. If this does not work, you may have to add a wildcard DNS record (for subdomains) or change to another setting in Permalinks (for subdirectories)."
+msgstr ""
+
+#: wp-admin/network.php:63
+msgid "The next screen for Network Setup will give you individually-generated lines of code to add to your wp-config.php and .htaccess files. Make sure the settings of your FTP client make files starting with a dot visible, so that you can find .htaccess; you may have to create this file if it really is not there. Make backup copies of those two files."
+msgstr ""
+
+#: wp-admin/network.php:64
+msgid "Add the designated lines of code to wp-config.php (just before <code>/*...stop editing...*/</code>) and <code>.htaccess</code> (replacing the existing ClassicPress rules)."
+msgstr ""
+
+#: wp-admin/network.php:65
+msgid "Once you add this code and refresh your browser, multisite should be enabled. This screen, now in the Network Admin navigation menu, will keep an archive of the added code. You can toggle between Network Admin and Site Admin by clicking on the Network Admin or an individual site name under the My Sites dropdown in the Toolbar."
+msgstr ""
+
+#: wp-admin/network.php:66
+msgid "The choice of subdirectory sites is disabled if this setup is more than a month old because of permalink problems with &#8220;/blog/&#8221; from the main site. This disabling will be addressed in a future version."
+msgstr ""
+
+#: wp-admin/network.php:68
+#: wp-admin/network.php:81
+msgid "<a href=\"https://wordpress.org/documentation/article/create-a-network/\">Documentation on Creating a Network</a>"
+msgstr ""
+
+#: wp-admin/network.php:69
+#: wp-admin/network.php:82
+msgid "<a href=\"https://wordpress.org/documentation/article/tools-network-screen/\">Documentation on the Network Screen</a>"
+msgstr ""
+
+#: wp-admin/network.php:74
+msgid "Network"
+msgstr ""
+
+#: wp-admin/network/index.php:24
+msgid "Welcome to your Network Admin. This area of the Administration Screens is used for managing all aspects of your Multisite Network."
+msgstr ""
+
+#: wp-admin/network/index.php:25
+msgid "From here you can:"
+msgstr ""
+
+#: wp-admin/network/index.php:26
+msgid "Add and manage sites or users"
+msgstr ""
+
+#: wp-admin/network/index.php:27
+msgid "Install and activate themes or plugins"
+msgstr ""
+
+#: wp-admin/network/index.php:28
+msgid "Update your network"
+msgstr ""
+
+#: wp-admin/network/index.php:29
+msgid "Modify global network settings"
+msgstr ""
+
+#: wp-admin/network/index.php:39
+msgid "The Right Now widget on this screen provides current user and site counts on your network."
+msgstr ""
+
+#: wp-admin/network/index.php:40
+msgid "To add a new user, <strong>click Create a New User</strong>."
+msgstr ""
+
+#: wp-admin/network/index.php:41
+msgid "To add a new site, <strong>click Create a New Site</strong>."
+msgstr ""
+
+#: wp-admin/network/index.php:42
+msgid "To search for a user or site, use the search boxes."
+msgstr ""
+
+#: wp-admin/network/index.php:43
+msgid "To search for a user, <strong>enter an email address or username</strong>. Use a wildcard to search for a partial username, such as user&#42;."
+msgstr ""
+
+#: wp-admin/network/index.php:44
+msgid "To search for a site, <strong>enter the path or domain</strong>."
+msgstr ""
+
+#: wp-admin/network/index.php:49
+msgid "Quick Tasks"
+msgstr ""
+
+#: wp-admin/network/index.php:56
+msgid "<a href=\"https://wordpress.org/documentation/article/network-admin/\">Documentation on the Network Admin</a>"
+msgstr ""
+
+#: wp-admin/network/menu.php:13
+msgid "Home"
+msgstr ""
+
+#. translators: %s: Number of available updates.
+#: wp-admin/network/menu.php:30
+msgid "Updates %s"
+msgstr ""
+
+#: wp-admin/network/menu.php:41
+msgid "Updates"
+msgstr ""
+
+#: wp-admin/network/menu.php:46
+#: wp-admin/network/upgrade.php:16
+#: wp-admin/network/upgrade.php:43
+#: wp-admin/network/upgrade.php:145
+msgid "Upgrade Network"
+msgstr ""
+
+#: wp-admin/network/menu.php:52
+msgid "All Sites"
+msgstr ""
+
+#: wp-admin/network/menu.php:56
+msgid "All Users"
+msgstr ""
+
+#: wp-admin/network/menu.php:57
+#: wp-admin/network/users.php:288
+msgctxt "user"
+msgid "Add New"
+msgstr ""
+
+#. translators: %s: Number of available theme updates.
+#: wp-admin/network/menu.php:63
+msgid "Themes %s"
+msgstr ""
+
+#: wp-admin/network/menu.php:80
+msgid "Installed Themes"
+msgstr ""
+
+#: wp-admin/network/menu.php:81
+#: wp-admin/network/themes.php:352
+msgctxt "theme"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/network/menu.php:82
+msgid "Theme File Editor"
+msgstr ""
+
+#. translators: %s: Number of available plugin updates.
+#: wp-admin/network/menu.php:88
+msgid "Plugins %s"
+msgstr ""
+
+#: wp-admin/network/menu.php:103
+#: wp-admin/network/settings.php:497
+msgid "Plugins"
+msgstr ""
+
+#: wp-admin/network/menu.php:105
+msgid "Installed Plugins"
+msgstr ""
+
+#: wp-admin/network/menu.php:106
+msgctxt "plugin"
+msgid "Add New"
+msgstr ""
+
+#: wp-admin/network/menu.php:107
+msgid "Plugin File Editor"
+msgstr ""
+
+#: wp-admin/network/menu.php:111
+#: wp-admin/network/settings.php:21
+msgid "Network Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:51
+msgid "This screen sets and changes options for the network as a whole. The first site is the main site in the network and network options are pulled from that original site&#8217;s options."
+msgstr ""
+
+#: wp-admin/network/settings.php:52
+msgid "Operational settings has fields for the network&#8217;s name and admin email."
+msgstr ""
+
+#: wp-admin/network/settings.php:53
+msgid "Registration settings can disable/enable public signups. If you let others sign up for a site, install spam plugins. Spaces, not commas, should separate names banned as sites for this network."
+msgstr ""
+
+#: wp-admin/network/settings.php:54
+msgid "New site settings are defaults applied when a new site is created in the network. These include welcome email for when a new site or user account is registered, and what&#8127;s put in the first post, page, comment, comment author, and comment URL."
+msgstr ""
+
+#: wp-admin/network/settings.php:55
+msgid "Upload settings control the size of the uploaded files and the amount of available upload space for each site. You can change the default value for specific sites when you edit a particular site. Allowed file types are also listed (space separated only)."
+msgstr ""
+
+#: wp-admin/network/settings.php:56
+msgid "You can set the language, and the translation files will be automatically downloaded and installed (available if your filesystem is writable)."
+msgstr ""
+
+#: wp-admin/network/settings.php:57
+msgid "Menu setting enables/disables the plugin menus from appearing for non super admins, so that only super admins, not site admins, have access to activate plugins."
+msgstr ""
+
+#: wp-admin/network/settings.php:58
+msgid "Super admins can no longer be added on the Options screen. You must now go to the list of existing users on Network Admin > Users and click on Username or the Edit action link below that name. This goes to an Edit User page where you can check a box to grant super admin privileges."
+msgstr ""
+
+#: wp-admin/network/settings.php:64
+msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-settings-screen/\">Documentation on Network Settings</a>"
+msgstr ""
+
+#: wp-admin/network/settings.php:150
+msgid "Operational Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:153
+msgid "Network Title"
+msgstr ""
+
+#: wp-admin/network/settings.php:160
+msgid "Network Admin Email"
+msgstr ""
+
+#: wp-admin/network/settings.php:164
+msgid "This address is used for admin purposes. If you change this, an email will be sent to your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>"
+msgstr ""
+
+#. translators: %s: New network admin email.
+#: wp-admin/network/settings.php:175
+msgid "There is a pending change of the network admin email to %s."
+msgstr ""
+
+#: wp-admin/network/settings.php:181
+msgid "Cancel"
+msgstr ""
+
+#: wp-admin/network/settings.php:190
+msgid "Registration Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:193
+msgid "Allow new registrations"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/network/settings.php:205
+msgid "New registrations settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:208
+msgid "Registration is disabled"
+msgstr ""
+
+#: wp-admin/network/settings.php:209
+msgid "User accounts may be registered"
+msgstr ""
+
+#: wp-admin/network/settings.php:210
+msgid "Logged in users may register new sites"
+msgstr ""
+
+#: wp-admin/network/settings.php:211
+msgid "Both sites and user accounts can be registered"
+msgstr ""
+
+#. translators: 1: NOBLOGREDIRECT, 2: wp-config.php
+#: wp-admin/network/settings.php:217
+msgid "If registration is disabled, please set %1$s in %2$s to a URL you will redirect visitors to if they visit a non-existent site."
+msgstr ""
+
+#: wp-admin/network/settings.php:229
+msgid "Registration notification"
+msgstr ""
+
+#: wp-admin/network/settings.php:236
+msgid "Send the network admin an email notification every time someone registers a site or user account"
+msgstr ""
+
+#: wp-admin/network/settings.php:241
+msgid "Add New Users"
+msgstr ""
+
+#: wp-admin/network/settings.php:243
+msgid "Allow site administrators to add new users to their site via the \"Users &rarr; Add New\" page"
+msgstr ""
+
+#: wp-admin/network/settings.php:248
+msgid "Banned Names"
+msgstr ""
+
+#: wp-admin/network/settings.php:261
+msgid "Users are not allowed to register these sites. Separate names by spaces."
+msgstr ""
+
+#: wp-admin/network/settings.php:267
+msgid "Limited Email Registrations"
+msgstr ""
+
+#: wp-admin/network/settings.php:286
+msgid "If you want to limit site registrations to certain domains. One domain per line."
+msgstr ""
+
+#: wp-admin/network/settings.php:292
+msgid "Banned Email Domains"
+msgstr ""
+
+#: wp-admin/network/settings.php:306
+msgid "If you want to ban domains from site registrations. One domain per line."
+msgstr ""
+
+#: wp-admin/network/settings.php:312
+msgid "New Site Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:316
+msgid "Welcome Email"
+msgstr ""
+
+#: wp-admin/network/settings.php:321
+msgid "The welcome email sent to new site owners."
+msgstr ""
+
+#: wp-admin/network/settings.php:326
+msgid "Welcome User Email"
+msgstr ""
+
+#: wp-admin/network/settings.php:331
+msgid "The welcome email sent to new users."
+msgstr ""
+
+#: wp-admin/network/settings.php:336
+msgid "First Post"
+msgstr ""
+
+#: wp-admin/network/settings.php:341
+msgid "The first post on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:346
+msgid "First Page"
+msgstr ""
+
+#: wp-admin/network/settings.php:351
+msgid "The first page on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:356
+msgid "First Comment"
+msgstr ""
+
+#: wp-admin/network/settings.php:361
+msgid "The first comment on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:366
+msgid "First Comment Author"
+msgstr ""
+
+#: wp-admin/network/settings.php:370
+msgid "The author of the first comment on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:375
+msgid "First Comment Email"
+msgstr ""
+
+#: wp-admin/network/settings.php:379
+msgid "The email address of the first comment author on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:384
+msgid "First Comment URL"
+msgstr ""
+
+#: wp-admin/network/settings.php:388
+msgid "The URL for the first comment on a new site."
+msgstr ""
+
+#: wp-admin/network/settings.php:393
+msgid "Upload Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:396
+msgid "Site upload space"
+msgstr ""
+
+#. translators: %s: Number of megabytes to limit uploads to.
+#: wp-admin/network/settings.php:402
+msgid "Limit total size of files uploaded to %s MB"
+msgstr ""
+
+#: wp-admin/network/settings.php:417
+msgid "Upload file types"
+msgstr ""
+
+#: wp-admin/network/settings.php:421
+msgid "Allowed file types. Separate types by spaces."
+msgstr ""
+
+#: wp-admin/network/settings.php:427
+msgid "Max upload file size"
+msgstr ""
+
+#. translators: %s: File size in kilobytes.
+#: wp-admin/network/settings.php:432
+msgid "%s KB"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/network/settings.php:439
+msgid "Size in kilobytes"
+msgstr ""
+
+#: wp-admin/network/settings.php:451
+msgid "Language Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:454
+msgid "Default Language"
+msgstr ""
+
+#: wp-admin/network/settings.php:501
+msgid "Menu Settings"
+msgstr ""
+
+#: wp-admin/network/settings.php:504
+msgid "Enable administration menus"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/network/settings.php:509
+msgid "Enable menus"
+msgstr ""
+
+#: wp-admin/network/site-info.php:14
+#: wp-admin/network/site-settings.php:14
+#: wp-admin/network/site-users.php:14
+msgid "Sorry, you are not allowed to edit this site."
+msgstr ""
+
+#: wp-admin/network/site-info.php:23
+#: wp-admin/network/site-settings.php:23
+#: wp-admin/network/site-themes.php:46
+#: wp-admin/network/site-users.php:41
+msgid "Invalid site ID."
+msgstr ""
+
+#: wp-admin/network/site-info.php:28
+#: wp-admin/network/site-settings.php:28
+#: wp-admin/network/site-themes.php:53
+#: wp-admin/network/site-users.php:46
+msgid "The requested site does not exist."
+msgstr ""
+
+#: wp-admin/network/site-info.php:126
+msgid "Site info updated."
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-admin/network/site-info.php:132
+#: wp-admin/network/site-settings.php:84
+#: wp-admin/network/site-themes.php:171
+#: wp-admin/network/site-users.php:200
+msgid "Edit Site: %s"
+msgstr ""
+
+#: wp-admin/network/site-info.php:168
+#: wp-admin/network/site-info.php:176
+#: wp-admin/network/site-new.php:204
+msgid "Site Address (URL)"
+msgstr ""
+
+#: wp-admin/network/site-info.php:190
+msgctxt "site"
+msgid "Public"
+msgstr ""
+
+#: wp-admin/network/site-info.php:199
+msgid "Attributes"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-admin/network/site-info.php:205
+msgid "Set site attributes"
+msgstr ""
+
+#: wp-admin/network/site-new.php:17
+msgid "Sorry, you are not allowed to add sites to this network."
+msgstr ""
+
+#: wp-admin/network/site-new.php:25
+msgid "This screen is for Super Admins to add new sites to the network. This is not affected by the registration settings."
+msgstr ""
+
+#: wp-admin/network/site-new.php:26
+msgid "If the admin email for the new site does not exist in the database, a new user will also be created."
+msgstr ""
+
+#: wp-admin/network/site-new.php:40
+msgid "Cannot create an empty site."
+msgstr ""
+
+#. translators: %s: Reserved names list.
+#: wp-admin/network/site-new.php:59
+msgid "The following words are reserved for use by ClassicPress functions and cannot be used as site names: %s"
+msgstr ""
+
+#: wp-admin/network/site-new.php:87
+msgid "Missing or invalid site address."
+msgstr ""
+
+#: wp-admin/network/site-new.php:91
+msgid "Missing email address."
+msgstr ""
+
+#: wp-admin/network/site-new.php:96
+msgid "Invalid email address."
+msgstr ""
+
+#: wp-admin/network/site-new.php:121
+msgid "The domain or path entered conflicts with an existing username."
+msgstr ""
+
+#: wp-admin/network/site-new.php:126
+msgid "There was an error creating the user."
+msgstr ""
+
+#. translators: 1: Dashboard URL, 2: Network admin edit URL.
+#: wp-admin/network/site-new.php:170
+msgid "Site added. <a href=\"%1$s\">Visit Dashboard</a> or <a href=\"%2$s\">Edit Site</a>"
+msgstr ""
+
+#: wp-admin/network/site-new.php:178
+#: wp-admin/network/site-new.php:188
+msgid "Add New Site"
+msgstr ""
+
+#: wp-admin/network/site-new.php:219
+msgid "Only lowercase letters (a-z), numbers, and hyphens are allowed."
+msgstr ""
+
+#: wp-admin/network/site-new.php:227
+msgid "Site Title"
+msgstr ""
+
+#: wp-admin/network/site-new.php:240
+msgid "Site Language"
+msgstr ""
+
+#: wp-admin/network/site-new.php:288
+msgid "Admin Email"
+msgstr ""
+
+#: wp-admin/network/site-new.php:297
+msgid "A new user will be created if the above email address is not in the database."
+msgstr ""
+
+#: wp-admin/network/site-new.php:297
+msgid "The username and a link to set the password will be mailed to this email address."
+msgstr ""
+
+#: wp-admin/network/site-new.php:309
+msgid "Add Site"
+msgstr ""
+
+#: wp-admin/network/site-settings.php:78
+msgid "Site options updated."
+msgstr ""
+
+#: wp-admin/network/site-themes.php:14
+msgid "Sorry, you are not allowed to manage themes for this site."
+msgstr ""
+
+#: wp-admin/network/site-themes.php:22
+msgid "Filter site themes list"
+msgstr ""
+
+#: wp-admin/network/site-themes.php:23
+msgid "Site themes list navigation"
+msgstr ""
+
+#: wp-admin/network/site-themes.php:24
+msgid "Site themes list"
+msgstr ""
+
+#: wp-admin/network/site-themes.php:193
+#: wp-admin/network/themes.php:373
+msgid "Theme enabled."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/network/site-themes.php:196
+#: wp-admin/network/themes.php:376
+msgid "%s theme enabled."
+msgid_plural "%s themes enabled."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/network/site-themes.php:202
+#: wp-admin/network/themes.php:382
+msgid "Theme disabled."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/network/site-themes.php:205
+#: wp-admin/network/themes.php:385
+msgid "%s theme disabled."
+msgid_plural "%s themes disabled."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/network/site-themes.php:209
+#: wp-admin/network/themes.php:416
+msgid "No theme selected."
+msgstr ""
+
+#: wp-admin/network/site-themes.php:213
+msgid "Network enabled themes are not shown on this screen."
+msgstr ""
+
+#: wp-admin/network/site-themes.php:216
+#: wp-admin/network/themes.php:424
+msgid "Search Installed Themes"
+msgstr ""
+
+#: wp-admin/network/site-users.php:25
+msgid "Filter site users list"
+msgstr ""
+
+#: wp-admin/network/site-users.php:26
+msgid "Site users list navigation"
+msgstr ""
+
+#: wp-admin/network/site-users.php:27
+msgid "Site users list"
+msgstr ""
+
+#: wp-admin/network/site-users.php:120
+msgid "Sorry, you are not allowed to remove users."
+msgstr ""
+
+#: wp-admin/network/site-users.php:146
+msgid "Sorry, you are not allowed to give users that role."
+msgstr ""
+
+#: wp-admin/network/site-users.php:158
+msgid "Something went wrong."
+msgstr ""
+
+#: wp-admin/network/site-users.php:159
+msgid "One of the selected users is not a member of this site."
+msgstr ""
+
+#: wp-admin/network/site-users.php:238
+#: wp-admin/network/user-new.php:91
+#: wp-admin/network/users.php:274
+msgid "User added."
+msgstr ""
+
+#: wp-admin/network/site-users.php:241
+msgid "User is already a member of this site."
+msgstr ""
+
+#: wp-admin/network/site-users.php:244
+msgid "User could not be added to this site."
+msgstr ""
+
+#: wp-admin/network/site-users.php:247
+msgid "Enter the username of an existing user."
+msgstr ""
+
+#: wp-admin/network/site-users.php:250
+msgid "Changed roles."
+msgstr ""
+
+#: wp-admin/network/site-users.php:253
+msgid "Select a user to change role."
+msgstr ""
+
+#: wp-admin/network/site-users.php:256
+msgid "User removed from this site."
+msgstr ""
+
+#: wp-admin/network/site-users.php:259
+msgid "Select a user to remove."
+msgstr ""
+
+#: wp-admin/network/site-users.php:262
+msgid "User created."
+msgstr ""
+
+#: wp-admin/network/site-users.php:265
+msgid "Enter the username and email."
+msgstr ""
+
+#: wp-admin/network/site-users.php:268
+msgid "Duplicated username or email address."
+msgstr ""
+
+#: wp-admin/network/site-users.php:275
+#: wp-admin/network/users.php:308
+msgid "Search Users"
+msgstr ""
+
+#: wp-admin/network/site-users.php:316
+msgid "Add Existing User"
+msgstr ""
+
+#: wp-admin/network/site-users.php:326
+#: wp-admin/network/site-users.php:364
+msgid "Role"
+msgstr ""
+
+#: wp-admin/network/site-users.php:337
+#: wp-admin/network/user-new.php:146
+msgid "Add User"
+msgstr ""
+
+#: wp-admin/network/site-users.php:351
+#: wp-admin/network/site-users.php:378
+#: wp-admin/network/user-new.php:100
+#: wp-admin/network/user-new.php:106
+msgid "Add New User"
+msgstr ""
+
+#: wp-admin/network/site-users.php:374
+#: wp-admin/network/user-new.php:134
+msgid "A password reset link will be sent to the user via email."
+msgstr ""
+
+#: wp-admin/network/sites.php:31
+msgid "Add New takes you to the Add New Site screen. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page."
+msgstr ""
+
+#: wp-admin/network/sites.php:32
+msgid "This is the main table of all sites on this network. Switch between list and excerpt views by using the icons above the right side of the table."
+msgstr ""
+
+#: wp-admin/network/sites.php:33
+msgid "Hovering over each site reveals seven options (three for the primary site):"
+msgstr ""
+
+#: wp-admin/network/sites.php:34
+msgid "An Edit link to a separate Edit Site screen."
+msgstr ""
+
+#: wp-admin/network/sites.php:35
+msgid "Dashboard leads to the Dashboard for that site."
+msgstr ""
+
+#: wp-admin/network/sites.php:36
+msgid "Deactivate, Archive, and Spam which lead to confirmation screens. These actions can be reversed later."
+msgstr ""
+
+#: wp-admin/network/sites.php:37
+msgid "Delete which is a permanent action after the confirmation screens."
+msgstr ""
+
+#: wp-admin/network/sites.php:38
+msgid "Visit to go to the front-end site live."
+msgstr ""
+
+#: wp-admin/network/sites.php:39
+msgid "The site ID is used internally, and is not shown on the front end of the site or to users/viewers."
+msgstr ""
+
+#: wp-admin/network/sites.php:40
+msgid "Clicking on bold headings can re-sort this table."
+msgstr ""
+
+#: wp-admin/network/sites.php:52
+msgid "Sites list navigation"
+msgstr ""
+
+#: wp-admin/network/sites.php:53
+msgid "Sites list"
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:66
+msgid "You are about to activate the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:68
+msgid "You are about to deactivate the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:70
+msgid "You are about to unarchive the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:72
+msgid "You are about to archive the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:74
+msgid "You are about to unspam the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:76
+msgid "You are about to mark the site %s as spam."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:78
+msgid "You are about to delete the site %s."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:80
+msgid "You are about to mark the site %s as mature."
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:82
+msgid "You are about to mark the site %s as not mature."
+msgstr ""
+
+#: wp-admin/network/sites.php:90
+msgid "The requested action is not valid."
+msgstr ""
+
+#: wp-admin/network/sites.php:106
+#: wp-admin/network/sites.php:224
+msgid "Sorry, you are not allowed to change the current site."
+msgstr ""
+
+#: wp-admin/network/sites.php:115
+#: wp-admin/network/sites.php:191
+msgid "Confirm your action"
+msgstr ""
+
+#: wp-admin/network/sites.php:122
+#: wp-admin/network/sites.php:209
+msgid "Confirm"
+msgstr ""
+
+#. translators: %s: Site URL.
+#: wp-admin/network/sites.php:168
+msgid "Sorry, you are not allowed to delete the site %s."
+msgstr ""
+
+#: wp-admin/network/sites.php:196
+msgid "You are about to delete the following sites:"
+msgstr ""
+
+#: wp-admin/network/sites.php:309
+msgid "Sites removed from spam."
+msgstr ""
+
+#: wp-admin/network/sites.php:312
+msgid "Sites marked as spam."
+msgstr ""
+
+#: wp-admin/network/sites.php:315
+msgid "Sites deleted."
+msgstr ""
+
+#: wp-admin/network/sites.php:318
+msgid "Site deleted."
+msgstr ""
+
+#: wp-admin/network/sites.php:321
+msgid "Sorry, you are not allowed to delete that site."
+msgstr ""
+
+#: wp-admin/network/sites.php:324
+msgid "Site archived."
+msgstr ""
+
+#: wp-admin/network/sites.php:327
+msgid "Site unarchived."
+msgstr ""
+
+#: wp-admin/network/sites.php:330
+msgid "Site activated."
+msgstr ""
+
+#: wp-admin/network/sites.php:333
+msgid "Site deactivated."
+msgstr ""
+
+#: wp-admin/network/sites.php:336
+msgid "Site removed from spam."
+msgstr ""
+
+#: wp-admin/network/sites.php:339
+msgid "Site marked as spam."
+msgstr ""
+
+#. translators: %s: Search query.
+#: wp-admin/network/sites.php:378
+#: wp-admin/network/themes.php:360
+#: wp-admin/network/users.php:296
+msgid "Search results for: %s"
+msgstr ""
+
+#: wp-admin/network/sites.php:392
+msgid "Search Sites"
+msgstr ""
+
+#: wp-admin/network/themes.php:14
+msgid "Sorry, you are not allowed to manage network themes."
+msgstr ""
+
+#: wp-admin/network/themes.php:85
+msgid "Update Themes"
+msgstr ""
+
+#: wp-admin/network/themes.php:102
+msgid "Sorry, you are not allowed to delete themes for this site."
+msgstr ""
+
+#: wp-admin/network/themes.php:137
+msgid "Delete Theme"
+msgstr ""
+
+#: wp-admin/network/themes.php:138
+#: wp-admin/network/themes.php:142
+msgid "Caution:"
+msgstr ""
+
+#: wp-admin/network/themes.php:138
+msgid "This theme may be active on other sites in the network."
+msgstr ""
+
+#: wp-admin/network/themes.php:139
+msgid "You are about to remove the following theme:"
+msgstr ""
+
+#: wp-admin/network/themes.php:141
+msgid "Delete Themes"
+msgstr ""
+
+#: wp-admin/network/themes.php:142
+msgid "These themes may be active on other sites in the network."
+msgstr ""
+
+#: wp-admin/network/themes.php:143
+msgid "You are about to remove the following themes:"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme author.
+#: wp-admin/network/themes.php:150
+msgctxt "theme"
+msgid "%1$s by %2$s"
+msgstr ""
+
+#: wp-admin/network/themes.php:158
+msgid "Are you sure you want to delete this theme?"
+msgstr ""
+
+#: wp-admin/network/themes.php:160
+msgid "Are you sure you want to delete these themes?"
+msgstr ""
+
+#: wp-admin/network/themes.php:174
+msgid "Yes, delete this theme"
+msgstr ""
+
+#: wp-admin/network/themes.php:176
+msgid "Yes, delete these themes"
+msgstr ""
+
+#: wp-admin/network/themes.php:183
+msgid "No, return me to the theme list"
+msgstr ""
+
+#: wp-admin/network/themes.php:226
+msgid "Sorry, you are not allowed to change themes automatic update settings."
+msgstr ""
+
+#: wp-admin/network/themes.php:300
+msgid "This screen enables and disables the inclusion of themes available to choose in the Appearance menu for each site. It does not activate or deactivate which theme a site is currently using."
+msgstr ""
+
+#: wp-admin/network/themes.php:301
+msgid "If the network admin disables a theme that is in use, it can still remain selected on that site. If another theme is chosen, the disabled theme will not appear in the site&#8217;s Appearance > Themes screen."
+msgstr ""
+
+#: wp-admin/network/themes.php:302
+msgid "Themes can be enabled on a site by site basis by the network admin on the Edit Site screen (which has a Themes tab); get there via the Edit action link on the All Sites screen. Only network admins are able to install or edit themes."
+msgstr ""
+
+#: wp-admin/network/themes.php:312
+msgid "Auto-updates"
+msgstr ""
+
+#: wp-admin/network/themes.php:314
+msgid "Auto-updates can be enabled or disabled for each individual theme. Themes with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system."
+msgstr ""
+
+#: wp-admin/network/themes.php:315
+msgid "Please note: Third-party themes and plugins, or custom code, may override ClassicPress scheduling."
+msgstr ""
+
+#: wp-admin/network/themes.php:319
+msgid "<a href=\"https://wordpress.org/documentation/article/plugins-themes-auto-updates/\">Documentation on Auto-updates</a>"
+msgstr ""
+
+#: wp-admin/network/themes.php:324
+msgid "<a href=\"https://codex.wordpress.org/Network_Admin_Themes_Screen\">Documentation on Network Themes</a>"
+msgstr ""
+
+#: wp-admin/network/themes.php:331
+msgid "Filter themes list"
+msgstr ""
+
+#: wp-admin/network/themes.php:332
+msgid "Themes list navigation"
+msgstr ""
+
+#: wp-admin/network/themes.php:333
+msgid "Themes list"
+msgstr ""
+
+#: wp-admin/network/themes.php:391
+msgid "Theme deleted."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/network/themes.php:394
+msgid "%s theme deleted."
+msgid_plural "%s themes deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/network/themes.php:400
+msgid "Theme will be auto-updated."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/network/themes.php:403
+msgid "%s theme will be auto-updated."
+msgid_plural "%s themes will be auto-updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/network/themes.php:409
+msgid "Theme will no longer be auto-updated."
+msgstr ""
+
+#. translators: %s: Number of themes.
+#: wp-admin/network/themes.php:412
+msgid "%s theme will no longer be auto-updated."
+msgid_plural "%s themes will no longer be auto-updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-admin/network/themes.php:418
+msgid "You cannot delete a theme while it is active on the main site."
+msgstr ""
+
+#: wp-admin/network/themes.php:431
+msgid "The following themes are installed but incomplete."
+msgstr ""
+
+#: wp-admin/network/upgrade.php:24
+msgid "Only use this screen once you have updated to a new version of ClassicPress through Updates/Available Updates (via the Network Administration navigation menu or the Toolbar). Clicking the Upgrade Network button will step through each site in the network, five at a time, and make sure any database updates are applied."
+msgstr ""
+
+#: wp-admin/network/upgrade.php:25
+msgid "If a version update to core has not happened, clicking this button will not affect anything."
+msgstr ""
+
+#: wp-admin/network/upgrade.php:26
+msgid "If this process fails for any reason, users logging in to their sites will force the same update."
+msgstr ""
+
+#: wp-admin/network/upgrade.php:32
+msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-updates-screen/\">Documentation on Upgrade Network</a>"
+msgstr ""
+
+#: wp-admin/network/upgrade.php:74
+msgid "All done!"
+msgstr ""
+
+#. translators: 1: Site URL, 2: Server error message.
+#: wp-admin/network/upgrade.php:99
+msgid "Warning! Problem updating %1$s. Your server may not be able to connect to sites running on it. Error message: %2$s"
+msgstr ""
+
+#: wp-admin/network/upgrade.php:125
+msgid "If your browser does not start loading the next page automatically, click this link:"
+msgstr ""
+
+#: wp-admin/network/upgrade.php:125
+msgid "Next Sites"
+msgstr ""
+
+#: wp-admin/network/upgrade.php:140
+msgid "Database Update Required"
+msgstr ""
+
+#: wp-admin/network/upgrade.php:141
+msgid "ClassicPress has been updated! Next and final step is to individually upgrade the sites in your network."
+msgstr ""
+
+#: wp-admin/network/upgrade.php:144
+msgid "The database update process may take a little while, so please be patient."
+msgstr ""
+
+#: wp-admin/network/user-new.php:14
+msgid "Sorry, you are not allowed to add users to this network."
+msgstr ""
+
+#: wp-admin/network/user-new.php:22
+msgid "Add User will set up a new user account on the network and send that person an email with username and password."
+msgstr ""
+
+#: wp-admin/network/user-new.php:23
+msgid "Users who are signed up to the network without a site are added as subscribers to the main or primary dashboard site, giving them profile pages to manage their accounts. These users will only see Dashboard and My Sites in the main navigation until a site is created for them."
+msgstr ""
+
+#: wp-admin/network/user-new.php:29
+#: wp-admin/network/users.php:242
+msgid "<a href=\"https://codex.wordpress.org/Network_Admin_Users_Screen\">Documentation on Network Users</a>"
+msgstr ""
+
+#: wp-admin/network/user-new.php:41
+msgid "Cannot create an empty user."
+msgstr ""
+
+#: wp-admin/network/user-new.php:55
+msgid "Cannot add user."
+msgstr ""
+
+#: wp-admin/network/user-new.php:94
+msgid "Edit user"
+msgstr ""
+
+#. translators: %s: User login.
+#: wp-admin/network/users.php:87
+msgid "Warning! User cannot be modified. The user %s is a network administrator."
+msgstr ""
+
+#: wp-admin/network/users.php:231
+msgid "This table shows all users across the network and the sites to which they are assigned."
+msgstr ""
+
+#: wp-admin/network/users.php:232
+msgid "Hover over any user on the list to make the edit links appear. The Edit link on the left will take you to their Edit User profile page; the Edit link on the right by any site name goes to an Edit Site screen for that site."
+msgstr ""
+
+#: wp-admin/network/users.php:233
+msgid "You can also go to the user&#8217;s profile page by clicking on the individual username."
+msgstr ""
+
+#: wp-admin/network/users.php:234
+msgid "You can sort the table by clicking on any of the table headings and switch between list and excerpt views by using the icons above the users list."
+msgstr ""
+
+#: wp-admin/network/users.php:235
+msgid "The bulk action will permanently delete selected users, or mark/unmark those selected as spam. Spam users will have posts removed and will be unable to sign up again with the same email addresses."
+msgstr ""
+
+#: wp-admin/network/users.php:236
+msgid "You can make an existing user an additional super admin by going to the Edit User profile page and checking the box to grant that privilege."
+msgstr ""
+
+#: wp-admin/network/users.php:248
+msgid "Filter users list"
+msgstr ""
+
+#: wp-admin/network/users.php:249
+msgid "Users list navigation"
+msgstr ""
+
+#: wp-admin/network/users.php:250
+msgid "Users list"
+msgstr ""
+
+#: wp-admin/network/users.php:262
+msgid "User deleted."
+msgstr ""
+
+#: wp-admin/network/users.php:265
+msgid "Users marked as spam."
+msgstr ""
+
+#: wp-admin/network/users.php:268
+msgid "Users removed from spam."
+msgstr ""
+
+#: wp-admin/network/users.php:271
+msgid "Users deleted."
+msgstr ""
+
+#. translators: 1: VHOST, 2: SUBDOMAIN_INSTALL, 3: wp-config.php, 4: is_subdomain_install()
+#: wp-includes/ms-default-constants.php:140
+msgid "The constant %1$s <strong>is deprecated</strong>. Use the boolean constant %2$s in %3$s to enable a subdomain configuration. Use %4$s to check whether a subdomain configuration is enabled."
+msgstr ""
+
+#. translators: 1: VHOST, 2: SUBDOMAIN_INSTALL
+#: wp-includes/ms-default-constants.php:151
+msgid "<strong>Conflicting values for the constants %1$s and %2$s.</strong> The value of %2$s will be assumed to be your subdomain configuration setting."
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:277
+#: wp-includes/ms-deprecated.php:296
+msgid "A variable mismatch has been detected."
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:277
+#: wp-includes/ms-deprecated.php:296
+msgid "Sorry, you are not allowed to view this item."
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:406
+msgid "<strong>Error:</strong> Site URL you&#8217;ve entered is already taken."
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:415
+msgid "<strong>Error:</strong> There was a problem creating site entry."
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:619
+msgid "Already Installed"
+msgstr ""
+
+#: wp-includes/ms-deprecated.php:619
+msgid "You appear to have already installed ClassicPress. To reinstall please clear your old database tables first."
+msgstr ""
+
+#: wp-includes/ms-functions.php:159
+msgid "The requested user does not exist."
+msgstr ""
+
+#: wp-includes/ms-functions.php:182
+msgid "User cannot be added to this site."
+msgstr ""
+
+#: wp-includes/ms-functions.php:271
+msgid "That user does not exist."
+msgstr ""
+
+#: wp-includes/ms-functions.php:464
+msgid "Usernames can only contain lowercase letters (a-z) and numbers."
+msgstr ""
+
+#: wp-includes/ms-functions.php:471
+msgid "Please enter a username."
+msgstr ""
+
+#: wp-includes/ms-functions.php:480
+#: wp-includes/ms-functions.php:487
+msgid "Sorry, that username is not allowed."
+msgstr ""
+
+#: wp-includes/ms-functions.php:491
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: wp-includes/ms-functions.php:493
+msgid "You cannot use that email address to signup. There are problems with them blocking some emails from ClassicPress. Please use another email provider."
+msgstr ""
+
+#: wp-includes/ms-functions.php:497
+msgid "Username must be at least 4 characters."
+msgstr ""
+
+#: wp-includes/ms-functions.php:501
+msgid "Username may not be longer than 60 characters."
+msgstr ""
+
+#: wp-includes/ms-functions.php:506
+msgid "Sorry, usernames must have letters too!"
+msgstr ""
+
+#: wp-includes/ms-functions.php:514
+msgid "Sorry, that email address is not allowed!"
+msgstr ""
+
+#: wp-includes/ms-functions.php:520
+msgid "Sorry, that username already exists!"
+msgstr ""
+
+#. translators: %s: Link to the login page.
+#: wp-includes/ms-functions.php:529
+msgid "<strong>Error:</strong> This email address is already registered. <a href=\"%s\">Log in</a> with this address or choose another one."
+msgstr ""
+
+#: wp-includes/ms-functions.php:545
+msgid "That username is currently reserved but may be available in a couple of days."
+msgstr ""
+
+#: wp-includes/ms-functions.php:556
+msgid "That email address has already been used. Please check your inbox for an activation email. It will become available in a couple of days if you do nothing."
+msgstr ""
+
+#: wp-includes/ms-functions.php:645
+msgid "Please enter a site name."
+msgstr ""
+
+#: wp-includes/ms-functions.php:649
+msgid "Site names can only contain lowercase letters (a-z) and numbers."
+msgstr ""
+
+#: wp-includes/ms-functions.php:653
+msgid "That name is not allowed."
+msgstr ""
+
+#. translators: %s: Minimum site name length.
+#: wp-includes/ms-functions.php:667
+msgid "Site name must be at least %s character."
+msgid_plural "Site name must be at least %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-includes/ms-functions.php:672
+msgid "Sorry, you may not use that site name."
+msgstr ""
+
+#: wp-includes/ms-functions.php:677
+msgid "Sorry, site names must have letters too!"
+msgstr ""
+
+#: wp-includes/ms-functions.php:695
+msgid "Please enter a site title."
+msgstr ""
+
+#: wp-includes/ms-functions.php:707
+#: wp-includes/ms-functions.php:1372
+#: wp-includes/ms-site.php:624
+msgid "Sorry, that site already exists!"
+msgstr ""
+
+#: wp-includes/ms-functions.php:716
+msgid "Sorry, that site is reserved!"
+msgstr ""
+
+#: wp-includes/ms-functions.php:735
+msgid "That site is currently reserved but may be available in a couple days."
+msgstr ""
+
+#. translators: New site notification email. 1: Activation URL, 2: New site URL.
+#: wp-includes/ms-functions.php:980
+msgid ""
+"To activate your site, please click the following link:\n"
+"\n"
+"%1$s\n"
+"\n"
+"After you activate, you will receive *another email* with your login.\n"
+"\n"
+"After you activate, you can visit your site here:\n"
+"\n"
+"%2$s"
+msgstr ""
+
+#. translators: New site notification email subject. 1: Network title, 2: New site URL.
+#: wp-includes/ms-functions.php:1012
+msgctxt "New site notification email subject"
+msgid "[%1$s] Activate %2$s"
+msgstr ""
+
+#. translators: New user notification email. %s: Activation URL.
+#: wp-includes/ms-functions.php:1100
+msgid ""
+"To activate your user, please click the following link:\n"
+"\n"
+"%s\n"
+"\n"
+"After you activate, you will receive *another email* with your login."
+msgstr ""
+
+#. translators: New user notification email subject. 1: Network title, 2: New user login.
+#: wp-includes/ms-functions.php:1124
+msgctxt "New user notification email subject"
+msgid "[%1$s] Activate %2$s"
+msgstr ""
+
+#: wp-includes/ms-functions.php:1164
+msgid "Invalid activation key."
+msgstr ""
+
+#: wp-includes/ms-functions.php:1169
+msgid "The user is already active."
+msgstr ""
+
+#: wp-includes/ms-functions.php:1171
+msgid "The site is already active."
+msgstr ""
+
+#: wp-includes/ms-functions.php:1187
+msgid "Could not create user"
+msgstr ""
+
+#: wp-includes/ms-functions.php:1203
+msgid "That username is already activated."
+msgstr ""
+
+#. translators: New site notification email. 1: Site URL, 2: User IP address, 3: URL to Network Settings screen.
+#: wp-includes/ms-functions.php:1445
+msgid ""
+"New Site: %1$s\n"
+"URL: %2$s\n"
+"Remote IP address: %3$s\n"
+"\n"
+"Disable these notifications: %4$s"
+msgstr ""
+
+#. translators: New site notification email subject. %s: New site URL.
+#: wp-includes/ms-functions.php:1470
+msgid "New Site Registration: %s"
+msgstr ""
+
+#. translators: New user notification email. 1: User login, 2: User IP address, 3: URL to Network Settings screen.
+#: wp-includes/ms-functions.php:1503
+msgid ""
+"New User: %1$s\n"
+"Remote IP address: %2$s\n"
+"\n"
+"Disable these notifications: %3$s"
+msgstr ""
+
+#. translators: New user notification email subject. %s: User login.
+#: wp-includes/ms-functions.php:1526
+msgid "New User Registration: %s"
+msgstr ""
+
+#. translators: Do not translate USERNAME, SITE_NAME, BLOG_URL, PASSWORD: those are placeholders.
+#: wp-includes/ms-functions.php:1621
+msgid ""
+"Hello USERNAME,\n"
+"\n"
+"Your new SITE_NAME site has been successfully set up at:\n"
+"BLOG_URL\n"
+"\n"
+"You can log in to the administrator account with the following information:\n"
+"\n"
+"Username: USERNAME\n"
+"Password: PASSWORD\n"
+"Log in here: BLOG_URLwp-login.php\n"
+"\n"
+"We hope you enjoy your new site. Thanks!\n"
+"\n"
+"--The Team @ SITE_NAME"
+msgstr ""
+
+#. translators: New site notification email subject. 1: Network title, 2: New site title.
+#: wp-includes/ms-functions.php:1678
+msgid "New %1$s Site: %2$s"
+msgstr ""
+
+#. translators: New site notification email subject. %s: Network title.
+#: wp-includes/ms-functions.php:1748
+msgid "[%s] New Site Created"
+msgstr ""
+
+#. translators: New site notification email. 1: User login, 2: Site URL, 3: Site title.
+#: wp-includes/ms-functions.php:1754
+msgid ""
+"New site created by %1$s\n"
+"\n"
+"Address: %2$s\n"
+"Name: %3$s"
+msgstr ""
+
+#: wp-includes/ms-functions.php:1767
+msgctxt "email \"From\" field"
+msgid "Site Admin"
+msgstr ""
+
+#. translators: New user notification email subject. 1: Network title, 2: New user login.
+#: wp-includes/ms-functions.php:1884
+msgid "New %1$s User: %2$s"
+msgstr ""
+
+#: wp-includes/ms-functions.php:2122
+msgid "Unable to submit this form, please try again."
+msgstr ""
+
+#. translators: %s: Home URL.
+#: wp-includes/ms-functions.php:2187
+msgid "An error occurred adding you to this site. Go to the <a href=\"%s\">homepage</a>."
+msgstr ""
+
+#. translators: 1: Home URL, 2: Admin URL.
+#: wp-includes/ms-functions.php:2196
+msgid "You have been added to this site. Please visit the <a href=\"%1$s\">homepage</a> or <a href=\"%2$s\">log in</a> using your username and password."
+msgstr ""
+
+#: wp-includes/ms-functions.php:2200
+msgid "ClassicPress &rsaquo; Success"
+msgstr ""
+
+#. translators: Do not translate USERNAME, PASSWORD, LOGINLINK, SITE_NAME: those are placeholders.
+#: wp-includes/ms-functions.php:2338
+msgid ""
+"Hello USERNAME,\n"
+"\n"
+"Your new account is set up.\n"
+"\n"
+"You can log in with the following information:\n"
+"Username: USERNAME\n"
+"Password: PASSWORD\n"
+"LOGINLINK\n"
+"\n"
+"Thanks!\n"
+"\n"
+"--The Team @ SITE_NAME"
+msgstr ""
+
+#. translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders.
+#: wp-includes/ms-functions.php:2735
+msgid ""
+"Hello ###USERNAME###,\n"
+"\n"
+"You recently requested to have the network admin email address on\n"
+"your network changed.\n"
+"\n"
+"If this is correct, please click on the following link to change it:\n"
+"###ADMIN_URL###\n"
+"\n"
+"You can safely ignore and delete this email if you do not want to\n"
+"take this action.\n"
+"\n"
+"This email has been sent to ###EMAIL###\n"
+"\n"
+"Regards,\n"
+"All at ###SITENAME###\n"
+"###SITEURL###"
+msgstr ""
+
+#. translators: Email change notification email subject. %s: Network title.
+#: wp-includes/ms-functions.php:2787
+msgid "[%s] Network Admin Email Change Request"
+msgstr ""
+
+#. translators: Do not translate OLD_EMAIL, NEW_EMAIL, SITENAME, SITEURL: those are placeholders.
+#: wp-includes/ms-functions.php:2833
+msgid ""
+"Hi,\n"
+"\n"
+"This notice confirms that the network admin email address was changed on ###SITENAME###.\n"
+"\n"
+"The new network admin email address is ###NEW_EMAIL###.\n"
+"\n"
+"This email has been sent to ###OLD_EMAIL###\n"
+"\n"
+"Regards,\n"
+"All at ###SITENAME###\n"
+"###SITEURL###"
+msgstr ""
+
+#. translators: Network admin email change notification email subject. %s: Network title.
+#: wp-includes/ms-functions.php:2850
+msgid "[%s] Network Admin Email Changed"
+msgstr ""
+
+#: wp-includes/ms-load.php:99
+msgid "This site is no longer available."
+msgstr ""
+
+#. translators: %s: Admin email link.
+#: wp-includes/ms-load.php:111
+msgid "This site has not been activated yet. If you are having problems activating your site, please contact %s."
+msgstr ""
+
+#: wp-includes/ms-load.php:122
+msgid "This site has been archived or suspended."
+msgstr ""
+
+#: wp-includes/ms-load.php:471
+msgid "Error establishing a database connection"
+msgstr ""
+
+#: wp-includes/ms-load.php:474
+msgid "If your site does not display, please contact the owner of this network."
+msgstr ""
+
+#: wp-includes/ms-load.php:475
+msgid "If you are the owner of this network please check that your host&#8217;s database server is running properly and all tables are error free."
+msgstr ""
+
+#. translators: %s: Table name.
+#: wp-includes/ms-load.php:480
+msgid "<strong>Database tables are missing.</strong> This means that your host&#8217;s database server is not running, ClassicPress was not installed properly, or someone deleted %s. You really should look at your database now."
+msgstr ""
+
+#. translators: 1: Site URL, 2: Table name, 3: Database name.
+#: wp-includes/ms-load.php:486
+msgid "<strong>Could not find site %1$s.</strong> Searched for table %2$s in database %3$s. Is that right?"
+msgstr ""
+
+#: wp-includes/ms-load.php:492
+msgid "What do I do now?"
+msgstr ""
+
+#. translators: %s: Documentation URL.
+#: wp-includes/ms-load.php:495
+msgid "Read the <a href=\"%s\" target=\"_blank\">Debugging a ClassicPress Network</a> article. Some of the suggestions there may help you figure out what went wrong."
+msgstr ""
+
+#: wp-includes/ms-load.php:496
+msgid "https://wordpress.org/documentation/article/debugging-a-wordpress-network/"
+msgstr ""
+
+#: wp-includes/ms-load.php:498
+msgid "If you are still stuck with this message, then check that your database contains the following tables:"
+msgstr ""
+
+#: wp-includes/ms-site.php:69
+msgid "Could not insert site into the database."
+msgstr ""
+
+#: wp-includes/ms-site.php:79
+msgid "Could not retrieve site data."
+msgstr ""
+
+#: wp-includes/ms-site.php:161
+#: wp-includes/ms-site.php:214
+#: wp-includes/ms-site.php:658
+#: wp-includes/ms-site.php:789
+msgid "Site ID must not be empty."
+msgstr ""
+
+#: wp-includes/ms-site.php:166
+#: wp-includes/ms-site.php:219
+msgid "Site does not exist."
+msgstr ""
+
+#: wp-includes/ms-site.php:180
+msgid "Could not update site in the database."
+msgstr ""
+
+#: wp-includes/ms-site.php:269
+msgid "Could not delete site from the database."
+msgstr ""
+
+#: wp-includes/ms-site.php:579
+msgid "Site domain must not be empty."
+msgstr ""
+
+#: wp-includes/ms-site.php:584
+msgid "Site path must not be empty."
+msgstr ""
+
+#: wp-includes/ms-site.php:589
+msgid "Site network ID must be provided."
+msgstr ""
+
+#: wp-includes/ms-site.php:596
+msgid "Both registration and last updated dates must be provided."
+msgstr ""
+
+#: wp-includes/ms-site.php:607
+msgid "Both registration and last updated dates must be valid dates."
+msgstr ""
+
+#: wp-includes/ms-site.php:663
+#: wp-includes/ms-site.php:794
+msgid "Site with the ID does not exist."
+msgstr ""
+
+#: wp-includes/ms-site.php:667
+msgid "The site appears to be already initialized."
+msgstr ""
+
+#. translators: %d: Site ID.
+#: wp-includes/ms-site.php:680
+msgid "Site %d"
+msgstr ""
+
+#: wp-includes/ms-site.php:798
+msgid "The site appears to be already uninitialized."
+msgstr ""
+
+#. translators: %s: Database table name.
+#: wp-includes/ms-site.php:1319
+msgid "The %s table is not installed. Please run the network database upgrade."
+msgstr ""

--- a/bin/create_pot.sh
+++ b/bin/create_pot.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	SED_COMMAND="sed"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	SED_COMMAND="gsed"
+else
+	echo "Sorry, this script hasn't been tested on your OS platform"
+	exit 1
+fi
+
+for gh_repo in ClassicPress/ClassicPress; do
+	user="$(echo "$gh_repo" | cut -d/ -f1)"
+	repo="$(echo "$gh_repo" | cut -d/ -f2)"
+	if ! [ -d "$repo/.git" ]; then
+		git clone "https://github.com/$user/$repo" "$repo"
+	fi
+done
+
+pushd ClassicPress/
+
+	# Reset everything
+	rm -rf build/
+	git reset --hard
+	git fetch origin
+	git checkout origin/develop -B develop
+	rm -rf node_modules/
+
+	# Set up node version
+	set +x
+	echo 'loading nvm and node'
+	. ~/.nvm/nvm.sh --no-use
+	nvm use || nvm install
+	set -x
+
+	# Install dependencies and generate a nightly build
+	npm install
+	./node_modules/.bin/grunt build
+
+	# Get version numbers for substitution later
+	WP_VERSION=$(grep '$wp_version =' build/wp-includes/version.php | head -n 1 | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
+	CP_VERSION=$(grep '$cp_version =' build/wp-includes/version.php | head -n 1 | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
+popd
+
+# Clean up POT files first
+rm *.pot || true
+
+# Create the POT files
+wp i18n make-pot ./ClassicPress/build ./en_US.pot --ignore-domain --skip-audit --exclude="wp-content,wp-admin,wp-includes/class-wp-network*.php,wp-includes/ms-*.php" --package-name="ClassicPress"
+wp i18n make-pot ./ClassicPress/build ./admin-en_US.pot --ignore-domain --skip-audit --exclude="wp-activate.php,wp-comments-post.php,wp-cron.php,wp-links-opml.php,wp-load.php,wp-login.php,wp-mail.php,wp-signup.php,wp-trackback.php,wp-content,wp-includes,wp-admin/includes/continents-cities.php,wp-admin/ms-*.php,wp-admin/my-sites.php,wp-admin/network.php,wp-admin/includes/class-wp-ms-*.php,wp-admin/includes/ms.php,wp-admin/includes/ms-*.php,wp-admin/network/" --package-name="ClassicPress"
+wp i18n make-pot ./ClassicPress/build ./admin-network-en_US.pot --ignore-domain --skip-audit --include="wp-admin/ms-*.php,wp-admin/my-sites.php,wp-admin/network.php,wp-admin/includes/class-wp-ms-*.php,wp-admin/includes/ms.php,wp-admin/includes/ms-*.php,wp-admin/network/,wp-includes/class-wp-network*.php,wp-includes/ms-*.php" --package-name="ClassicPress"
+wp i18n make-pot ./ClassicPress/build ./continents-cities-en_US.pot --ignore-domain --skip-audit --include="wp-admin/includes/continents-cities.php" --package-name="ClassicPress"
+
+for pot in en_US.pot admin-en_US.pot admin-network-en_US.pot continents-cities-en_US.pot; do
+	# Prepend the Copyright notice to POT files
+	$SED_COMMAND -i '1s/^/# Copyright (C) 2024 ClassicPress\n/' ./"$pot"
+	$SED_COMMAND -i '2s/^/# This file is distributed under the same license as the ClassicPress package.\n/' ./"$pot"
+	# Delete unused lines from POT files
+	$SED_COMMAND -i '7d;8d;13d' ./"$pot"
+	# Add forum link for bug reporting
+	$SED_COMMAND -ri 's|Report-Msgid-Bugs-To: |Report-Msgid-Bugs-To: https://forums.classicpress.net/c/team-discussions/internationalisation/42|' ./"$pot"
+	# Update version number
+	$SED_COMMAND -ri "s|${WP_VERSION}|${CP_VERSION}|" ./"$pot"
+done

--- a/continents-cities-en_US.pot
+++ b/continents-cities-en_US.pot
@@ -1,0 +1,2123 @@
+# Copyright (C) 2024 ClassicPress
+# This file is distributed under the same license as the ClassicPress package.
+msgid ""
+msgstr ""
+"Project-Id-Version: ClassicPress 2.0.0\n"
+"Report-Msgid-Bugs-To: https://forums.classicpress.net/c/team-discussions/internationalisation/42\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-04-16T12:25:01+00:00\n"
+"X-Generator: WP-CLI 2.10.0\n"
+
+#: wp-admin/includes/continents-cities.php:12
+msgid "Africa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:13
+msgid "Abidjan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:14
+msgid "Accra"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:15
+msgid "Addis Ababa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:16
+msgid "Algiers"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:17
+msgid "Asmara"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:18
+msgid "Asmera"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:19
+msgid "Bamako"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:20
+msgid "Bangui"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:21
+msgid "Banjul"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:22
+msgid "Bissau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:23
+msgid "Blantyre"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:24
+msgid "Brazzaville"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:25
+msgid "Bujumbura"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:26
+msgid "Cairo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:27
+msgid "Casablanca"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:28
+msgid "Ceuta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:29
+msgid "Conakry"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:30
+msgid "Dakar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:31
+msgid "Dar es Salaam"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:32
+msgid "Djibouti"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:33
+msgid "Douala"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:34
+msgid "El Aaiun"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:35
+msgid "Freetown"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:36
+msgid "Gaborone"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:37
+msgid "Harare"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:38
+msgid "Johannesburg"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:39
+msgid "Juba"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:40
+msgid "Kampala"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:41
+msgid "Khartoum"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:42
+msgid "Kigali"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:43
+msgid "Kinshasa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:44
+msgid "Lagos"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:45
+msgid "Libreville"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:46
+msgid "Lome"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:47
+msgid "Luanda"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:48
+msgid "Lubumbashi"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:49
+msgid "Lusaka"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:50
+msgid "Malabo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:51
+msgid "Maputo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:52
+msgid "Maseru"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:53
+msgid "Mbabane"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:54
+msgid "Mogadishu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:55
+msgid "Monrovia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:56
+msgid "Nairobi"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:57
+msgid "Ndjamena"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:58
+msgid "Niamey"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:59
+msgid "Nouakchott"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:60
+msgid "Ouagadougou"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:61
+msgid "Porto-Novo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:62
+msgid "Sao Tome"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:63
+msgid "Timbuktu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:64
+msgid "Tripoli"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:65
+msgid "Tunis"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:66
+msgid "Windhoek"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:68
+msgid "America"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:69
+msgid "Adak"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:70
+msgid "Anchorage"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:71
+msgid "Anguilla"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:72
+msgid "Antigua"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:73
+msgid "Araguaina"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:74
+msgid "Argentina"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:75
+msgid "Buenos Aires"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:76
+msgid "Catamarca"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:77
+msgid "ComodRivadavia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:78
+msgid "Cordoba"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:79
+msgid "Jujuy"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:80
+msgid "La Rioja"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:81
+msgid "Mendoza"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:82
+msgid "Rio Gallegos"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:83
+msgid "Salta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:84
+msgid "San Juan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:85
+msgid "San Luis"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:86
+msgid "Tucuman"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:87
+msgid "Ushuaia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:88
+msgid "Aruba"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:89
+msgid "Asuncion"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:90
+msgid "Atikokan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:91
+msgid "Atka"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:92
+msgid "Bahia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:93
+msgid "Bahia Banderas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:94
+msgid "Barbados"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:95
+msgid "Belem"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:96
+msgid "Belize"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:97
+msgid "Blanc-Sablon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:98
+msgid "Boa Vista"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:99
+msgid "Bogota"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:100
+msgid "Boise"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:101
+msgid "Cambridge Bay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:102
+msgid "Campo Grande"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:103
+msgid "Cancun"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:104
+msgid "Caracas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:105
+msgid "Cayenne"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:106
+msgid "Cayman"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:107
+msgid "Chicago"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:108
+msgid "Chihuahua"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:109
+msgid "Coral Harbour"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:110
+msgid "Costa Rica"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:111
+msgid "Creston"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:112
+msgid "Cuiaba"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:113
+msgid "Curacao"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:114
+msgid "Danmarkshavn"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:115
+msgid "Dawson"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:116
+msgid "Dawson Creek"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:117
+msgid "Denver"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:118
+msgid "Detroit"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:119
+msgid "Dominica"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:120
+msgid "Edmonton"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:121
+msgid "Eirunepe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:122
+msgid "El Salvador"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:123
+msgid "Ensenada"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:124
+msgid "Fort Nelson"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:125
+msgid "Fort Wayne"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:126
+msgid "Fortaleza"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:127
+msgid "Glace Bay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:128
+msgid "Godthab"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:129
+msgid "Goose Bay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:130
+msgid "Grand Turk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:131
+msgid "Grenada"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:132
+msgid "Guadeloupe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:133
+msgid "Guatemala"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:134
+msgid "Guayaquil"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:135
+msgid "Guyana"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:136
+msgid "Halifax"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:137
+msgid "Havana"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:138
+msgid "Hermosillo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:139
+msgid "Indiana"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:140
+msgid "Indianapolis"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:141
+msgid "Knox"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:142
+msgid "Marengo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:143
+msgid "Petersburg"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:144
+msgid "Tell City"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:145
+msgid "Vevay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:146
+msgid "Vincennes"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:147
+msgid "Winamac"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:148
+msgid "Inuvik"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:149
+msgid "Iqaluit"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:150
+msgid "Jamaica"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:151
+msgid "Juneau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:152
+msgid "Kentucky"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:153
+msgid "Louisville"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:154
+msgid "Monticello"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:155
+msgid "Knox IN"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:156
+msgid "Kralendijk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:157
+msgid "La Paz"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:158
+msgid "Lima"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:159
+msgid "Los Angeles"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:160
+msgid "Lower Princes"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:161
+msgid "Maceio"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:162
+msgid "Managua"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:163
+msgid "Manaus"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:164
+msgid "Marigot"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:165
+msgid "Martinique"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:166
+msgid "Matamoros"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:167
+msgid "Mazatlan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:168
+msgid "Menominee"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:169
+msgid "Merida"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:170
+msgid "Metlakatla"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:171
+msgid "Mexico City"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:172
+msgid "Miquelon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:173
+msgid "Moncton"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:174
+msgid "Monterrey"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:175
+msgid "Montevideo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:176
+msgid "Montreal"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:177
+msgid "Montserrat"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:178
+msgid "Nassau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:179
+msgid "New York"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:180
+msgid "Nipigon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:181
+msgid "Nome"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:182
+msgid "Noronha"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:183
+msgid "North Dakota"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:184
+msgid "Beulah"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:185
+msgid "Center"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:186
+msgid "New Salem"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:187
+msgid "Nuuk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:188
+msgid "Ojinaga"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:189
+msgid "Panama"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:190
+msgid "Pangnirtung"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:191
+msgid "Paramaribo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:192
+msgid "Phoenix"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:193
+msgid "Port-au-Prince"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:194
+msgid "Port of Spain"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:195
+msgid "Porto Acre"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:196
+msgid "Porto Velho"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:197
+msgid "Puerto Rico"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:198
+msgid "Punta Arenas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:199
+msgid "Rainy River"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:200
+msgid "Rankin Inlet"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:201
+msgid "Recife"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:202
+msgid "Regina"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:203
+msgid "Resolute"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:204
+msgid "Rio Branco"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:205
+msgid "Rosario"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:206
+msgid "Santa Isabel"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:207
+msgid "Santarem"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:208
+msgid "Santiago"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:209
+msgid "Santo Domingo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:210
+msgid "Sao Paulo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:211
+msgid "Scoresbysund"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:212
+msgid "Shiprock"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:213
+msgid "Sitka"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:214
+msgid "St Barthelemy"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:215
+msgid "St Johns"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:216
+msgid "St Kitts"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:217
+msgid "St Lucia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:218
+msgid "St Thomas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:219
+msgid "St Vincent"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:220
+msgid "Swift Current"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:221
+msgid "Tegucigalpa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:222
+msgid "Thule"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:223
+msgid "Thunder Bay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:224
+msgid "Tijuana"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:225
+msgid "Toronto"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:226
+msgid "Tortola"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:227
+msgid "Vancouver"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:228
+msgid "Virgin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:229
+msgid "Whitehorse"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:230
+msgid "Winnipeg"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:231
+msgid "Yakutat"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:232
+msgid "Yellowknife"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:234
+msgid "Antarctica"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:235
+msgid "Casey"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:236
+msgid "Davis"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:237
+msgid "DumontDUrville"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:238
+msgid "Macquarie"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:239
+msgid "Mawson"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:240
+msgid "McMurdo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:241
+msgid "Palmer"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:242
+msgid "Rothera"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:243
+msgid "South Pole"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:244
+msgid "Syowa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:245
+msgid "Troll"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:246
+msgid "Vostok"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:248
+msgid "Arctic"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:249
+msgid "Longyearbyen"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:251
+msgid "Asia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:252
+msgid "Aden"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:253
+msgid "Almaty"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:254
+msgid "Amman"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:255
+msgid "Anadyr"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:256
+msgid "Aqtau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:257
+msgid "Aqtobe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:258
+msgid "Ashgabat"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:259
+msgid "Ashkhabad"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:260
+msgid "Atyrau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:261
+msgid "Baghdad"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:262
+msgid "Bahrain"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:263
+msgid "Baku"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:264
+msgid "Bangkok"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:265
+msgid "Barnaul"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:266
+msgid "Beirut"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:267
+msgid "Bishkek"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:268
+msgid "Brunei"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:269
+msgid "Calcutta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:270
+msgid "Chita"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:271
+msgid "Choibalsan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:272
+msgid "Chongqing"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:273
+msgid "Chungking"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:274
+msgid "Colombo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:275
+msgid "Dacca"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:276
+msgid "Damascus"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:277
+msgid "Dhaka"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:278
+msgid "Dili"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:279
+msgid "Dubai"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:280
+msgid "Dushanbe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:281
+msgid "Famagusta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:282
+msgid "Gaza"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:283
+msgid "Harbin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:284
+msgid "Hebron"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:285
+msgid "Ho Chi Minh"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:286
+msgid "Hong Kong"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:287
+msgid "Hovd"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:288
+msgid "Irkutsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:289
+msgid "Jakarta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:290
+msgid "Jayapura"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:291
+msgid "Jerusalem"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:292
+msgid "Kabul"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:293
+msgid "Kamchatka"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:294
+msgid "Karachi"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:295
+msgid "Kashgar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:296
+msgid "Kathmandu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:297
+msgid "Katmandu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:298
+msgid "Khandyga"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:299
+msgid "Kolkata"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:300
+msgid "Krasnoyarsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:301
+msgid "Kuala Lumpur"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:302
+msgid "Kuching"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:303
+msgid "Kuwait"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:304
+msgid "Macao"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:305
+msgid "Macau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:306
+msgid "Magadan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:307
+msgid "Makassar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:308
+msgid "Manila"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:309
+msgid "Muscat"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:310
+msgid "Nicosia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:311
+msgid "Novokuznetsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:312
+msgid "Novosibirsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:313
+msgid "Omsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:314
+msgid "Oral"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:315
+msgid "Phnom Penh"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:316
+msgid "Pontianak"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:317
+msgid "Pyongyang"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:318
+msgid "Qatar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:319
+msgid "Qostanay"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:320
+msgid "Qyzylorda"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:321
+msgid "Rangoon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:322
+msgid "Riyadh"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:323
+msgid "Saigon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:324
+msgid "Sakhalin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:325
+msgid "Samarkand"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:326
+msgid "Seoul"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:327
+msgid "Shanghai"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:328
+msgid "Singapore"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:329
+msgid "Srednekolymsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:330
+msgid "Taipei"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:331
+msgid "Tashkent"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:332
+msgid "Tbilisi"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:333
+msgid "Tehran"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:334
+msgid "Tel Aviv"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:335
+msgid "Thimbu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:336
+msgid "Thimphu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:337
+msgid "Tokyo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:338
+msgid "Tomsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:339
+msgid "Ujung Pandang"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:340
+msgid "Ulaanbaatar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:341
+msgid "Ulan Bator"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:342
+msgid "Urumqi"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:343
+msgid "Ust-Nera"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:344
+msgid "Vientiane"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:345
+msgid "Vladivostok"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:346
+msgid "Yakutsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:347
+msgid "Yangon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:348
+msgid "Yekaterinburg"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:349
+msgid "Yerevan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:351
+msgid "Atlantic"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:352
+msgid "Azores"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:353
+msgid "Bermuda"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:354
+msgid "Canary"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:355
+msgid "Cape Verde"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:356
+msgid "Faeroe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:357
+msgid "Faroe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:358
+msgid "Jan Mayen"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:359
+msgid "Madeira"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:360
+msgid "Reykjavik"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:361
+msgid "South Georgia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:362
+msgid "St Helena"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:363
+msgid "Stanley"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:365
+msgid "Australia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:366
+msgid "ACT"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:367
+msgid "Adelaide"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:368
+msgid "Brisbane"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:369
+msgid "Broken Hill"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:370
+msgid "Canberra"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:371
+msgid "Currie"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:372
+msgid "Darwin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:373
+msgid "Eucla"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:374
+msgid "Hobart"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:375
+msgid "LHI"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:376
+msgid "Lindeman"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:377
+msgid "Lord Howe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:378
+msgid "Melbourne"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:379
+msgid "NSW"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:380
+msgid "North"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:381
+msgid "Perth"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:382
+msgid "Queensland"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:383
+msgid "South"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:384
+msgid "Sydney"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:385
+msgid "Tasmania"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:386
+msgid "Victoria"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:387
+msgid "West"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:388
+msgid "Yancowinna"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:390
+msgid "Etc"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:391
+msgid "GMT"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:392
+msgid "GMT+0"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:393
+msgid "GMT+1"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:394
+msgid "GMT+10"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:395
+msgid "GMT+11"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:396
+msgid "GMT+12"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:397
+msgid "GMT+2"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:398
+msgid "GMT+3"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:399
+msgid "GMT+4"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:400
+msgid "GMT+5"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:401
+msgid "GMT+6"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:402
+msgid "GMT+7"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:403
+msgid "GMT+8"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:404
+msgid "GMT+9"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:405
+msgid "GMT-0"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:406
+msgid "GMT-1"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:407
+msgid "GMT-10"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:408
+msgid "GMT-11"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:409
+msgid "GMT-12"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:410
+msgid "GMT-13"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:411
+msgid "GMT-14"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:412
+msgid "GMT-2"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:413
+msgid "GMT-3"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:414
+msgid "GMT-4"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:415
+msgid "GMT-5"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:416
+msgid "GMT-6"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:417
+msgid "GMT-7"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:418
+msgid "GMT-8"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:419
+msgid "GMT-9"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:420
+msgid "GMT0"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:421
+msgid "Greenwich"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:422
+msgid "UCT"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:423
+msgid "UTC"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:424
+msgid "Universal"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:425
+msgid "Zulu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:427
+msgid "Europe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:428
+msgid "Amsterdam"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:429
+msgid "Andorra"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:430
+msgid "Astrakhan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:431
+msgid "Athens"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:432
+msgid "Belfast"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:433
+msgid "Belgrade"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:434
+msgid "Berlin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:435
+msgid "Bratislava"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:436
+msgid "Brussels"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:437
+msgid "Bucharest"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:438
+msgid "Budapest"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:439
+msgid "Busingen"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:440
+msgid "Chisinau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:441
+msgid "Copenhagen"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:442
+msgid "Dublin"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:443
+msgid "Gibraltar"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:444
+msgid "Guernsey"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:445
+msgid "Helsinki"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:446
+msgid "Isle of Man"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:447
+msgid "Istanbul"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:448
+msgid "Jersey"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:449
+msgid "Kaliningrad"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:450
+msgid "Kiev"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:451
+msgid "Kyiv"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:452
+msgid "Kirov"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:453
+msgid "Lisbon"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:454
+msgid "Ljubljana"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:455
+msgid "London"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:456
+msgid "Luxembourg"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:457
+msgid "Madrid"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:458
+msgid "Malta"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:459
+msgid "Mariehamn"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:460
+msgid "Minsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:461
+msgid "Monaco"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:462
+msgid "Moscow"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:463
+msgid "Oslo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:464
+msgid "Paris"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:465
+msgid "Podgorica"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:466
+msgid "Prague"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:467
+msgid "Riga"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:468
+msgid "Rome"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:469
+msgid "Samara"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:470
+msgid "San Marino"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:471
+msgid "Sarajevo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:472
+msgid "Saratov"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:473
+msgid "Simferopol"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:474
+msgid "Skopje"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:475
+msgid "Sofia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:476
+msgid "Stockholm"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:477
+msgid "Tallinn"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:478
+msgid "Tirane"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:479
+msgid "Tiraspol"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:480
+msgid "Ulyanovsk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:481
+msgid "Uzhgorod"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:482
+msgid "Vaduz"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:483
+msgid "Vatican"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:484
+msgid "Vienna"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:485
+msgid "Vilnius"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:486
+msgid "Volgograd"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:487
+msgid "Warsaw"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:488
+msgid "Zagreb"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:489
+msgid "Zaporozhye"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:490
+msgid "Zurich"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:492
+msgid "Indian"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:493
+msgid "Antananarivo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:494
+msgid "Chagos"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:495
+msgid "Christmas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:496
+msgid "Cocos"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:497
+msgid "Comoro"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:498
+msgid "Kerguelen"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:499
+msgid "Mahe"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:500
+msgid "Maldives"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:501
+msgid "Mauritius"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:502
+msgid "Mayotte"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:503
+msgid "Reunion"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:505
+msgid "Pacific"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:506
+msgid "Apia"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:507
+msgid "Auckland"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:508
+msgid "Bougainville"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:509
+msgid "Chatham"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:510
+msgid "Chuuk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:511
+msgid "Easter"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:512
+msgid "Efate"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:513
+msgid "Enderbury"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:514
+msgid "Fakaofo"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:515
+msgid "Fiji"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:516
+msgid "Funafuti"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:517
+msgid "Galapagos"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:518
+msgid "Gambier"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:519
+msgid "Guadalcanal"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:520
+msgid "Guam"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:521
+msgid "Honolulu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:522
+msgid "Johnston"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:523
+msgid "Kanton"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:524
+msgid "Kiritimati"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:525
+msgid "Kosrae"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:526
+msgid "Kwajalein"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:527
+msgid "Majuro"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:528
+msgid "Marquesas"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:529
+msgid "Midway"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:530
+msgid "Nauru"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:531
+msgid "Niue"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:532
+msgid "Norfolk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:533
+msgid "Noumea"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:534
+msgid "Pago Pago"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:535
+msgid "Palau"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:536
+msgid "Pitcairn"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:537
+msgid "Pohnpei"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:538
+msgid "Ponape"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:539
+msgid "Port Moresby"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:540
+msgid "Rarotonga"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:541
+msgid "Saipan"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:542
+msgid "Samoa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:543
+msgid "Tahiti"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:544
+msgid "Tarawa"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:545
+msgid "Tongatapu"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:546
+msgid "Truk"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:547
+msgid "Wake"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:548
+msgid "Wallis"
+msgstr ""
+
+#: wp-admin/includes/continents-cities.php:549
+msgid "Yap"
+msgstr ""

--- a/en_US.pot
+++ b/en_US.pot
@@ -3,10 +3,12 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ClassicPress 2.0.0\n"
-"Report-Msgid-Bugs-To:https://forums.classicpress.net/c/team-discussions/internationalisation/42\n"
+"Report-Msgid-Bugs-To: https://forums.classicpress.net/c/team-discussions/internationalisation/42\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-04-16T12:24:33+00:00\n"
+"X-Generator: WP-CLI 2.10.0\n"
 
 #: wp-activate.php:30
 msgid "A key value mismatch has been detected. Please follow the link provided in your activation email."
@@ -26,22 +28,7 @@ msgid "Activation Key:"
 msgstr ""
 
 #: wp-activate.php:155
-#: wp-admin/includes/class-theme-installer-skin.php:141
-#: wp-admin/includes/class-theme-upgrader-skin.php:113
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:706
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:568
-#: wp-admin/includes/class-wp-plugins-list-table.php:599
-#: wp-admin/includes/class-wp-plugins-list-table.php:867
-#: wp-admin/includes/class-wp-themes-list-table.php:215
-#: wp-admin/includes/theme.php:1032
-#: wp-admin/theme-install.php:368
-#: wp-admin/theme-install.php:443
-#: wp-admin/themes.php:556
-#: wp-admin/themes.php:916
-#: wp-admin/themes.php:1151
 #: wp-includes/customize/class-wp-customize-theme-control.php:258
-#: wp-admin/js/updates.js:766
-#: wp-admin/js/updates.js:1419
 msgid "Activate"
 msgstr ""
 
@@ -66,7 +53,6 @@ msgid "Username:"
 msgstr ""
 
 #: wp-activate.php:202
-#: wp-admin/includes/meta-boxes.php:218
 #: wp-includes/post-template.php:1767
 msgid "Password:"
 msgstr ""
@@ -81,22954 +67,6 @@ msgstr ""
 msgid "Your account is now activated. <a href=\"%1$s\">Log in</a> or go back to the <a href=\"%2$s\">homepage</a>."
 msgstr ""
 
-#. translators: Page title of the About ClassicPress page in the admin.
-#: wp-admin/about.php:15
-msgctxt "page title"
-msgid "About"
-msgstr ""
-
-#: wp-admin/about.php:20
-#: wp-admin/credits.php:22
-#: wp-admin/freedoms.php:36
-msgid "Welcome to ClassicPress!"
-msgstr ""
-
-#. translators: %s: Plugin version.
-#. translators: %s: Plugin version number.
-#. translators: %s: Theme version number.
-#. translators: %s: Theme version.
-#. translators: %s: ClassicPress version.
-#: wp-admin/about.php:23
-#: wp-admin/credits.php:25
-#: wp-admin/freedoms.php:39
-#: wp-admin/includes/ajax-actions.php:4538
-#: wp-admin/includes/ajax-actions.php:4581
-#: wp-admin/includes/class-wp-debug-data.php:917
-#: wp-admin/includes/class-wp-debug-data.php:964
-#: wp-admin/includes/class-wp-debug-data.php:1286
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:722
-#: wp-admin/includes/class-wp-plugins-list-table.php:1052
-#: wp-admin/includes/update.php:232
-#: wp-admin/includes/update.php:264
-msgid "Version %s"
-msgstr ""
-
-#. translators: link to "business-focused CMS" article
-#. translators: link to ClassicPress website
-#: wp-admin/about.php:30
-#: wp-admin/credits.php:32
-#: wp-admin/freedoms.php:46
-msgid "Thank you for using ClassicPress, the <a href=\"%s\">CMS for Creators</a>."
-msgstr ""
-
-#: wp-admin/about.php:35
-#: wp-admin/credits.php:37
-#: wp-admin/freedoms.php:51
-msgid "Stable. Lightweight. Instantly Familiar."
-msgstr ""
-
-#: wp-admin/about.php:40
-#: wp-admin/credits.php:43
-#: wp-admin/freedoms.php:57
-msgid "About"
-msgstr ""
-
-#: wp-admin/about.php:41
-#: wp-admin/credits.php:13
-#: wp-admin/credits.php:44
-#: wp-admin/freedoms.php:58
-msgid "Credits"
-msgstr ""
-
-#: wp-admin/about.php:42
-#: wp-admin/credits.php:45
-#: wp-admin/freedoms.php:19
-#: wp-admin/freedoms.php:59
-msgid "Freedoms"
-msgstr ""
-
-#: wp-admin/about.php:43
-#: wp-admin/credits.php:46
-#: wp-admin/freedoms.php:60
-#: wp-admin/menu.php:342
-#: wp-admin/options-privacy.php:22
-#: wp-admin/options-privacy.php:157
-#: wp-admin/privacy-policy-guide.php:40
-msgid "Privacy"
-msgstr ""
-
-#. translators: link to learn more about translating ClassicPress
-#: wp-admin/about.php:53
-msgid "Help us translate ClassicPress into your language! <a href=\"%s\">Learn more</a>."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/about.php:60
-#: wp-includes/admin-bar.php:136
-#: wp-includes/admin-bar.php:156
-msgid "About ClassicPress"
-msgstr ""
-
-#. translators: link to ClassicPress site
-#: wp-admin/about.php:67
-msgid "<a href=\"%s\"><strong>ClassicPress</strong></a> is a fork of the WordPress %s branch, including the battle-tested and proven classic editor interface using TinyMCE."
-msgstr ""
-
-#: wp-admin/about.php:75
-msgid "This has been a solid foundation for millions of sites for many years, and we believe it will also be an excellent foundation for the future."
-msgstr ""
-
-#: wp-admin/about.php:80
-msgid "Join our growing community"
-msgstr ""
-
-#. translators: 1: link with instructions to join ClassicPress Zulip, 2: link to community forums
-#: wp-admin/about.php:85
-msgid "For general discussion about ClassicPress, <a href=\"%1$s\"><strong>join our Zulip group</strong></a> or our <a href=\"%2$s\"><strong>community forum</strong></a>."
-msgstr ""
-
-#. translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum
-#: wp-admin/about.php:95
-msgid "If you need help with something else, please see our <a href=\"%1$s\"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href=\"%2$s\"><strong>support forum</strong></a>."
-msgstr ""
-
-#. translators: 1: link to ClassicPress GitHub repository, 2: link to GitHub issues list
-#: wp-admin/about.php:105
-msgid "ClassicPress is developed <a href=\"%1$s\"><strong>on GitHub</strong></a>. For specific bug reports or technical suggestions, see the <a href=\"%2$s\"><strong>issues list</strong></a> and add your report if it is not already present."
-msgstr ""
-
-#: wp-admin/about.php:111
-msgid "ClassicPress changelogs"
-msgstr ""
-
-#: wp-admin/about.php:112
-msgid "ClassicPress 2.0.0"
-msgstr ""
-
-#. translators: link to ClassicPress 1.0.0 changelog
-#: wp-admin/about.php:117
-msgid "For a list of new features and other changes from WordPress %1$s, see the <a href=\"%2$s\"><strong>ClassicPress 2.0.0 (Bella) release notes</strong></a>."
-msgstr ""
-
-#. translators: current ClassicPress version
-#: wp-admin/about.php:127
-msgid "ClassicPress 1.0.1 - %s"
-msgstr ""
-
-#. translators: link to ClassicPress release announcements subforum
-#: wp-admin/about.php:136
-msgid "The changes and new features included in recent versions of ClassicPress can be found in our <a href=\"%s\"><strong>Release Announcements subforum</strong></a>."
-msgstr ""
-
-#: wp-admin/about.php:141
-msgid "ClassicPress 1.0.0"
-msgstr ""
-
-#. translators: link to ClassicPress 1.0.0 changelog
-#: wp-admin/about.php:146
-msgid "For a list of new features and other changes in WordPress %1$s, see the <a href=\"%2$s\"><strong>ClassicPress 1.0.0 (Aurora) release notes</strong></a>."
-msgstr ""
-
-#: wp-admin/about.php:152
-msgid "ClassicPress Maintenance and Security Releases"
-msgstr ""
-
-#: wp-admin/about.php:155
-msgid "This version of ClassicPress includes all changes from the following versions of WordPress:"
-msgstr ""
-
-#. translators: %s: WordPress version.
-#. translators: %s: ClassicPress version number
-#: wp-admin/about.php:164
-#: wp-admin/about.php:251
-msgid "<strong>Version %s</strong> addressed some security issues."
-msgstr ""
-
-#. translators: %s: HelpHub URL.
-#. translators: %s: HelpHub URL
-#. translators: %s: Codex URL
-#: wp-admin/about.php:171
-#: wp-admin/about.php:196
-#: wp-admin/about.php:221
-#: wp-admin/about.php:272
-msgid "For more information, see <a href=\"%s\">the release notes</a>."
-msgstr ""
-
-#. translators: %s: WordPress version.
-#. translators: %s: WordPress version
-#. translators: %s: ClassicPress version.
-#: wp-admin/about.php:174
-#: wp-admin/about.php:199
-#: wp-admin/about.php:224
-#: wp-admin/upgrade.php:81
-msgid "https://wordpress.org/support/wordpress-version/version-%s/"
-msgstr ""
-
-#. translators: 1: WordPress version number, 2: plural number of bugs.
-#: wp-admin/about.php:184
-#: wp-admin/about.php:209
-msgid "<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug."
-msgid_plural "<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/about.php:239
-msgid "Maintenance Release"
-msgstr ""
-
-#: wp-admin/about.php:240
-msgid "Maintenance Releases"
-msgstr ""
-
-#: wp-admin/about.php:242
-msgid "Security Release"
-msgstr ""
-
-#: wp-admin/about.php:243
-msgid "Security Releases"
-msgstr ""
-
-#: wp-admin/about.php:245
-msgid "Maintenance and Security Release"
-msgstr ""
-
-#: wp-admin/about.php:246
-msgid "Maintenance and Security Releases"
-msgstr ""
-
-#. translators: %s: ClassicPress version number
-#: wp-admin/about.php:249
-msgid "<strong>Version %s</strong> addressed one security issue."
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: plural number of bugs.
-#: wp-admin/about.php:254
-msgid "<strong>Version %1$s</strong> addressed %2$s bug."
-msgid_plural "<strong>Version %1$s</strong> addressed %2$s bugs."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: ClassicPress version number, 2: plural number of bugs. Singular security issue.
-#: wp-admin/about.php:260
-msgid "<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bug."
-msgid_plural "<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bugs."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: ClassicPress version number, 2: plural number of bugs. More than one security issue.
-#: wp-admin/about.php:266
-msgid "<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug."
-msgid_plural "<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: https://www.classicpress.net
-#: wp-admin/admin-footer.php:37
-msgid "Thank you for creating with <a href=\"%s\">ClassicPress</a>."
-msgstr ""
-
-#: wp-admin/admin-footer.php:38
-#: wp-admin/upgrade.php:69
-msgid "https://www.classicpress.net/"
-msgstr ""
-
-#. translators: Network admin screen title. %s: Network title.
-#. translators: %s: Site title.
-#: wp-admin/admin-header.php:40
-#: wp-includes/admin-bar.php:351
-msgid "Network Admin: %s"
-msgstr ""
-
-#. translators: User dashboard screen title. %s: Network title.
-#. translators: %s: Site title.
-#: wp-admin/admin-header.php:43
-#: wp-includes/admin-bar.php:354
-msgid "User Dashboard: %s"
-msgstr ""
-
-#. translators: Admin screen title. %s: Admin screen name.
-#: wp-admin/admin-header.php:50
-msgid "%s &#8212; ClassicPress"
-msgstr ""
-
-#. translators: Editor admin screen title. 1: "Edit item" text for the post type, 2: Post title.
-#: wp-admin/admin-header.php:60
-msgid "%1$s &#8220;%2$s&#8221;"
-msgstr ""
-
-#. translators: Admin screen title. 1: Admin screen name, 2: Network or site name.
-#. translators: Login screen title. 1: Login screen name, 2: Network or site name.
-#: wp-admin/admin-header.php:68
-#: wp-login.php:72
-msgid "%1$s &lsaquo; %2$s &#8212; ClassicPress"
-msgstr ""
-
-#. translators: %s: Admin screen title.
-#. translators: %s: Login screen title.
-#: wp-admin/admin-header.php:73
-#: wp-login.php:76
-msgid "Recovery Mode &#8212; %s"
-msgstr ""
-
-#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
-#. translators: 1: Post edited date, 2: Post edited time.
-#. translators: 1: Post creation date, 2: Post creation time.
-#. translators: Default date format, see https://www.php.net/manual/datetime.format.php
-#. translators: 1: Date, 2: Time.
-#. translators: Localized date format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/admin.php:113
-#: wp-admin/edit-form-advanced.php:663
-#: wp-admin/edit-form-advanced.php:666
-#: wp-admin/includes/ajax-actions.php:1559
-#: wp-admin/includes/ajax-actions.php:2802
-#: wp-admin/includes/ajax-actions.php:2805
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:70
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:85
-#: wp-admin/includes/class-wp-privacy-policy-content.php:366
-#: wp-admin/includes/dashboard.php:679
-#: wp-admin/includes/media.php:1638
-#: wp-admin/includes/schema.php:438
-#: wp-admin/options-general.php:493
-#: wp-admin/options-general.php:524
-#: wp-admin/update-core.php:907
-#: wp-includes/class-wp-locale.php:395
-#: wp-includes/media.php:4150
-#: wp-includes/script-loader.php:161
-msgid "F j, Y"
-msgstr ""
-
-#. translators: Comment time format. See https://www.php.net/manual/datetime.format.php
-#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
-#. translators: 1: Post edited date, 2: Post edited time.
-#. translators: 1: Post creation date, 2: Post creation time.
-#. translators: Post time format. See https://www.php.net/manual/datetime.format.php
-#. translators: Default time format, see https://www.php.net/manual/datetime.format.php
-#. translators: Localized time format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/admin.php:114
-#: wp-admin/comment.php:223
-#: wp-admin/edit-form-advanced.php:663
-#: wp-admin/edit-form-advanced.php:666
-#: wp-admin/includes/ajax-actions.php:1559
-#: wp-admin/includes/ajax-actions.php:2803
-#: wp-admin/includes/ajax-actions.php:2806
-#: wp-admin/includes/class-wp-comments-list-table.php:1018
-#: wp-admin/includes/class-wp-posts-list-table.php:1172
-#: wp-admin/includes/schema.php:440
-#: wp-admin/options-general.php:493
-#: wp-admin/options-general.php:572
-#: wp-includes/class-wp-locale.php:397
-#: wp-includes/script-loader.php:158
-msgid "g:i a"
-msgstr ""
-
-#: wp-admin/admin.php:262
-msgid "Invalid plugin page."
-msgstr ""
-
-#. translators: %s: Admin page generated by a plugin.
-#: wp-admin/admin.php:269
-msgid "Cannot load %s."
-msgstr ""
-
-#: wp-admin/admin.php:305
-#: wp-admin/import.php:15
-msgid "Sorry, you are not allowed to import content into this site."
-msgstr ""
-
-#: wp-admin/admin.php:338
-#: wp-admin/import.php:19
-#: wp-admin/menu.php:322
-msgid "Import"
-msgstr ""
-
-#: wp-admin/async-upload.php:38
-#: wp-admin/includes/ajax-actions.php:2426
-#: wp-admin/includes/ajax-actions.php:2492
-#: wp-admin/media-new.php:16
-#: wp-admin/media-upload.php:20
-#: wp-admin/upload.php:13
-#: wp-includes/class-wp-xmlrpc-server.php:4363
-#: wp-includes/class-wp-xmlrpc-server.php:4418
-#: wp-includes/class-wp-xmlrpc-server.php:6388
-msgid "Sorry, you are not allowed to upload files."
-msgstr ""
-
-#: wp-admin/async-upload.php:46
-#: wp-admin/edit.php:18
-#: wp-admin/edit.php:41
-#: wp-admin/post-new.php:24
-#: wp-admin/post.php:131
-#: wp-admin/post.php:249
-#: wp-admin/post.php:286
-#: wp-admin/post.php:315
-#: wp-includes/class-wp-customize-nav-menus.php:949
-#: wp-includes/class-wp-xmlrpc-server.php:1440
-#: wp-includes/class-wp-xmlrpc-server.php:1996
-#: wp-includes/class-wp-xmlrpc-server.php:3666
-#: wp-includes/class-wp-xmlrpc-server.php:4561
-#: wp-includes/class-wp-xmlrpc-server.php:5379
-#: wp-includes/class-wp-xmlrpc-server.php:5449
-#: wp-includes/class-wp-xmlrpc-server.php:5743
-#: wp-includes/class-wp-xmlrpc-server.php:5816
-#: wp-includes/post.php:1493
-#: wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php:442
-#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:141
-msgid "Invalid post type."
-msgstr ""
-
-#: wp-admin/async-upload.php:72
-#: wp-admin/includes/media.php:3281
-#: wp-includes/media-template.php:540
-#: wp-includes/media-template.php:785
-msgid "Copy URL to clipboard"
-msgstr ""
-
-#: wp-admin/async-upload.php:73
-#: wp-admin/includes/class-wp-media-list-table.php:863
-#: wp-admin/includes/class-wp-privacy-policy-content.php:409
-#: wp-admin/includes/media.php:3282
-#: wp-admin/site-health-info.php:55
-#: wp-includes/media-template.php:541
-#: wp-includes/media-template.php:786
-msgid "Copied!"
-msgstr ""
-
-#: wp-admin/async-upload.php:77
-msgctxt "media item"
-msgid "Edit"
-msgstr ""
-
-#: wp-admin/async-upload.php:79
-msgctxt "media item"
-msgid "Success"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/async-upload.php:120
-#: wp-admin/includes/dashboard.php:1529
-#: wp-admin/includes/file.php:344
-#: wp-admin/index.php:166
-#: wp-includes/class-wp-customize-manager.php:4291
-#: wp-includes/script-loader.php:805
-#: wp-includes/widgets/class-wp-widget-text.php:539
-#: wp-includes/widgets/class-wp-widget-text.php:554
-#: wp-includes/js/wp-pointer.js:20
-msgid "Dismiss"
-msgstr ""
-
-#. translators: %s: Name of the file that failed to upload.
-#. translators: %s: File name.
-#: wp-admin/async-upload.php:124
-#: wp-includes/script-loader.php:809
-msgid "&#8220;%s&#8221; has failed to upload."
-msgstr ""
-
-#: wp-admin/authorize-application.php:66
-msgid "Authorize Application"
-msgstr ""
-
-#: wp-admin/authorize-application.php:87
-msgid "The Authorize Application request is not allowed."
-msgstr ""
-
-#: wp-admin/authorize-application.php:88
-#: wp-admin/authorize-application.php:95
-#: wp-admin/authorize-application.php:113
-msgid "Cannot Authorize Application"
-msgstr ""
-
-#: wp-admin/authorize-application.php:94
-msgid "Your website appears to use Basic Authentication, which is not currently compatible with application passwords."
-msgstr ""
-
-#: wp-admin/authorize-application.php:98
-#: wp-admin/authorize-application.php:116
-msgid "Go Back"
-msgstr ""
-
-#: wp-admin/authorize-application.php:106
-#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:729
-#: wp-includes/user.php:381
-msgid "Application passwords are not available for your account. Please contact the site administrator for assistance."
-msgstr ""
-
-#: wp-admin/authorize-application.php:108
-#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:685
-#: wp-includes/user.php:376
-msgid "Application passwords are not available."
-msgstr ""
-
-#: wp-admin/authorize-application.php:145
-msgid "An application would like to connect to your account."
-msgstr ""
-
-#. translators: %s: Application name.
-#: wp-admin/authorize-application.php:151
-msgid "Would you like to give the application identifying itself as %s access to your account? You should only do this if you trust the application in question."
-msgstr ""
-
-#: wp-admin/authorize-application.php:157
-msgid "Would you like to give this application access to your account? You should only do this if you trust the application in question."
-msgstr ""
-
-#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
-#: wp-admin/authorize-application.php:170
-msgid "This will grant access to <a href=\"%1$s\">the %2$s site in this installation that you have permissions on</a>."
-msgid_plural "This will grant access to <a href=\"%1$s\">all %2$s sites in this installation that you have permissions on</a>."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
-#: wp-admin/authorize-application.php:178
-msgid "This will grant access to <a href=\"%1$s\">the %2$s site on the network as you have Super Admin rights</a>."
-msgid_plural "This will grant access to <a href=\"%1$s\">all %2$s sites on the network as you have Super Admin rights</a>."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Application name.
-#: wp-admin/authorize-application.php:204
-#: wp-admin/user-edit.php:991
-#: wp-admin/js/auth-app.js:90
-msgid "Your new password for %s is:"
-msgstr ""
-
-#: wp-admin/authorize-application.php:211
-#: wp-admin/user-edit.php:998
-#: wp-admin/js/auth-app.js:98
-msgid "Be sure to save this in a safe location. You will not be able to retrieve it."
-msgstr ""
-
-#: wp-admin/authorize-application.php:239
-#: wp-admin/user-edit.php:837
-msgid "New Application Password Name"
-msgstr ""
-
-#: wp-admin/authorize-application.php:263
-msgid "Yes, I approve of this connection"
-msgstr ""
-
-#. translators: %s: The URL the user is being redirected to.
-#: wp-admin/authorize-application.php:277
-#: wp-admin/authorize-application.php:311
-msgid "You will be sent to %s"
-msgstr ""
-
-#: wp-admin/authorize-application.php:290
-msgid "You will be given a password to manually enter into the application in question."
-msgstr ""
-
-#: wp-admin/authorize-application.php:297
-msgid "No, I do not approve of this connection"
-msgstr ""
-
-#: wp-admin/authorize-application.php:315
-msgid "You will be returned to the ClassicPress Dashboard, and no changes will be made."
-msgstr ""
-
-#: wp-admin/comment.php:46
-msgid "You cannot edit this comment because the associated post is in the Trash. Please restore the post first, then try again."
-msgstr ""
-
-#: wp-admin/comment.php:57
-#: wp-admin/edit-form-comment.php:22
-#: wp-admin/includes/template.php:460
-msgid "Edit Comment"
-msgstr ""
-
-#: wp-admin/comment.php:62
-#: wp-admin/edit-comments.php:189
-#: wp-admin/edit-form-advanced.php:340
-#: wp-admin/edit-link-form.php:66
-#: wp-admin/edit-tags.php:268
-#: wp-admin/edit.php:247
-#: wp-admin/edit.php:300
-#: wp-admin/erase-personal-data.php:23
-#: wp-admin/export-personal-data.php:23
-#: wp-admin/export.php:51
-#: wp-admin/import.php:24
-#: wp-admin/includes/class-custom-background.php:89
-#: wp-admin/includes/class-custom-image-header.php:100
-#: wp-admin/includes/class-wp-screen.php:831
-#: wp-admin/includes/ms.php:1134
-#: wp-admin/index.php:44
-#: wp-admin/link-manager.php:57
-#: wp-admin/media-new.php:49
-#: wp-admin/media.php:86
-#: wp-admin/my-sites.php:44
-#: wp-admin/nav-menus.php:643
-#: wp-admin/nav-menus.php:684
-#: wp-admin/network/index.php:34
-#: wp-admin/network/settings.php:49
-#: wp-admin/network/site-new.php:23
-#: wp-admin/network/sites.php:29
-#: wp-admin/network/themes.php:298
-#: wp-admin/network/upgrade.php:22
-#: wp-admin/network/user-new.php:20
-#: wp-admin/network/users.php:229
-#: wp-admin/options-discussion.php:24
-#: wp-admin/options-general.php:46
-#: wp-admin/options-media.php:34
-#: wp-admin/options-permalink.php:23
-#: wp-admin/options-privacy.php:38
-#: wp-admin/options-reading.php:25
-#: wp-admin/options-writing.php:23
-#: wp-admin/plugin-editor.php:125
-#: wp-admin/plugin-install.php:93
-#: wp-admin/plugins.php:543
-#: wp-admin/revision.php:151
-#: wp-admin/site-health.php:80
-#: wp-admin/theme-editor.php:28
-#: wp-admin/theme-install.php:124
-#: wp-admin/themes.php:143
-#: wp-admin/update-core.php:845
-#: wp-admin/upload.php:138
-#: wp-admin/upload.php:319
-#: wp-admin/user-edit.php:70
-#: wp-admin/user-new.php:279
-#: wp-admin/users.php:34
-#: wp-admin/widgets-form.php:43
-msgid "Overview"
-msgstr ""
-
-#: wp-admin/comment.php:64
-msgid "You can edit the information left in a comment if needed. This is often useful when you notice that a commenter has made a typographical error."
-msgstr ""
-
-#: wp-admin/comment.php:65
-msgid "You can also moderate the comment from this screen using the Status box, where you can also change the timestamp of the comment."
-msgstr ""
-
-#: wp-admin/comment.php:70
-#: wp-admin/edit-comments.php:209
-#: wp-admin/edit-form-advanced.php:314
-#: wp-admin/edit-form-advanced.php:331
-#: wp-admin/edit-form-advanced.php:350
-#: wp-admin/edit-link-form.php:75
-#: wp-admin/edit-tags.php:302
-#: wp-admin/edit.php:291
-#: wp-admin/edit.php:316
-#: wp-admin/erase-personal-data.php:64
-#: wp-admin/export-personal-data.php:64
-#: wp-admin/export.php:58
-#: wp-admin/import.php:31
-#: wp-admin/includes/class-custom-background.php:99
-#: wp-admin/includes/class-custom-image-header.php:136
-#: wp-admin/includes/ms.php:1156
-#: wp-admin/index.php:112
-#: wp-admin/link-manager.php:78
-#: wp-admin/media-new.php:60
-#: wp-admin/media.php:96
-#: wp-admin/my-sites.php:51
-#: wp-admin/nav-menus.php:691
-#: wp-admin/network.php:67
-#: wp-admin/network.php:80
-#: wp-admin/network/index.php:55
-#: wp-admin/network/settings.php:63
-#: wp-admin/network/site-new.php:31
-#: wp-admin/network/sites.php:45
-#: wp-admin/network/themes.php:323
-#: wp-admin/network/upgrade.php:31
-#: wp-admin/network/user-new.php:28
-#: wp-admin/network/users.php:241
-#: wp-admin/options-discussion.php:31
-#: wp-admin/options-general.php:52
-#: wp-admin/options-media.php:40
-#: wp-admin/options-permalink.php:59
-#: wp-admin/options-privacy.php:46
-#: wp-admin/options-reading.php:52
-#: wp-admin/options-writing.php:52
-#: wp-admin/plugin-editor.php:142
-#: wp-admin/plugin-install.php:117
-#: wp-admin/plugins.php:586
-#: wp-admin/revision.php:156
-#: wp-admin/site-health.php:89
-#: wp-admin/theme-editor.php:51
-#: wp-admin/theme-install.php:142
-#: wp-admin/themes.php:206
-#: wp-admin/tools.php:55
-#: wp-admin/update-core.php:866
-#: wp-admin/upload.php:158
-#: wp-admin/upload.php:351
-#: wp-admin/user-edit.php:76
-#: wp-admin/user-new.php:300
-#: wp-admin/users.php:81
-#: wp-admin/widgets-form.php:70
-msgid "For more information:"
-msgstr ""
-
-#: wp-admin/comment.php:71
-#: wp-admin/edit-comments.php:210
-msgid "<a href=\"https://wordpress.org/documentation/article/comments-screen/\">Documentation on Comments</a>"
-msgstr ""
-
-#: wp-admin/comment.php:72
-#: wp-admin/edit-comments.php:213
-#: wp-admin/edit-form-advanced.php:316
-#: wp-admin/edit-form-advanced.php:334
-#: wp-admin/edit-form-advanced.php:352
-#: wp-admin/edit-link-form.php:77
-#: wp-admin/edit-tags.php:312
-#: wp-admin/edit.php:293
-#: wp-admin/edit.php:318
-#: wp-admin/erase-personal-data.php:66
-#: wp-admin/export-personal-data.php:66
-#: wp-admin/export.php:60
-#: wp-admin/includes/class-custom-image-header.php:138
-#: wp-admin/index.php:114
-#: wp-admin/link-manager.php:80
-#: wp-admin/media-new.php:62
-#: wp-admin/media.php:98
-#: wp-admin/my-sites.php:53
-#: wp-admin/nav-menus.php:693
-#: wp-admin/network.php:83
-#: wp-admin/network/settings.php:65
-#: wp-admin/network/themes.php:326
-#: wp-admin/network/upgrade.php:33
-#: wp-admin/options-discussion.php:33
-#: wp-admin/options-general.php:54
-#: wp-admin/options-media.php:42
-#: wp-admin/options-permalink.php:67
-#: wp-admin/options-reading.php:54
-#: wp-admin/options-writing.php:54
-#: wp-admin/plugin-editor.php:145
-#: wp-admin/plugin-install.php:119
-#: wp-admin/plugins.php:589
-#: wp-admin/revision.php:158
-#: wp-admin/theme-editor.php:56
-#: wp-admin/theme-install.php:145
-#: wp-admin/themes.php:210
-#: wp-admin/tools.php:57
-#: wp-admin/upload.php:160
-#: wp-admin/upload.php:353
-#: wp-admin/user-edit.php:78
-#: wp-admin/user-new.php:302
-#: wp-admin/users.php:84
-#: wp-admin/widgets-form.php:72
-msgid "<a href=\"https://wordpress.org/support/forums/\">Support forums</a>"
-msgstr ""
-
-#: wp-admin/comment.php:79
-#: wp-admin/comment.php:279
-#: wp-admin/edit-comments.php:278
-#: wp-includes/class-wp-xmlrpc-server.php:3595
-#: wp-includes/class-wp-xmlrpc-server.php:3732
-#: wp-includes/class-wp-xmlrpc-server.php:3800
-#: wp-includes/comment.php:2495
-#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:343
-msgid "Invalid comment ID."
-msgstr ""
-
-#: wp-admin/comment.php:79
-#: wp-admin/comment.php:279
-#: wp-admin/includes/post.php:1761
-#: wp-admin/plugin-editor.php:335
-#: wp-admin/theme-editor.php:384
-#: wp-includes/class-wp-customize-manager.php:4318
-msgid "Go back"
-msgstr ""
-
-#: wp-admin/comment.php:83
-#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:786
-msgid "Sorry, you are not allowed to edit this comment."
-msgstr ""
-
-#: wp-admin/comment.php:87
-msgid "This comment is in the Trash. Please move it out of the Trash if you want to edit it."
-msgstr ""
-
-#: wp-admin/comment.php:101
-msgid "Moderate Comment"
-msgstr ""
-
-#: wp-admin/comment.php:133
-msgid "You are about to mark the following comment as spam:"
-msgstr ""
-
-#: wp-admin/comment.php:134
-#: wp-admin/includes/class-wp-comments-list-table.php:368
-msgctxt "comment"
-msgid "Mark as spam"
-msgstr ""
-
-#: wp-admin/comment.php:137
-msgid "You are about to move the following comment to the Trash:"
-msgstr ""
-
-#: wp-admin/comment.php:138
-#: wp-admin/edit-form-comment.php:242
-#: wp-admin/includes/class-wp-comments-list-table.php:380
-#: wp-admin/includes/class-wp-media-list-table.php:187
-#: wp-admin/includes/class-wp-posts-list-table.php:448
-#: wp-admin/includes/media.php:1679
-#: wp-admin/includes/meta-boxes.php:368
-#: wp-admin/includes/meta-boxes.php:472
-#: wp-includes/media-template.php:569
-#: wp-includes/media-template.php:732
-#: wp-includes/media.php:4616
-msgid "Move to Trash"
-msgstr ""
-
-#: wp-admin/comment.php:141
-msgid "You are about to delete the following comment:"
-msgstr ""
-
-#: wp-admin/comment.php:142
-msgid "Permanently delete comment"
-msgstr ""
-
-#: wp-admin/comment.php:145
-msgid "You are about to approve the following comment:"
-msgstr ""
-
-#: wp-admin/comment.php:146
-msgid "Approve comment"
-msgstr ""
-
-#: wp-admin/comment.php:154
-msgid "This comment is currently approved."
-msgstr ""
-
-#: wp-admin/comment.php:157
-msgid "This comment is currently marked as spam."
-msgstr ""
-
-#: wp-admin/comment.php:160
-msgid "This comment is currently in the Trash."
-msgstr ""
-
-#: wp-admin/comment.php:168
-#: wp-admin/includes/network.php:440
-#: wp-admin/includes/network.php:448
-#: wp-admin/includes/network.php:456
-#: wp-admin/network/themes.php:138
-#: wp-admin/network/themes.php:142
-#: wp-admin/plugins.php:343
-#: wp-admin/plugins.php:349
-#: wp-admin/theme-editor.php:311
-msgid "Caution:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/comment.php:172
-#: wp-admin/edit-form-comment.php:48
-#: wp-admin/includes/class-plugin-installer-skin.php:218
-#: wp-admin/includes/class-theme-installer-skin.php:241
-#: wp-admin/includes/class-wp-comments-list-table.php:469
-#: wp-admin/includes/class-wp-debug-data.php:1100
-#: wp-admin/includes/class-wp-debug-data.php:1195
-#: wp-admin/includes/class-wp-media-list-table.php:330
-#: wp-admin/includes/class-wp-post-comments-list-table.php:25
-#: wp-admin/includes/class-wp-posts-list-table.php:667
-#: wp-admin/includes/class-wp-posts-list-table.php:1703
-#: wp-admin/includes/meta-boxes.php:976
-#: wp-admin/includes/meta-boxes.php:1708
-#: wp-admin/includes/plugin-install.php:306
-#: wp-admin/includes/theme-install.php:109
-#: wp-includes/class-wp-editor.php:1213
-#: wp-includes/theme-compat/sidebar.php:29
-msgid "Author"
-msgstr ""
-
-#: wp-admin/comment.php:177
-#: wp-admin/edit-form-comment.php:63
-#: wp-admin/includes/class-wp-ms-users-list-table.php:195
-#: wp-admin/includes/class-wp-users-list-table.php:375
-#: wp-admin/includes/template.php:493
-#: wp-admin/network/site-users.php:360
-#: wp-admin/network/user-new.php:130
-#: wp-admin/user-edit.php:533
-#: wp-admin/user-new.php:422
-#: wp-admin/user-new.php:536
-#: wp-includes/comment-template.php:2545
-#: wp-login.php:1083
-msgid "Email"
-msgstr ""
-
-#: wp-admin/comment.php:183
-#: wp-admin/edit-form-comment.php:69
-#: wp-admin/includes/class-walker-nav-menu-edit.php:195
-#: wp-admin/includes/class-wp-links-list-table.php:133
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:358
-#: wp-admin/includes/media.php:2884
-#: wp-admin/includes/nav-menu.php:300
-#: wp-admin/includes/template.php:498
-#: wp-includes/class-wp-customize-nav-menus.php:1275
-#: wp-includes/class-wp-editor.php:1266
-#: wp-includes/class-wp-editor.php:1887
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:88
-#: wp-includes/embed.php:1172
-#: wp-includes/media-template.php:880
-#: wp-includes/media-template.php:1106
-#: wp-includes/media-template.php:1229
-#: wp-includes/media-template.php:1303
-#: wp-includes/media-template.php:1394
-#: wp-includes/media.php:4576
-#: wp-includes/media.php:5134
-#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:62
-#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:176
-#: wp-includes/widgets/class-wp-widget-media-image.php:113
-msgid "URL"
-msgstr ""
-
-#. translators: Column name or table row header.
-#: wp-admin/comment.php:188
-#: wp-admin/includes/class-wp-comments-list-table.php:474
-msgid "In response to"
-msgstr ""
-
-#. translators: %s: Comment link.
-#: wp-admin/comment.php:206
-#: wp-admin/includes/class-wp-comments-list-table.php:926
-#: wp-includes/comment-template.php:1010
-msgid "In reply to %s."
-msgstr ""
-
-#: wp-admin/comment.php:214
-msgid "Submitted on"
-msgstr ""
-
-#. translators: 1: Comment date, 2: Comment time.
-#. translators: Publish box date string. 1: Date, 2: Time.
-#. translators: 1: Post date, 2: Post time.
-#. translators: Publish box date string. 1: Date, 2: Time. See https://www.php.net/manual/datetime.format.php
-#: wp-admin/comment.php:219
-#: wp-admin/edit-form-advanced.php:169
-#: wp-admin/edit-form-comment.php:146
-#: wp-admin/includes/class-wp-comments-list-table.php:1014
-#: wp-admin/includes/class-wp-posts-list-table.php:1168
-#: wp-admin/includes/meta-boxes.php:232
-#: wp-admin/includes/meta-boxes.php:439
-#: wp-includes/comment-template.php:1227
-#: wp-includes/comment-template.php:1240
-msgid "%1$s at %2$s"
-msgstr ""
-
-#. translators: Comment date format. See https://www.php.net/manual/datetime.format.php
-#. translators: Date format in table columns, see https://www.php.net/manual/datetime.format.php
-#. translators: Post date format. See https://www.php.net/manual/datetime.format.php
-#: wp-admin/comment.php:221
-#: wp-admin/includes/ajax-actions.php:2205
-#: wp-admin/includes/class-wp-comments-list-table.php:1016
-#: wp-admin/includes/class-wp-media-list-table.php:539
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:474
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:495
-#: wp-admin/includes/class-wp-ms-users-list-table.php:342
-#: wp-admin/includes/class-wp-posts-list-table.php:1170
-#: wp-includes/class-wp-editor.php:1817
-msgid "Y/m/d"
-msgstr ""
-
-#. translators: Field name in comment form.
-#: wp-admin/comment.php:234
-#: wp-includes/comment-template.php:1156
-#: wp-includes/comment-template.php:2603
-msgctxt "noun"
-msgid "Comment"
-msgstr ""
-
-#: wp-admin/comment.php:238
-#: wp-admin/edit-form-comment.php:159
-#: wp-admin/includes/class-wp-comments-list-table.php:810
-#: wp-admin/includes/class-wp-links-list-table.php:337
-#: wp-admin/includes/class-wp-media-list-table.php:758
-#: wp-admin/includes/class-wp-media-list-table.php:810
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:702
-#: wp-admin/includes/class-wp-ms-users-list-table.php:404
-#: wp-admin/includes/class-wp-ms-users-list-table.php:527
-#: wp-admin/includes/class-wp-posts-list-table.php:440
-#: wp-admin/includes/class-wp-posts-list-table.php:1450
-#: wp-admin/includes/class-wp-terms-list-table.php:477
-#: wp-admin/includes/class-wp-users-list-table.php:472
-#: wp-admin/includes/dashboard.php:759
-#: wp-admin/includes/meta-boxes.php:135
-#: wp-admin/includes/meta-boxes.php:197
-#: wp-admin/includes/meta-boxes.php:292
-#: wp-admin/includes/post.php:1548
-#: wp-includes/class-walker-comment.php:258
-#: wp-includes/class-wp-editor.php:1389
-#: wp-includes/comment-template.php:1233
-msgid "Edit"
-msgstr ""
-
-#: wp-admin/comment.php:247
-#: wp-admin/includes/class-walker-nav-menu-edit.php:304
-#: wp-admin/includes/class-wp-posts-list-table.php:2046
-#: wp-admin/includes/class-wp-terms-list-table.php:699
-#: wp-admin/includes/dashboard.php:214
-#: wp-admin/includes/file.php:2530
-#: wp-admin/includes/image-edit.php:106
-#: wp-admin/includes/media.php:1676
-#: wp-admin/includes/media.php:2211
-#: wp-admin/includes/meta-boxes.php:166
-#: wp-admin/includes/meta-boxes.php:224
-#: wp-admin/includes/template.php:510
-#: wp-admin/includes/template.php:759
-#: wp-admin/includes/template.php:894
-#: wp-admin/nav-menus.php:1163
-#: wp-admin/network/settings.php:181
-#: wp-admin/options-general.php:254
-#: wp-admin/user-edit.php:555
-#: wp-admin/user-edit.php:705
-#: wp-admin/widgets-form.php:337
-#: wp-admin/widgets-form.php:340
-#: wp-admin/widgets-form.php:545
-#: wp-includes/class-wp-editor.php:1182
-#: wp-includes/class-wp-editor.php:1933
-#: wp-includes/media.php:4580
-#: wp-includes/script-loader.php:1101
-#: wp-admin/js/post.js:1028
-msgid "Cancel"
-msgstr ""
-
-#: wp-admin/comment.php:282
-#: wp-admin/edit-comments.php:281
-#: wp-admin/includes/comment.php:55
-msgid "Sorry, you are not allowed to edit comments on this post."
-msgstr ""
-
-#: wp-admin/comment.php:370
-msgid "Unknown action."
-msgstr ""
-
-#. translators: %s: https://www.classicpress.net/contributors
-#: wp-admin/credits.php:54
-msgid "ClassicPress is created by a <a href=\"%1$s\">worldwide team</a> of passionate individuals."
-msgstr ""
-
-#. translators: %s: https://www.classicpress.net/get-involved
-#: wp-admin/credits.php:60
-msgid "Interested in helping out with development? <a href=\"%s\">Get involved in ClassicPress</a>."
-msgstr ""
-
-#: wp-admin/customize.php:17
-#: wp-admin/customize.php:34
-#: wp-admin/edit-comments.php:13
-#: wp-admin/edit-tags.php:28
-#: wp-admin/edit-tags.php:85
-#: wp-admin/edit-tags.php:116
-#: wp-admin/edit-tags.php:136
-#: wp-admin/edit-tags.php:172
-#: wp-admin/edit.php:46
-#: wp-admin/includes/bookmark.php:31
-#: wp-admin/media-upload.php:46
-#: wp-admin/nav-menus.php:25
-#: wp-admin/options.php:50
-#: wp-admin/options.php:83
-#: wp-admin/post-new.php:60
-#: wp-admin/press-this.php:21
-#: wp-admin/term.php:42
-#: wp-admin/themes.php:14
-#: wp-admin/themes.php:42
-#: wp-admin/themes.php:62
-#: wp-admin/user-new.php:15
-#: wp-admin/user-new.php:22
-#: wp-admin/user-new.php:55
-#: wp-admin/user-new.php:188
-#: wp-admin/users.php:15
-#: wp-admin/widgets.php:17
-#: wp-includes/class-wp-customize-manager.php:515
-#: wp-includes/script-loader.php:1106
-msgid "You need a higher level of permission."
-msgstr ""
-
-#: wp-admin/customize.php:18
-#: wp-includes/class-wp-customize-manager.php:516
-#: wp-includes/script-loader.php:1107
-msgid "Sorry, you are not allowed to customize this site."
-msgstr ""
-
-#: wp-admin/customize.php:35
-msgid "Sorry, you are not allowed to edit this changeset."
-msgstr ""
-
-#: wp-admin/customize.php:71
-msgid "Your scheduled changes just published"
-msgstr ""
-
-#: wp-admin/customize.php:72
-#: wp-admin/customize.php:81
-msgid "Customize New Changes"
-msgstr ""
-
-#: wp-admin/customize.php:79
-#: wp-admin/includes/class-custom-image-header.php:818
-#: wp-admin/includes/class-custom-image-header.php:1004
-#: wp-admin/includes/class-custom-image-header.php:1015
-#: wp-admin/includes/file.php:632
-#: wp-admin/media-upload.php:38
-#: wp-admin/network/site-users.php:158
-#: wp-admin/themes.php:27
-#: wp-admin/themes.php:70
-#: wp-admin/users.php:157
-#: wp-includes/class-wp-customize-manager.php:450
-#: wp-includes/class-wp-xmlrpc-server.php:4009
-#: wp-includes/functions.php:3566
-#: wp-includes/script-loader.php:607
-#: wp-includes/script-loader.php:1105
-#: wp-admin/js/tags.js:62
-#: wp-admin/js/updates.js:1940
-msgid "Something went wrong."
-msgstr ""
-
-#: wp-admin/customize.php:80
-msgid "This changeset cannot be further modified."
-msgstr ""
-
-#: wp-admin/customize.php:147
-#: wp-admin/includes/class-wp-debug-data.php:411
-#: wp-admin/includes/dashboard.php:1176
-msgid "Loading&hellip;"
-msgstr ""
-
-#: wp-admin/customize.php:189
-#: wp-admin/includes/meta-boxes.php:389
-#: wp-admin/includes/meta-boxes.php:390
-#: wp-admin/includes/meta-boxes.php:1607
-#: wp-includes/class-wp-customize-manager.php:4847
-#: wp-includes/script-loader.php:1089
-#: wp-admin/js/post.js:795
-msgid "Publish"
-msgstr ""
-
-#: wp-admin/customize.php:189
-#: wp-includes/script-loader.php:1087
-msgid "Activate &amp; Publish"
-msgstr ""
-
-#: wp-admin/customize.php:192
-#: wp-admin/customize.php:197
-#: wp-admin/edit-form-advanced.php:392
-#: wp-includes/script-loader.php:1147
-msgid "Publish Settings"
-msgstr ""
-
-#: wp-admin/customize.php:195
-#: wp-admin/theme-install.php:386
-#: wp-admin/theme-install.php:448
-#: wp-admin/themes.php:569
-#: wp-admin/themes.php:929
-#: wp-admin/themes.php:1160
-msgctxt "theme"
-msgid "Cannot Activate"
-msgstr ""
-
-#: wp-admin/customize.php:202
-#: wp-admin/includes/class-theme-upgrader-skin.php:92
-#: wp-admin/includes/theme.php:1018
-#: wp-admin/menu.php:207
-#: wp-admin/theme-install.php:375
-#: wp-admin/themes.php:549
-#: wp-admin/themes.php:908
-#: wp-admin/themes.php:1141
-#: wp-includes/admin-bar.php:442
-#: wp-includes/customize/class-wp-customize-theme-control.php:244
-msgid "Customize"
-msgstr ""
-
-#: wp-admin/customize.php:203
-#: wp-admin/includes/class-custom-background.php:265
-#: wp-admin/includes/class-custom-image-header.php:538
-#: wp-admin/includes/class-wp-posts-list-table.php:1500
-#: wp-admin/includes/class-wp-theme-install-list-table.php:346
-#: wp-admin/includes/meta-boxes.php:73
-#: wp-admin/includes/post.php:1837
-#: wp-admin/theme-install.php:378
-#: wp-admin/theme-install.php:391
-#: wp-admin/theme-install.php:401
-#: wp-admin/theme-install.php:408
-#: wp-admin/theme-install.php:565
-#: wp-includes/class-wp-customize-manager.php:4320
-#: wp-includes/class-wp-editor.php:1249
-#: wp-includes/media-template.php:1531
-msgid "Preview"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/customize.php:209
-msgid "Close the Customizer and go back to the previous page"
-msgstr ""
-
-#. translators: %s: The site/panel title in the Customizer.
-#: wp-admin/customize.php:231
-#: wp-includes/class-wp-customize-panel.php:386
-#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:83
-msgid "You are customizing %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/customize.php:237
-#: wp-admin/includes/class-wp-screen.php:954
-#: wp-includes/class-wp-customize-panel.php:393
-#: wp-includes/class-wp-customize-section.php:388
-#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:90
-#: wp-includes/customize/class-wp-customize-themes-panel.php:91
-msgid "Help"
-msgstr ""
-
-#: wp-admin/customize.php:244
-msgid "The Customizer allows you to preview changes to your site before publishing them. You can navigate to different pages on your site within the preview. Edit shortcuts are shown for some editable elements. The Customizer is intended for use with non-block themes."
-msgstr ""
-
-#: wp-admin/customize.php:249
-msgid "<a href=\"https://wordpress.org/documentation/article/customizer/\">Documentation on Customizer</a>"
-msgstr ""
-
-#: wp-admin/customize.php:262
-#: wp-includes/script-loader.php:1110
-msgctxt "label for hide controls button without length constraints"
-msgid "Hide Controls"
-msgstr ""
-
-#: wp-admin/customize.php:264
-msgctxt "short (~12 characters) label for hide controls button"
-msgid "Hide Controls"
-msgstr ""
-
-#: wp-admin/edit-comments.php:14
-#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:150
-#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:389
-msgid "Sorry, you are not allowed to edit comments."
-msgstr ""
-
-#. translators: 1: Comments count, 2: Post title.
-#: wp-admin/edit-comments.php:156
-msgid "Comments (%1$s) on &#8220;%2$s&#8221;"
-msgstr ""
-
-#. translators: %s: Post title.
-#. translators: %s: Link to post.
-#: wp-admin/edit-comments.php:164
-#: wp-admin/edit-comments.php:233
-msgid "Comments on &#8220;%s&#8221;"
-msgstr ""
-
-#. translators: %s: Comments count.
-#: wp-admin/edit-comments.php:175
-#: wp-admin/js/edit-comments.js:195
-#: wp-admin/js/edit-comments.js:215
-msgid "Comments (%s)"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#. translators: Default privacy policy heading.
-#: wp-admin/edit-comments.php:180
-#: wp-admin/edit-comments.php:241
-#: wp-admin/includes/class-wp-comments-list-table.php:501
-#: wp-admin/includes/class-wp-media-list-table.php:365
-#: wp-admin/includes/class-wp-media-list-table.php:367
-#: wp-admin/includes/class-wp-posts-list-table.php:711
-#: wp-admin/includes/class-wp-posts-list-table.php:713
-#: wp-admin/includes/class-wp-posts-list-table.php:1881
-#: wp-admin/includes/class-wp-privacy-policy-content.php:475
-#: wp-admin/includes/file.php:20
-#: wp-admin/includes/meta-boxes.php:1699
-#: wp-includes/comment.php:3783
-#: wp-includes/link-template.php:3281
-#: wp-includes/link-template.php:3344
-#: wp-admin/js/edit-comments.js:220
-msgid "Comments"
-msgstr ""
-
-#: wp-admin/edit-comments.php:191
-msgid "You can manage comments made on your site similar to the way you manage posts and other content. This screen is customizable in the same ways as other management screens, and you can act on comments using the on-hover action links or the bulk actions."
-msgstr ""
-
-#: wp-admin/edit-comments.php:197
-msgid "Moderating Comments"
-msgstr ""
-
-#: wp-admin/edit-comments.php:199
-msgid "A red bar on the left means the comment is waiting for you to moderate it."
-msgstr ""
-
-#: wp-admin/edit-comments.php:200
-msgid "In the <strong>Author</strong> column, in addition to the author&#8217;s name, email address, and blog URL, the commenter&#8217;s IP address is shown. Clicking on this link will show you all the comments made from this IP address."
-msgstr ""
-
-#: wp-admin/edit-comments.php:201
-msgid "In the <strong>Comment</strong> column, hovering over any comment gives you options to approve, reply (and approve), quick edit, edit, spam mark, or trash that comment."
-msgstr ""
-
-#: wp-admin/edit-comments.php:202
-msgid "In the <strong>In response to</strong> column, there are three elements. The text is the name of the post that inspired the comment, and links to the post editor for that entry. The View Post link leads to that post on your live site. The small bubble with the number in it shows the number of approved comments that post has received. If there are pending comments, a red notification circle with the number of pending comments is displayed. Clicking the notification circle will filter the comments screen to show only pending comments on that post."
-msgstr ""
-
-#: wp-admin/edit-comments.php:203
-msgid "In the <strong>Submitted on</strong> column, the date and time the comment was left on your site appears. Clicking on the date/time link will take you to that comment on your live site."
-msgstr ""
-
-#: wp-admin/edit-comments.php:204
-msgid "Many people take advantage of keyboard shortcuts to moderate their comments more quickly. Use the link to the side to learn more."
-msgstr ""
-
-#: wp-admin/edit-comments.php:211
-msgid "<a href=\"https://wordpress.org/documentation/article/understand-comment-spam/\">Documentation on Comment Spam</a>"
-msgstr ""
-
-#: wp-admin/edit-comments.php:212
-#: wp-admin/user-edit.php:349
-msgid "<a href=\"https://wordpress.org/documentation/article/keyboard-shortcuts-classic-editor/#keyboard-shortcuts-for-comments\">Documentation on Keyboard Shortcuts</a>"
-msgstr ""
-
-#: wp-admin/edit-comments.php:218
-msgid "Filter comments list"
-msgstr ""
-
-#: wp-admin/edit-comments.php:219
-msgid "Comments list navigation"
-msgstr ""
-
-#: wp-admin/edit-comments.php:220
-msgid "Comments list"
-msgstr ""
-
-#. translators: %s: Search query.
-#: wp-admin/edit-comments.php:263
-#: wp-admin/edit-tags.php:342
-#: wp-admin/edit.php:407
-#: wp-admin/link-manager.php:111
-#: wp-admin/network/sites.php:378
-#: wp-admin/network/themes.php:360
-#: wp-admin/network/users.php:296
-#: wp-admin/plugins.php:737
-#: wp-admin/upload.php:381
-#: wp-admin/users.php:638
-#: wp-admin/js/updates.js:2665
-msgid "Search results for: %s"
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:301
-msgid "%s comment approved."
-msgid_plural "%s comments approved."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:307
-msgid "%s comment marked as spam."
-msgid_plural "%s comments marked as spam."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:307
-#: wp-admin/edit-comments.php:318
-#: wp-admin/edit.php:428
-#: wp-admin/includes/image-edit.php:88
-#: wp-admin/includes/media.php:1680
-#: wp-admin/includes/template.php:554
-#: wp-admin/includes/template.php:563
-#: wp-admin/upload.php:71
-#: wp-admin/upload.php:92
-#: wp-includes/class-wp-editor.php:1178
-msgid "Undo"
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:312
-msgid "%s comment restored from the spam."
-msgid_plural "%s comments restored from the spam."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:318
-msgid "%s comment moved to the Trash."
-msgid_plural "%s comments moved to the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:323
-msgid "%s comment restored from the Trash."
-msgid_plural "%s comments restored from the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/edit-comments.php:328
-msgid "%s comment permanently deleted."
-msgid_plural "%s comments permanently deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/edit-comments.php:336
-msgid "This comment is already approved."
-msgstr ""
-
-#: wp-admin/edit-comments.php:336
-#: wp-admin/edit-comments.php:342
-msgid "Edit comment"
-msgstr ""
-
-#: wp-admin/edit-comments.php:339
-msgid "This comment is already in the Trash."
-msgstr ""
-
-#: wp-admin/edit-comments.php:339
-msgid "View Trash"
-msgstr ""
-
-#: wp-admin/edit-comments.php:342
-msgid "This comment is already marked as spam."
-msgstr ""
-
-#: wp-admin/edit-comments.php:357
-msgid "Search Comments"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:127
-#: wp-admin/edit-form-advanced.php:134
-msgid "Preview post"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:141
-msgid "View post"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:148
-#: wp-admin/edit-form-advanced.php:155
-msgid "Preview page"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:162
-msgid "View page"
-msgstr ""
-
-#. translators: Publish box date format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/edit-form-advanced.php:171
-#: wp-admin/edit-form-comment.php:148
-#: wp-admin/includes/meta-boxes.php:234
-#: wp-admin/includes/meta-boxes.php:441
-msgctxt "publish box date format"
-msgid "M j, Y"
-msgstr ""
-
-#. translators: Publish box time format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/edit-form-advanced.php:173
-#: wp-admin/edit-form-comment.php:150
-#: wp-admin/includes/meta-boxes.php:236
-#: wp-admin/includes/meta-boxes.php:443
-msgctxt "publish box time format"
-msgid "H:i"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:178
-#: wp-admin/edit-form-advanced.php:181
-#: wp-includes/class-wp-post-type.php:829
-msgid "Post updated."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:179
-#: wp-admin/edit-form-advanced.php:194
-msgid "Custom field updated."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:180
-#: wp-admin/edit-form-advanced.php:195
-msgid "Custom field deleted."
-msgstr ""
-
-#. translators: %s: Date and time of the revision.
-#: wp-admin/edit-form-advanced.php:183
-msgid "Post restored to revision from %s."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:184
-#: wp-includes/class-wp-post-type.php:825
-msgid "Post published."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:185
-msgid "Post saved."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:186
-msgid "Post submitted."
-msgstr ""
-
-#. translators: %s: Scheduled date for the post.
-#: wp-admin/edit-form-advanced.php:188
-msgid "Post scheduled for: %s."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:189
-msgid "Post draft updated."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:193
-#: wp-admin/edit-form-advanced.php:196
-#: wp-includes/class-wp-post-type.php:829
-msgid "Page updated."
-msgstr ""
-
-#. translators: %s: Date and time of the revision.
-#: wp-admin/edit-form-advanced.php:198
-msgid "Page restored to revision from %s."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:199
-#: wp-includes/class-wp-post-type.php:825
-msgid "Page published."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:200
-msgid "Page saved."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:201
-msgid "Page submitted."
-msgstr ""
-
-#. translators: %s: Scheduled date for the page.
-#: wp-admin/edit-form-advanced.php:203
-msgid "Page scheduled for: %s."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:204
-msgid "Page draft updated."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:206
-#: wp-admin/media.php:109
-#: wp-admin/upload.php:18
-#: wp-admin/upload.php:89
-msgid "Media file updated."
-msgstr ""
-
-#. translators: %s: URL to view the autosave.
-#: wp-admin/edit-form-advanced.php:249
-msgid "There is an autosave of this post that is more recent than the version below. <a href=\"%s\">View the autosave</a>"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:278
-msgid "The title field and the big Post Editing Area are fixed in place, but you can reposition all the other boxes using drag and drop. You can also minimize or expand them by clicking the title bar of each box. Use the Screen Options tab to unhide more boxes (Excerpt, Send Trackbacks, Custom Fields, Discussion, Slug, Author) or to choose a 1- or 2-column layout for this screen."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:283
-msgid "Customizing This Display"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:288
-msgid "<strong>Title</strong> &mdash; Enter a title for your post. After you enter a title, you&#8217;ll see the permalink below, which you can edit."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:289
-msgid "<strong>Post editor</strong> &mdash; Enter the text for your post. There are two modes of editing: Visual and Text. Choose the mode by clicking on the appropriate tab."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:290
-msgid "Visual mode gives you an editor that is similar to a word processor. Click the Toolbar Toggle button to get a second row of controls."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:291
-msgid "The Text mode allows you to enter HTML along with your post text. Note that &lt;p&gt; and &lt;br&gt; tags are converted to line breaks when switching to the Text editor to make it less cluttered. When you type, a single line break can be used instead of typing &lt;br&gt;, and two line breaks instead of paragraph tags. The line breaks are converted back to tags automatically."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:292
-msgid "You can insert media files by clicking the button above the post editor and following the directions. You can align or edit images using the inline formatting toolbar available in Visual mode."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:293
-msgid "You can enable distraction-free writing mode using the icon to the right. This feature is not available for old browsers or devices with small screens, and requires that the full-height editor be enabled in Screen Options."
-msgstr ""
-
-#. translators: %s: Alt + F10
-#: wp-admin/edit-form-advanced.php:296
-msgid "Keyboard users: When you are working in the visual editor, you can use %s to access the toolbar."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:303
-msgid "Title and Post Editor"
-msgstr ""
-
-#. translators: %s: URL to Press This bookmarklet.
-#: wp-admin/edit-form-advanced.php:311
-msgid "You can also create posts with the <a href=\"%s\">Press This bookmarklet</a>."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:315
-msgid "<a href=\"https://wordpress.org/documentation/article/write-posts-classic-editor/\">Documentation on Writing and Editing Posts</a>"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:319
-#: wp-admin/edit.php:302
-msgid "Pages are similar to posts in that they have a title, body text, and associated metadata, but they are different in that they are not part of the chronological blog stream, kind of like permanent posts. Pages are not categorized or tagged, but can have a hierarchy. You can nest pages under other pages by making one the &#8220;Parent&#8221; of the other, creating a group of pages."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:320
-msgid "Creating a Page is very similar to creating a Post, and the screens can be customized in the same way using drag and drop, the Screen Options tab, and expanding/collapsing boxes as you choose. This screen also has the distraction-free writing space, available in both the Visual and Text modes via the Fullscreen buttons. The Page editor mostly works the same as the Post editor, but there are some Page-specific features in the Page Attributes box."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:325
-msgid "About Pages"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:332
-msgid "<a href=\"https://wordpress.org/documentation/article/pages-add-new-screen/\">Documentation on Adding New Pages</a>"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:333
-msgid "<a href=\"https://wordpress.org/documentation/article/pages-screen/\">Documentation on Editing Pages</a>"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:342
-#: wp-admin/media.php:88
-msgid "This screen allows you to edit fields for metadata in a file within the media library."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:343
-#: wp-admin/media.php:89
-msgid "For images only, you can click on Edit Image under the thumbnail to expand out an inline image editor with icons for cropping, rotating, or flipping the image as well as for undoing and redoing. The boxes on the right give you more options for scaling the image, for cropping it, and for cropping the thumbnail in a different way than you crop the original image. You can click on Help in those boxes to get more information."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:344
-#: wp-admin/media.php:90
-msgid "Note that you crop the image by clicking on it (the Crop icon is already selected) and dragging the cropping frame to select the desired part. Then click Save to retain the cropping."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:345
-#: wp-admin/media.php:91
-msgid "Remember to click Update to save metadata entered or changed."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:351
-#: wp-admin/media.php:97
-msgid "<a href=\"https://wordpress.org/documentation/article/edit-media/\">Documentation on Edit Media</a>"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:357
-msgid "You can upload and insert media (images, audio, documents, etc.) by clicking the Add Media button. You can select from the images and files already uploaded to the Media Library, or upload new media to add to your page or post. To create an image gallery, select the images to add and click the &#8220;Create a new gallery&#8221; button."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:358
-msgid "You can also embed media from many popular websites including Twitter, YouTube, Flickr and others by pasting the media URL on its own line into the content of your post/page. <a href=\"https://wordpress.org/documentation/article/embeds/\">Learn more about embeds</a>."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:363
-msgid "Inserting Media"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:370
-msgid "Several boxes on this screen contain settings for how your content will be published, including:"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:372
-msgid "<strong>Publish</strong> &mdash; You can set the terms of publishing your post in the Publish box. For Status, Visibility, and Publish (immediately), click on the Edit link to reveal more options. Visibility includes options for password-protecting a post or making it stay at the top of your blog indefinitely (sticky). The Password protected option allows you to set an arbitrary password for each post. The Private option hides the post from everyone except editors and administrators. Publish (immediately) allows you to set a future or past date and time, so you can schedule a post to be published in the future or backdate a post."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:376
-msgid "<strong>Format</strong> &mdash; Post Formats designate how your theme will display a specific post. For example, you could have a <em>standard</em> blog post with a title and paragraphs, or a short <em>aside</em> that omits the title and contains a short text blurb. Your theme could enable all or some of 10 possible formats. <a href=\"https://wordpress.org/documentation/article/post-formats/#supported-formats\">Learn more about each post format</a>."
-msgstr ""
-
-#. translators: %s: Featured image.
-#: wp-admin/edit-form-advanced.php:382
-msgid "<strong>%s</strong> &mdash; This allows you to associate an image with your post without inserting it. This is usually useful only if your theme makes use of the image as a post thumbnail on the home page, a custom header, etc."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:397
-msgid "<strong>Send Trackbacks</strong> &mdash; Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. Enter the URL(s) you want to send trackbacks. If you link to other WordPress sites they&#8217;ll be notified automatically using pingbacks, and this field is unnecessary."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:398
-msgid "<strong>Discussion</strong> &mdash; You can turn comments and pings on or off, and if there are comments on the post, you can see them here and moderate them."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:403
-#: wp-admin/options-discussion.php:16
-msgid "Discussion Settings"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:408
-msgid "<strong>Parent</strong> &mdash; You can arrange your pages in hierarchies. For example, you could have an &#8220;About&#8221; page that has &#8220;Life Story&#8221; and &#8220;My Dog&#8221; pages under it. There are no limits to how many levels you can nest pages."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:409
-msgid "<strong>Template</strong> &mdash; Some themes have custom templates you can use for certain pages that might have additional features or custom layouts. If so, you&#8217;ll see them in this dropdown menu."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:410
-msgid "<strong>Order</strong> &mdash; Pages are usually ordered alphabetically, but you can choose your own order by entering a number (1 for first, etc.) in this field."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:415
-#: wp-includes/class-wp-post-type.php:814
-msgid "Page Attributes"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:457
-msgctxt "Admin Post Navigation"
-msgid "Previous post: "
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:459
-msgctxt "Admin Post Navigation"
-msgid "&larr; Previous"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:467
-msgctxt "Admin Post Navigation"
-msgid "Next post: "
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:469
-msgctxt "Admin Post Navigation"
-msgid "Next &rarr;"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:486
-msgid "<strong>Connection lost.</strong> Saving has been disabled until you are reconnected."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:487
-msgid "This post is being backed up in your browser, just in case."
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:555
-msgid "Add title"
-msgstr ""
-
-#: wp-admin/edit-form-advanced.php:582
-msgid "Get Shortlink"
-msgstr ""
-
-#. translators: %s: Number of words.
-#: wp-admin/edit-form-advanced.php:650
-msgid "Word count: %s"
-msgstr ""
-
-#. translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time.
-#. translators: 1: User's display name, 2: Date of last edit, 3: Time of last edit.
-#: wp-admin/edit-form-advanced.php:663
-#: wp-admin/includes/ajax-actions.php:2813
-msgid "Last edited by %1$s on %2$s at %3$s"
-msgstr ""
-
-#. translators: 1: Post edited date, 2: Post edited time.
-#. translators: 1: Date of last edit, 2: Time of last edit.
-#: wp-admin/edit-form-advanced.php:666
-#: wp-admin/includes/ajax-actions.php:2816
-msgid "Last edited on %1$s at %2$s"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:37
-msgctxt "comment"
-msgid "Permalink:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-form-comment.php:53
-#: wp-includes/comment.php:3733
-msgid "Comment Author"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:59
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:28
-#: wp-admin/includes/class-wp-debug-data.php:1086
-#: wp-admin/includes/class-wp-debug-data.php:1181
-#: wp-admin/includes/class-wp-ms-users-list-table.php:194
-#: wp-admin/includes/class-wp-users-list-table.php:374
-#: wp-admin/includes/template.php:488
-#: wp-admin/user-edit.php:428
-#: wp-includes/comment-template.php:2532
-msgid "Name"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-form-comment.php:84
-#: wp-admin/includes/template.php:469
-msgid "Comment"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:105
-#: wp-admin/edit-link-form.php:30
-#: wp-admin/includes/image-edit.php:107
-#: wp-admin/includes/meta-boxes.php:44
-#: wp-admin/includes/meta-boxes.php:429
-#: wp-admin/includes/meta-boxes.php:1118
-#: wp-admin/includes/meta-boxes.php:1600
-#: wp-admin/includes/widgets.php:277
-#: wp-includes/class-wp-editor.php:1251
-#: wp-admin/js/widgets.js:202
-#: wp-admin/js/widgets.js:429
-#: wp-admin/js/widgets/custom-html-widgets.js:261
-msgid "Save"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:113
-#: wp-admin/export.php:234
-#: wp-admin/export.php:286
-#: wp-admin/includes/meta-boxes.php:104
-msgid "Status:"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:117
-msgid "Approved"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:120
-msgid "Pending"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:123
-msgid "Spam"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-form-comment.php:133
-msgid "Comment status"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:136
-#: wp-includes/comment.php:266
-msgctxt "comment status"
-msgid "Approved"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:137
-msgctxt "comment status"
-msgid "Pending"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:138
-#: wp-includes/comment.php:267
-msgctxt "comment status"
-msgid "Spam"
-msgstr ""
-
-#. translators: %s: Comment date.
-#: wp-admin/edit-form-comment.php:156
-msgid "Submitted on: %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-form-comment.php:162
-#: wp-admin/includes/meta-boxes.php:296
-msgid "Edit date and time"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-form-comment.php:169
-#: wp-admin/includes/meta-boxes.php:304
-msgid "Date and time"
-msgstr ""
-
-#. translators: %s: Post link.
-#: wp-admin/edit-form-comment.php:197
-msgid "In response to: %s"
-msgstr ""
-
-#. translators: %s: Comment link.
-#. translators: Comment moderation. %s: Parent comment edit URL.
-#: wp-admin/edit-form-comment.php:214
-#: wp-includes/pluggable.php:1782
-#: wp-includes/pluggable.php:1966
-msgid "In reply to: %s"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:242
-#: wp-admin/includes/class-wp-comments-list-table.php:793
-#: wp-admin/includes/class-wp-media-list-table.php:779
-#: wp-admin/includes/class-wp-media-list-table.php:841
-#: wp-admin/includes/class-wp-posts-list-table.php:1486
-#: wp-admin/includes/dashboard.php:785
-#: wp-admin/includes/media.php:1669
-msgid "Delete Permanently"
-msgstr ""
-
-#: wp-admin/edit-form-comment.php:245
-#: wp-admin/edit-tag-form.php:298
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:474
-#: wp-admin/includes/class-wp-plugins-list-table.php:608
-#: wp-admin/includes/class-wp-posts-list-table.php:2041
-#: wp-admin/includes/class-wp-posts-list-table.php:2043
-#: wp-admin/includes/class-wp-theme-install-list-table.php:318
-#: wp-admin/includes/class-wp-theme-install-list-table.php:477
-#: wp-admin/includes/meta-boxes.php:401
-#: wp-admin/includes/meta-boxes.php:402
-#: wp-admin/includes/meta-boxes.php:483
-#: wp-admin/includes/meta-boxes.php:484
-#: wp-admin/includes/template.php:662
-#: wp-admin/media.php:137
-#: wp-admin/media.php:157
-#: wp-includes/media.php:4581
-#: wp-includes/script-loader.php:1055
-#: wp-login.php:666
-#: wp-admin/js/post.js:798
-#: wp-admin/js/post.js:821
-msgid "Update"
-msgstr ""
-
-#. translators: %s: URL to Links screen.
-#: wp-admin/edit-link-form.php:16
-msgid "<a href=\"%s\">Links</a> / Edit Link"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:17
-#: wp-admin/includes/meta-boxes.php:1159
-msgid "Update Link"
-msgstr ""
-
-#. translators: %s: URL to Links screen.
-#: wp-admin/edit-link-form.php:22
-msgid "<a href=\"%s\">Links</a> / Add New Link"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:23
-#: wp-admin/includes/meta-boxes.php:1161
-#: wp-includes/class-wp-editor.php:1936
-#: wp-includes/script-loader.php:1056
-msgid "Add Link"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:31
-#: wp-admin/includes/class-wp-links-list-table.php:134
-#: wp-includes/category-template.php:560
-#: wp-includes/theme-compat/sidebar.php:129
-#: wp-includes/widgets/class-wp-widget-categories.php:31
-#: wp-includes/widgets/class-wp-widget-categories.php:48
-msgid "Categories"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-link-form.php:32
-#: wp-admin/includes/meta-boxes.php:1244
-#: wp-includes/class-wp-editor.php:1263
-msgid "Target"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:33
-#: wp-admin/includes/class-walker-nav-menu-edit.php:226
-#: wp-admin/includes/nav-menu.php:1128
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:119
-msgid "Link Relationship (XFN)"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:34
-#: wp-includes/class-wp-editor.php:1219
-msgid "Advanced"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:68
-msgid "You can add or edit links on this screen by entering information in each of the boxes. Only the link&#8217;s web address and name (the text you want to display on your site as the link) are required fields."
-msgstr ""
-
-#: wp-admin/edit-link-form.php:69
-msgid "The boxes for link name, web address, and description have fixed positions, while the others may be repositioned using drag and drop. You can also hide boxes you do not use in the Screen Options tab, or minimize boxes by clicking on the title bar of the box."
-msgstr ""
-
-#: wp-admin/edit-link-form.php:70
-msgid "XFN stands for <a href=\"https://gmpg.org/xfn/\">XHTML Friends Network</a>, which is optional. ClassicPress allows the generation of XFN attributes to show how you are related to the authors/owners of the site to which you are linking."
-msgstr ""
-
-#: wp-admin/edit-link-form.php:76
-msgid "<a href=\"https://codex.wordpress.org/Links_Add_New_Screen\">Documentation on Creating Links</a>"
-msgstr ""
-
-#. translators: Add new links.
-#: wp-admin/edit-link-form.php:90
-#: wp-admin/link-manager.php:104
-#: wp-admin/menu.php:83
-msgctxt "link"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:95
-msgid "Link added."
-msgstr ""
-
-#: wp-admin/edit-link-form.php:114
-#: wp-admin/includes/class-wp-links-list-table.php:132
-msgctxt "link name"
-msgid "Name"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:117
-msgid "Example: Nifty blogging software"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:122
-msgid "Web Address"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:125
-msgid "Example: <code>https://www.classicpress.net</code> &#8212; do not forget the <code>https://</code>"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:130
-#: wp-admin/edit-tag-form.php:203
-#: wp-admin/edit-tags.php:511
-#: wp-admin/includes/class-walker-nav-menu-edit.php:232
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:331
-#: wp-admin/includes/class-wp-plugins-list-table.php:462
-#: wp-admin/includes/class-wp-terms-list-table.php:193
-#: wp-admin/includes/media.php:1401
-#: wp-admin/includes/media.php:3198
-#: wp-admin/includes/nav-menu.php:1129
-#: wp-admin/themes.php:603
-#: wp-includes/class-wp-editor.php:1212
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:125
-#: wp-includes/media-template.php:533
-#: wp-includes/media-template.php:778
-msgid "Description"
-msgstr ""
-
-#: wp-admin/edit-link-form.php:133
-msgid "This will be shown when someone hovers over the link in the blogroll, or optionally below the link."
-msgstr ""
-
-#: wp-admin/edit-tag-form.php:147
-#: wp-admin/edit-tags.php:453
-#: wp-admin/includes/class-wp-terms-list-table.php:192
-#: wp-admin/includes/class-wp-terms-list-table.php:665
-msgctxt "term name"
-msgid "Name"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/edit-tag-form.php:152
-#: wp-admin/edit-tags.php:458
-#: wp-admin/includes/class-wp-posts-list-table.php:1645
-#: wp-admin/includes/class-wp-terms-list-table.php:194
-#: wp-admin/includes/class-wp-terms-list-table.php:670
-#: wp-admin/includes/meta-boxes.php:953
-#: wp-admin/includes/meta-boxes.php:1704
-msgid "Slug"
-msgstr ""
-
-#: wp-admin/edit-tag-form.php:186
-#: wp-admin/edit-tags.php:473
-#: wp-admin/includes/class-wp-debug-data.php:1080
-#: wp-admin/includes/media.php:1151
-#: wp-admin/includes/media.php:1279
-#: wp-admin/includes/media.php:2911
-#: wp-admin/includes/media.php:2927
-#: wp-includes/deprecated.php:706
-#: wp-includes/media-template.php:828
-#: wp-includes/media-template.php:855
-#: wp-includes/media-template.php:940
-#: wp-includes/media-template.php:1084
-#: wp-includes/media-template.php:1101
-#: wp-includes/media-template.php:1148
-#: wp-includes/media-template.php:1224
-#: wp-includes/media-template.php:1344
-#: wp-includes/media-template.php:1443
-#: wp-includes/script-loader.php:877
-msgid "None"
-msgstr ""
-
-#: wp-admin/edit-tag-form.php:195
-#: wp-admin/edit-tags.php:504
-msgid "Categories, unlike tags, can have a hierarchy. You might have a Jazz category, and under that have children categories for Bebop and Big Band. Totally optional."
-msgstr ""
-
-#: wp-admin/edit-tag-form.php:302
-#: wp-admin/includes/class-wp-links-list-table.php:87
-#: wp-admin/includes/class-wp-links-list-table.php:343
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:285
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:724
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:477
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:639
-#: wp-admin/includes/class-wp-ms-users-list-table.php:114
-#: wp-admin/includes/class-wp-ms-users-list-table.php:531
-#: wp-admin/includes/class-wp-plugins-list-table.php:612
-#: wp-admin/includes/class-wp-plugins-list-table.php:823
-#: wp-admin/includes/class-wp-plugins-list-table.php:884
-#: wp-admin/includes/class-wp-terms-list-table.php:169
-#: wp-admin/includes/class-wp-terms-list-table.php:493
-#: wp-admin/includes/class-wp-themes-list-table.php:232
-#: wp-admin/includes/class-wp-users-list-table.php:280
-#: wp-admin/includes/class-wp-users-list-table.php:481
-#: wp-admin/includes/media.php:1671
-#: wp-admin/includes/meta-boxes.php:1151
-#: wp-admin/includes/template.php:660
-#: wp-admin/includes/theme.php:1022
-#: wp-admin/includes/widgets.php:271
-#: wp-admin/themes.php:651
-#: wp-admin/themes.php:1171
-#: wp-admin/widgets-form.php:335
-msgid "Delete"
-msgstr ""
-
-#: wp-admin/edit-tags.php:13
-#: wp-admin/edit-tags.php:19
-#: wp-admin/includes/class-wp-terms-list-table.php:57
-#: wp-includes/class-wp-tax-query.php:549
-#: wp-includes/class-wp-tax-query.php:556
-#: wp-includes/class-wp-term.php:173
-#: wp-includes/class-wp-xmlrpc-server.php:2091
-#: wp-includes/class-wp-xmlrpc-server.php:2196
-#: wp-includes/class-wp-xmlrpc-server.php:2312
-#: wp-includes/class-wp-xmlrpc-server.php:2391
-#: wp-includes/class-wp-xmlrpc-server.php:2456
-#: wp-includes/class-wp-xmlrpc-server.php:2562
-#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:189
-#: wp-includes/taxonomy.php:532
-#: wp-includes/taxonomy.php:790
-#: wp-includes/taxonomy.php:891
-#: wp-includes/taxonomy.php:1083
-#: wp-includes/taxonomy.php:1253
-#: wp-includes/taxonomy.php:2168
-#: wp-includes/taxonomy.php:2310
-#: wp-includes/taxonomy.php:2699
-#: wp-includes/taxonomy.php:2886
-#: wp-includes/taxonomy.php:3097
-msgid "Invalid taxonomy."
-msgstr ""
-
-#: wp-admin/edit-tags.php:23
-#: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:194
-msgid "Sorry, you are not allowed to edit terms in this taxonomy."
-msgstr ""
-
-#: wp-admin/edit-tags.php:29
-#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:99
-#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:166
-msgid "Sorry, you are not allowed to manage terms in this taxonomy."
-msgstr ""
-
-#: wp-admin/edit-tags.php:86
-#: wp-includes/class-wp-xmlrpc-server.php:2097
-#: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:481
-msgid "Sorry, you are not allowed to create terms in this taxonomy."
-msgstr ""
-
-#: wp-admin/edit-tags.php:117
-#: wp-admin/edit.php:176
-#: wp-admin/post.php:319
-#: wp-admin/themes.php:63
-#: wp-admin/upload.php:283
-msgid "Sorry, you are not allowed to delete this item."
-msgstr ""
-
-#: wp-admin/edit-tags.php:137
-#: wp-admin/options.php:84
-msgid "Sorry, you are not allowed to delete these items."
-msgstr ""
-
-#: wp-admin/edit-tags.php:160
-#: wp-admin/edit-tags.php:180
-#: wp-admin/post.php:127
-#: wp-admin/term.php:31
-msgid "You attempted to edit an item that does not exist. Perhaps it was deleted?"
-msgstr ""
-
-#: wp-admin/edit-tags.php:173
-#: wp-admin/includes/class-wp-screen.php:288
-#: wp-admin/includes/post.php:2037
-#: wp-admin/media-upload.php:47
-#: wp-admin/post.php:20
-#: wp-admin/post.php:47
-#: wp-admin/post.php:139
-#: wp-admin/term.php:43
-msgid "Sorry, you are not allowed to edit this item."
-msgstr ""
-
-#. translators: %s: URL to Writing Settings screen.
-#: wp-admin/edit-tags.php:250
-msgid "You can use categories to define sections of your site and group related posts. The default category is &#8220;Uncategorized&#8221; until you change it in your <a href=\"%s\">writing settings</a>."
-msgstr ""
-
-#: wp-admin/edit-tags.php:254
-msgid "You can create groups of links by using Link Categories. Link Category names must be unique and Link Categories are separate from the categories you use for posts."
-msgstr ""
-
-#: wp-admin/edit-tags.php:256
-msgid "You can assign keywords to your posts using <strong>tags</strong>. Unlike categories, tags have no hierarchy, meaning there is no relationship from one tag to another."
-msgstr ""
-
-#: wp-admin/edit-tags.php:260
-msgid "You can delete Link Categories in the Bulk Action pull-down, but that action does not delete the links within the category. Instead, it moves them to the default Link Category."
-msgstr ""
-
-#: wp-admin/edit-tags.php:262
-msgid "What&#8217;s the difference between categories and tags? Normally, tags are ad-hoc keywords that identify important information in your post (names, subjects, etc) that may or may not recur in other posts, while categories are pre-determined sections. If you think of your site like a book, the categories are like the Table of Contents and the tags are like the terms in the index."
-msgstr ""
-
-#: wp-admin/edit-tags.php:275
-msgid "When adding a new category on this screen, you&#8217;ll fill in the following fields:"
-msgstr ""
-
-#: wp-admin/edit-tags.php:277
-msgid "When adding a new tag on this screen, you&#8217;ll fill in the following fields:"
-msgstr ""
-
-#: wp-admin/edit-tags.php:281
-msgid "<strong>Name</strong> &mdash; The name is how it appears on your site."
-msgstr ""
-
-#: wp-admin/edit-tags.php:283
-msgid "<strong>Slug</strong> &mdash; The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens."
-msgstr ""
-
-#: wp-admin/edit-tags.php:286
-msgid "<strong>Parent</strong> &mdash; Categories, unlike tags, can have a hierarchy. You might have a Jazz category, and under that have child categories for Bebop and Big Band. Totally optional. To create a subcategory, just choose another category from the Parent dropdown."
-msgstr ""
-
-#: wp-admin/edit-tags.php:289
-msgid "<strong>Description</strong> &mdash; The description is not prominent by default; however, some themes may display it."
-msgstr ""
-
-#: wp-admin/edit-tags.php:291
-msgid "You can change the display of this screen using the Screen Options tab to set how many items are displayed per screen and to display/hide columns in the table."
-msgstr ""
-
-#: wp-admin/edit-tags.php:296
-msgid "Adding Categories"
-msgstr ""
-
-#: wp-admin/edit-tags.php:296
-msgid "Adding Tags"
-msgstr ""
-
-#: wp-admin/edit-tags.php:305
-msgid "<a href=\"https://wordpress.org/documentation/article/posts-categories-screen/\">Documentation on Categories</a>"
-msgstr ""
-
-#: wp-admin/edit-tags.php:307
-msgid "<a href=\"https://codex.wordpress.org/Links_Link_Categories_Screen\">Documentation on Link Categories</a>"
-msgstr ""
-
-#: wp-admin/edit-tags.php:309
-msgid "<a href=\"https://wordpress.org/documentation/article/posts-tags-screen/\">Documentation on Tags</a>"
-msgstr ""
-
-#. translators: %s: Default category.
-#: wp-admin/edit-tags.php:621
-msgid "Deleting a category does not delete the posts in that category. Instead, posts that were only assigned to the deleted category are set to the default category %s. The default category cannot be deleted."
-msgstr ""
-
-#. translators: %s: URL to Categories to Tags Converter tool.
-#: wp-admin/edit-tags.php:632
-msgid "Categories can be selectively converted to tags using the <a href=\"%s\">category to tag converter</a>."
-msgstr ""
-
-#. translators: %s: URL to Categories to Tags Converter tool.
-#: wp-admin/edit-tags.php:645
-msgid "Tags can be selectively converted to categories using the <a href=\"%s\">tag to category converter</a>."
-msgstr ""
-
-#: wp-admin/edit.php:22
-#: wp-admin/edit.php:47
-#: wp-admin/post.php:135
-#: wp-includes/class-wp-xmlrpc-server.php:2003
-#: wp-includes/class-wp-xmlrpc-server.php:4567
-#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:95
-#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:157
-#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:161
-msgid "Sorry, you are not allowed to edit posts in this post type."
-msgstr ""
-
-#: wp-admin/edit.php:123
-#: wp-admin/post.php:253
-#: wp-admin/upload.php:247
-msgid "Sorry, you are not allowed to move this item to the Trash."
-msgstr ""
-
-#: wp-admin/edit.php:132
-#: wp-admin/post.php:264
-#: wp-admin/upload.php:251
-msgid "Error in moving the item to Trash."
-msgstr ""
-
-#: wp-admin/edit.php:156
-#: wp-admin/post.php:290
-#: wp-admin/upload.php:268
-msgid "Sorry, you are not allowed to restore this item from the Trash."
-msgstr ""
-
-#: wp-admin/edit.php:160
-#: wp-admin/post.php:294
-#: wp-admin/upload.php:272
-msgid "Error in restoring the item from Trash."
-msgstr ""
-
-#: wp-admin/edit.php:181
-#: wp-admin/post.php:325
-#: wp-admin/upload.php:287
-#: wp-includes/media.php:4619
-msgid "Error in deleting the attachment."
-msgstr ""
-
-#: wp-admin/edit.php:185
-#: wp-admin/post.php:329
-msgid "Error in deleting the item."
-msgstr ""
-
-#: wp-admin/edit.php:249
-msgid "This screen provides access to all of your posts. You can customize the display of this screen to suit your workflow."
-msgstr ""
-
-#: wp-admin/edit.php:255
-#: wp-admin/users.php:43
-msgid "Screen Content"
-msgstr ""
-
-#: wp-admin/edit.php:257
-msgid "You can customize the display of this screen&#8217;s contents in a number of ways:"
-msgstr ""
-
-#: wp-admin/edit.php:259
-msgid "You can hide/display columns based on your needs and decide how many posts to list per screen using the Screen Options tab."
-msgstr ""
-
-#: wp-admin/edit.php:260
-msgid "You can filter the list of posts by post status using the text links above the posts list to only show posts with that status. The default view is to show all posts."
-msgstr ""
-
-#: wp-admin/edit.php:261
-msgid "You can view posts in a simple title list or with an excerpt using the Screen Options tab."
-msgstr ""
-
-#: wp-admin/edit.php:262
-msgid "You can refine the list to show only posts in a specific category or from a specific month by using the dropdown menus above the posts list. Click the Filter button after making your selection. You also can refine the list by clicking on the post author, category or tag in the posts list."
-msgstr ""
-
-#: wp-admin/edit.php:269
-#: wp-admin/upload.php:329
-#: wp-admin/users.php:74
-msgid "Available Actions"
-msgstr ""
-
-#: wp-admin/edit.php:271
-msgid "Hovering over a row in the posts list will display action links that allow you to manage your post. You can perform the following actions:"
-msgstr ""
-
-#: wp-admin/edit.php:273
-msgid "<strong>Edit</strong> takes you to the editing screen for that post. You can also reach that screen by clicking on the post title."
-msgstr ""
-
-#: wp-admin/edit.php:274
-msgid "<strong>Quick Edit</strong> provides inline access to the metadata of your post, allowing you to update post details without leaving this screen."
-msgstr ""
-
-#: wp-admin/edit.php:275
-msgid "<strong>Trash</strong> removes your post from this list and places it in the Trash, from which you can permanently delete it."
-msgstr ""
-
-#: wp-admin/edit.php:276
-msgid "<strong>Preview</strong> will show you what your draft post will look like if you publish it. View will take you to your live site to view the post. Which link is available depends on your post&#8217;s status."
-msgstr ""
-
-#: wp-admin/edit.php:283
-#: wp-admin/includes/class-wp-list-table.php:568
-msgid "Bulk actions"
-msgstr ""
-
-#: wp-admin/edit.php:285
-msgid "You can also edit or move multiple posts to the Trash at once. Select the posts you want to act on using the checkboxes, then select the action you want to take from the Bulk actions menu and click Apply."
-msgstr ""
-
-#: wp-admin/edit.php:286
-msgid "When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the x next to its name in the Bulk Edit area that appears."
-msgstr ""
-
-#: wp-admin/edit.php:292
-msgid "<a href=\"https://wordpress.org/documentation/article/posts-screen/\">Documentation on Managing Posts</a>"
-msgstr ""
-
-#: wp-admin/edit.php:308
-msgid "Managing Pages"
-msgstr ""
-
-#: wp-admin/edit.php:310
-msgid "Managing pages is very similar to managing posts, and the screens can be customized in the same way."
-msgstr ""
-
-#: wp-admin/edit.php:311
-msgid "You can also perform the same types of actions, including narrowing the list by using the filters, acting on a page using the action links that appear when you hover over a row, or using the Bulk actions menu to edit the metadata for multiple pages at once."
-msgstr ""
-
-#: wp-admin/edit.php:317
-msgid "<a href=\"https://wordpress.org/documentation/article/pages-screen/\">Documentation on Managing Pages</a>"
-msgstr ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/edit.php:350
-msgid "%s post updated."
-msgid_plural "%s posts updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/edit.php:351
-msgid "1 post not updated, somebody is editing it."
-msgstr ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/edit.php:353
-msgid "%s post not updated, somebody is editing it."
-msgid_plural "%s posts not updated, somebody is editing them."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/edit.php:355
-msgid "%s post permanently deleted."
-msgid_plural "%s posts permanently deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/edit.php:357
-msgid "%s post moved to the Trash."
-msgid_plural "%s posts moved to the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/edit.php:359
-msgid "%s post restored from the Trash."
-msgid_plural "%s posts restored from the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/edit.php:363
-msgid "%s page updated."
-msgid_plural "%s pages updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/edit.php:364
-msgid "1 page not updated, somebody is editing it."
-msgstr ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/edit.php:366
-msgid "%s page not updated, somebody is editing it."
-msgid_plural "%s pages not updated, somebody is editing them."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/edit.php:368
-msgid "%s page permanently deleted."
-msgid_plural "%s pages permanently deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/edit.php:370
-msgid "%s page moved to the Trash."
-msgid_plural "%s pages moved to the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/edit.php:372
-msgid "%s page restored from the Trash."
-msgid_plural "%s pages restored from the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/erase-personal-data.php:13
-msgid "Sorry, you are not allowed to erase personal data on this site."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:17
-#: wp-admin/erase-personal-data.php:107
-#: wp-admin/menu.php:327
-#: wp-includes/user.php:4627
-msgid "Erase Personal Data"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:25
-msgid "This screen is where you manage requests to erase personal data."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:26
-msgid "Privacy Laws around the world require businesses and online services to delete, anonymize, or forget the data they collect about an individual. The rights those laws enshrine are sometimes called the \"Right to be Forgotten\"."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:27
-#: wp-admin/export-personal-data.php:27
-msgid "The tool associates data stored in ClassicPress with a supplied email address, including profile data and comments."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:28
-msgid "Note: As this tool only gathers data from ClassicPress and participating plugins, you may need to do more to comply with erasure requests. For example, you are also responsible for ensuring that data collected by or stored with the 3rd party services your organization uses gets deleted."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:35
-#: wp-admin/export-personal-data.php:35
-msgid "Default Data"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:37
-msgid "ClassicPress collects (but <em>never</em> publishes) a limited amount of data from logged-in users but then deletes it or anonymizes it. That data can include: "
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:38
-#: wp-admin/export-personal-data.php:38
-msgid "<strong>Profile Information</strong> &mdash; user email address, username, display name, nickname, first name, last name, description/bio, and registration date."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:39
-msgid "<strong>Community Events Location</strong> &mdash; The IP Address of the user which is used for the Upcoming Community Events shown in the dashboard widget."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:40
-#: wp-admin/export-personal-data.php:40
-msgid "<strong>Session Tokens</strong> &mdash; User login information, IP Addresses, Expiration Date, User Agent (Browser/OS), and Last Login."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:41
-msgid "<strong>Comments</strong> &mdash; ClassicPress does not delete comments. The software does anonymize (but, again, <em>never</em> publishes) the associated Email Address, IP Address, and User Agent (Browser/OS)."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:42
-msgid "<strong>Media</strong> &mdash; A list of URLs for all media file uploads made by the user."
-msgstr ""
-
-#. translators: %s: URL to Privacy Policy Guide screen.
-#: wp-admin/erase-personal-data.php:48
-msgid "If you are not sure, check the plugin documentation or contact the plugin author to see if the plugin collects data and if it supports the Data Eraser tool. This information may be available in the <a href=\"%s\">Privacy Policy Guide</a>."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:55
-#: wp-admin/export-personal-data.php:55
-msgid "Plugin Data"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:57
-msgid "Many plugins may collect or store personal data either in the ClassicPress database or remotely. Any Erase Personal Data request should delete data from plugins as well."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:58
-msgid "If you are a plugin author, you can <a href=\"https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-eraser-to-your-plugin/\" target=\"_blank\">learn more about how to add support for the Personal Data Eraser to a plugin here</a>."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:65
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-erase-personal-data-screen/\">Documentation on Erase Personal Data</a>"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:94
-msgid "Filter erase personal data list"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:95
-msgid "Erase personal data list navigation"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:96
-msgid "Erase personal data list"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:108
-msgid "This tool helps site owners comply with local laws and regulations by deleting or anonymizing known data for a given user."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:114
-msgid "Add Data Erasure Request"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:119
-#: wp-admin/export-personal-data.php:119
-msgid "Username or email address"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:127
-#: wp-admin/export-personal-data.php:127
-msgid "Confirmation email"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:132
-msgid "Send personal data erasure confirmation email."
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:138
-#: wp-admin/export-personal-data.php:138
-msgid "Send Request"
-msgstr ""
-
-#: wp-admin/erase-personal-data.php:150
-#: wp-admin/export-personal-data.php:150
-msgid "Search Requests"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:13
-msgid "Sorry, you are not allowed to export personal data on this site."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:17
-#: wp-admin/export-personal-data.php:107
-#: wp-admin/menu.php:326
-#: wp-includes/user.php:4624
-msgid "Export Personal Data"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:25
-msgid "This screen is where you manage requests for an export of personal data."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:26
-msgid "Privacy Laws around the world require businesses and online services to provide an export of some of the data they collect about an individual, and to deliver that export on request. The rights those laws enshrine are sometimes called the \"Right of Data Portability\". It allows individuals to obtain and reuse their personal data for their own purposes across different services. It allows them to move, copy or transfer personal data easily from one IT environment to another."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:28
-msgid "Note: Since this tool only gathers data from ClassicPress and participating plugins, you may need to do more to comply with export requests. For example, you should also send the requester some of the data collected from or stored with the 3rd party services your organization uses."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:37
-msgid "ClassicPress collects (but <em>never</em> publishes) a limited amount of data from registered users who have logged in to the site. Generally, these users are people who contribute to the site in some way -- content, store management, and so on. With rare exceptions, these users do not include occasional visitors who might have registered to comment on articles or buy products. The data ClassicPress retains can include:"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:39
-msgid "<strong>Community Events Location</strong> &mdash; The IP Address of the user, which populates the Upcoming Community Events dashboard widget with relevant information."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:41
-msgid "<strong>Comments</strong> &mdash; For user comments, Email Address, IP Address, User Agent (Browser/OS), Date/Time, Comment Content, and Content URL."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:42
-msgid "<strong>Media</strong> &mdash; A list of URLs for media files the user uploads."
-msgstr ""
-
-#. translators: %s: URL to Privacy Policy Guide screen.
-#: wp-admin/export-personal-data.php:48
-msgid "If you are not sure, check the plugin documentation or contact the plugin author to see if the plugin collects data and if it supports the Data Exporter tool. This information may be available in the <a href=\"%s\">Privacy Policy Guide</a>."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:57
-msgid "Many plugins may collect or store personal data either in the ClassicPress database or remotely. Any Export Personal Data request should include data from plugins as well."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:58
-msgid "Plugin authors can <a href=\"https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-exporter-to-your-plugin/\" target=\"_blank\">learn more about how to add the Personal Data Exporter to a plugin here</a>."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:65
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-export-personal-data-screen/\">Documentation on Export Personal Data</a>"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:94
-msgid "Filter export personal data list"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:95
-msgid "Export personal data list navigation"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:96
-msgid "Export personal data list"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:108
-msgid "This tool helps site owners comply with local laws and regulations by exporting known data for a given user in a .zip file."
-msgstr ""
-
-#: wp-admin/export-personal-data.php:114
-msgid "Add Data Export Request"
-msgstr ""
-
-#: wp-admin/export-personal-data.php:132
-msgid "Send personal data export confirmation email."
-msgstr ""
-
-#: wp-admin/export.php:13
-msgid "Sorry, you are not allowed to export the content of this site."
-msgstr ""
-
-#: wp-admin/export.php:20
-#: wp-admin/menu.php:323
-msgid "Export"
-msgstr ""
-
-#: wp-admin/export.php:52
-msgid "You can export a file of your site&#8217;s content in order to import it into another installation or platform. The export file will be an XML file format called WXR. Posts, pages, comments, custom fields, categories, and tags can be included. You can choose for the WXR file to include only certain posts or pages by setting the dropdown filters to limit the export by category, author, date range by month, or publishing status."
-msgstr ""
-
-#: wp-admin/export.php:53
-msgid "Once generated, your WXR file can be imported by another ClassicPress site or by another blogging platform able to access this format."
-msgstr ""
-
-#: wp-admin/export.php:59
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-export-screen/\">Documentation on Export</a>"
-msgstr ""
-
-#: wp-admin/export.php:173
-msgid "When you click the button below ClassicPress will create an XML file for you to save to your computer."
-msgstr ""
-
-#: wp-admin/export.php:174
-msgid "This format, which is called ClassicPress eXtended RSS or WXR, will contain your posts, pages, comments, custom fields, categories, and tags."
-msgstr ""
-
-#: wp-admin/export.php:175
-msgid "Once you&#8217;ve saved the download file, you can use the Import function in another ClassicPress installation to import the content from this site."
-msgstr ""
-
-#: wp-admin/export.php:177
-msgid "Choose what to export"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/export.php:183
-msgid "Content to export"
-msgstr ""
-
-#: wp-admin/export.php:187
-msgid "All content"
-msgstr ""
-
-#: wp-admin/export.php:188
-msgid "This will contain all of your posts, pages, comments, custom fields, terms, navigation menus, and custom posts."
-msgstr ""
-
-#: wp-admin/export.php:190
-#: wp-admin/includes/class-wp-users-list-table.php:377
-#: wp-includes/class-wp-post-type.php:800
-msgctxt "post type general name"
-msgid "Posts"
-msgstr ""
-
-#: wp-admin/export.php:193
-msgid "Categories:"
-msgstr ""
-
-#: wp-admin/export.php:194
-#: wp-admin/export.php:206
-#: wp-admin/export.php:236
-#: wp-admin/export.php:258
-#: wp-admin/export.php:288
-#: wp-admin/includes/class-wp-users-list-table.php:189
-msgid "All"
-msgstr ""
-
-#: wp-admin/export.php:198
-#: wp-admin/export.php:250
-msgid "Authors:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/export.php:218
-#: wp-admin/export.php:270
-#: wp-admin/export.php:315
-msgid "Date range:"
-msgstr ""
-
-#: wp-admin/export.php:221
-#: wp-admin/export.php:273
-#: wp-admin/export.php:318
-msgid "Start date:"
-msgstr ""
-
-#: wp-admin/export.php:223
-#: wp-admin/export.php:228
-#: wp-admin/export.php:275
-#: wp-admin/export.php:280
-#: wp-admin/export.php:320
-#: wp-admin/export.php:325
-#: wp-admin/includes/template.php:746
-#: wp-admin/nav-menus.php:902
-#: wp-admin/options-privacy.php:296
-#: wp-admin/options-reading.php:121
-#: wp-admin/options-reading.php:138
-#: wp-admin/privacy.php:220
-#: wp-admin/widgets-form.php:317
-#: wp-includes/class-wp-customize-control.php:590
-#: wp-includes/class-wp-customize-nav-menus.php:707
-#: wp-includes/widgets/class-wp-nav-menu-widget.php:172
-msgid "&mdash; Select &mdash;"
-msgstr ""
-
-#: wp-admin/export.php:226
-#: wp-admin/export.php:278
-#: wp-admin/export.php:323
-msgid "End date:"
-msgstr ""
-
-#: wp-admin/export.php:247
-#: wp-includes/post-template.php:1293
-#: wp-includes/theme-compat/sidebar.php:117
-#: wp-includes/widgets/class-wp-widget-pages.php:31
-#: wp-includes/widgets/class-wp-widget-pages.php:44
-msgid "Pages"
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/export.php:308
-#: wp-admin/includes/class-wp-privacy-policy-content.php:488
-#: wp-admin/includes/media.php:2515
-#: wp-admin/includes/plugin-install.php:380
-#: wp-admin/menu.php:66
-#: wp-admin/menu.php:340
-#: wp-includes/class-wp-editor.php:1233
-#: wp-includes/media.php:4575
-#: wp-includes/media.php:5141
-msgid "Media"
-msgstr ""
-
-#: wp-admin/export.php:342
-msgid "Download Export File"
-msgstr ""
-
-#: wp-admin/freedoms.php:66
-msgid "From time to time, your ClassicPress site may send anonymous data to ClassicPress.net. Some examples of the kinds of data that may be sent are the version of ClassicPress your site is running and a list of installed plugins and themes."
-msgstr ""
-
-#: wp-admin/freedoms.php:68
-msgid "We take privacy and transparency very seriously. To learn more about what data we collect, how we use it, and what precautions we take to ensure site owners&#8217; privacy, please see the <a href=\"%s\">ClassicPress Privacy Policy</a>."
-msgstr ""
-
-#: wp-admin/freedoms.php:73
-msgid "ClassicPress is Free and open source software, built by a distributed community of volunteer developers from around the world. ClassicPress comes with some awesome, worldview-changing rights courtesy of its <a href=\"%s\">license</a>, the GPL."
-msgstr ""
-
-#: wp-admin/freedoms.php:76
-msgid "You have the freedom to run the program, for any purpose. (freedom 0)"
-msgstr ""
-
-#: wp-admin/freedoms.php:77
-msgid "You have access to the source code, the freedom to study how the program works, and the freedom to change it to make it do what you wish. (freedom 1)"
-msgstr ""
-
-#: wp-admin/freedoms.php:78
-msgid "You have the freedom to redistribute copies of the original program so you can help your neighbor. (freedom 2)"
-msgstr ""
-
-#: wp-admin/freedoms.php:79
-msgid "You have the freedom to distribute copies of your modified versions to others. By doing this you can give the whole community a chance to benefit from your changes. (freedom 3)"
-msgstr ""
-
-#: wp-admin/freedoms.php:85
-#: wp-admin/includes/plugin-install.php:731
-#: wp-admin/plugin-install.php:98
-#: wp-admin/plugins.php:550
-msgid "https://wordpress.org/plugins/"
-msgstr ""
-
-#: wp-admin/freedoms.php:86
-#: wp-admin/theme-install.php:111
-#: wp-admin/themes.php:157
-msgid "https://wordpress.org/themes/"
-msgstr ""
-
-#: wp-admin/freedoms.php:89
-msgid "Every plugin and theme in ClassicPress.net&#8217;s directory is 100%% GPL or a similarly free and compatible license, so you can feel safe finding <a href=\"%1$s\">plugins</a> and <a href=\"%2$s\">themes</a> there. If you get a plugin or theme from another source, make sure to ask them if it&#8217;s <a href=\"%3$s\">GPL</a> first. If they don&#8217;t respect the ClassicPress license, we don&#8217;t recommend them."
-msgstr ""
-
-#: wp-admin/freedoms.php:93
-msgid "Don&#8217;t you wish all software came with these freedoms? So do we! For more information, check out the <a href=\"https://www.fsf.org/\">Free Software Foundation</a>."
-msgstr ""
-
-#: wp-admin/import.php:25
-msgid "This screen lists links to plugins to import data from blogging/content management platforms. Choose the platform you want to import from, and click Install Now when you are prompted in the popup window. If your platform is not listed, click the link to search the plugin directory for other importer plugins to see if there is one for your platform."
-msgstr ""
-
-#: wp-admin/import.php:26
-msgid "In previous versions of ClassicPress, all importers were built-in. They have been turned into plugins since most people only use them once or infrequently."
-msgstr ""
-
-#: wp-admin/import.php:32
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-import-screen/\">Documentation on Import</a>"
-msgstr ""
-
-#: wp-admin/import.php:33
-msgid "<a href=\"https://wordpress.org/support/forums\">Support</a>"
-msgstr ""
-
-#: wp-admin/import.php:65
-#: wp-admin/includes/network.php:116
-#: wp-admin/themes.php:305
-#: wp-admin/users.php:329
-msgid "Error:"
-msgstr ""
-
-#. translators: %s: Importer slug.
-#: wp-admin/import.php:68
-msgid "The %s importer is invalid or is not installed."
-msgstr ""
-
-#: wp-admin/import.php:73
-msgid "If you have posts or comments in another system, ClassicPress can import those into this site. To get started, choose a system to import from below:"
-msgstr ""
-
-#: wp-admin/import.php:96
-msgid "No importers are available."
-msgstr ""
-
-#. translators: %s: Importer name.
-#: wp-admin/import.php:132
-#: wp-admin/import.php:181
-#: wp-admin/js/updates.js:861
-msgid "Run %s"
-msgstr ""
-
-#: wp-admin/import.php:133
-#: wp-admin/import.php:182
-#: wp-admin/js/updates.js:865
-msgid "Run Importer"
-msgstr ""
-
-#. translators: %s: Importer name.
-#. translators: %s: Plugin name and version.
-#. translators: %s: Plugin name.
-#: wp-admin/import.php:159
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:524
-#: wp-admin/js/updates.js:912
-#: wp-admin/js/updates.js:2147
-#: wp-admin/js/updates.js:2270
-msgctxt "plugin"
-msgid "Install %s now"
-msgstr ""
-
-#: wp-admin/import.php:160
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:526
-#: wp-admin/includes/class-wp-theme-install-list-table.php:336
-#: wp-admin/includes/plugin-install.php:339
-#: wp-admin/includes/plugin-install.php:891
-#: wp-admin/includes/theme-install.php:207
-#: wp-admin/press-this.php:63
-#: wp-admin/js/updates.js:916
-#: wp-admin/js/updates.js:2231
-#: wp-admin/js/updates.js:2274
-msgid "Install Now"
-msgstr ""
-
-#. translators: %s: URL to Import screen on the main site.
-#: wp-admin/import.php:165
-msgid "This importer is not installed. Please install importers from <a href=\"%s\">the main site</a>."
-msgstr ""
-
-#. translators: %s: Importer name.
-#. translators: %s: Plugin name and version.
-#. translators: %s: Plugin name.
-#: wp-admin/import.php:204
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:618
-#: wp-admin/includes/class-wp-plugins-list-table.php:1074
-msgid "More information about %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/import.php:205
-#: wp-admin/includes/class-wp-theme-install-list-table.php:379
-#: wp-admin/includes/class-wp-themes-list-table.php:270
-#: wp-includes/media-template.php:430
-msgid "Details"
-msgstr ""
-
-#. translators: %s: URL to Add Plugins screen.
-#: wp-admin/import.php:228
-msgid "If the importer you need is not listed, <a href=\"%s\">search the plugin directory</a> to see if an importer is available."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:124
-#: wp-admin/includes/meta-boxes.php:574
-#: wp-admin/includes/post.php:562
-#: wp-admin/includes/post.php:2140
-#: wp-includes/post.php:5014
-#: wp-admin/js/inline-edit-post.js:504
-#: wp-admin/js/tags-box.js:9
-msgctxt "tag delimiter"
-msgid ","
-msgstr ""
-
-#. translators: 1: User login, 2: User email address.
-#: wp-admin/includes/ajax-actions.php:336
-msgctxt "user autocomplete result"
-msgid "%1$s (%2$s)"
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/ajax-actions.php:424
-#: wp-admin/includes/ajax-actions.php:1367
-#: wp-admin/includes/dashboard.php:342
-#: wp-includes/comment-template.php:937
-#: wp-includes/comment-template.php:952
-msgid "%s Comment"
-msgid_plural "%s Comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#. translators: Hidden accessibility text. %s: Number of comments.
-#: wp-admin/includes/ajax-actions.php:429
-#: wp-admin/includes/ajax-actions.php:500
-#: wp-admin/includes/ajax-actions.php:1372
-#: wp-admin/includes/dashboard.php:350
-#: wp-admin/menu.php:94
-#: wp-includes/admin-bar.php:942
-msgid "%s Comment in moderation"
-msgid_plural "%s Comments in moderation"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#. translators: %s: Number of items.
-#. translators: Number of items.
-#. translators: %s: Number of items (tags).
-#. translators: %s: The remaining number of plugins.
-#: wp-admin/includes/ajax-actions.php:492
-#: wp-admin/includes/class-wp-list-table.php:989
-#: wp-admin/includes/class-wp-list-table.php:1620
-#: wp-includes/category-template.php:878
-#: wp-includes/category-template.php:889
-#: wp-admin/js/updates.js:1070
-msgid "%s item"
-msgid_plural "%s items"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %d: Comment ID.
-#: wp-admin/includes/ajax-actions.php:919
-msgid "Comment %d does not exist"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1036
-#: wp-admin/includes/ajax-actions.php:2301
-#: wp-includes/class-wp-customize-widgets.php:783
-#: wp-admin/js/media.js:127
-#: wp-admin/js/media.js:132
-#: wp-admin/js/updates.js:1949
-msgid "An error has occurred. Please reload the page and try again."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1255
-msgid "You cannot reply to a comment on a draft post."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1279
-msgid "Sorry, you must be logged in to reply to a comment."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1285
-#: wp-admin/includes/ajax-actions.php:1402
-msgid "Please type your comment text."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1502
-msgid "Menu Item"
-msgstr ""
-
-#. translators: 1: Post creation date, 2: Post creation time.
-#: wp-admin/includes/ajax-actions.php:1559
-msgid "Draft created on %1$s at %2$s"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1576
-#: wp-admin/includes/ajax-actions.php:1584
-msgid "Please provide a custom field value."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1607
-msgid "Please provide a custom field name."
-msgstr ""
-
-#. translators: %s: The new user.
-#: wp-admin/includes/ajax-actions.php:1697
-msgid "User %s added"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1989
-#: wp-admin/includes/post.php:272
-#: wp-includes/class-wp-xmlrpc-server.php:2981
-#: wp-includes/class-wp-xmlrpc-server.php:3197
-msgid "Sorry, you are not allowed to edit this page."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:1993
-#: wp-admin/includes/media.php:3741
-#: wp-admin/includes/post.php:274
-#: wp-admin/includes/post.php:1964
-#: wp-admin/includes/post.php:1968
-#: wp-includes/class-wp-xmlrpc-server.php:1450
-#: wp-includes/class-wp-xmlrpc-server.php:1937
-#: wp-includes/class-wp-xmlrpc-server.php:4776
-#: wp-includes/class-wp-xmlrpc-server.php:4960
-#: wp-includes/class-wp-xmlrpc-server.php:5199
-#: wp-includes/class-wp-xmlrpc-server.php:5738
-#: wp-includes/class-wp-xmlrpc-server.php:6058
-#: wp-includes/class-wp-xmlrpc-server.php:6431
-#: wp-includes/class-wp-xmlrpc-server.php:6620
-#: wp-includes/class-wp-xmlrpc-server.php:6678
-#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:489
-#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:804
-msgid "Sorry, you are not allowed to edit this post."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2000
-msgid "Someone"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/ajax-actions.php:2003
-msgid "Saving is disabled: %s is currently editing this post."
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/ajax-actions.php:2007
-msgid "Saving is disabled: %s is currently editing this page."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2126
-#: wp-admin/includes/ajax-actions.php:2132
-#: wp-admin/includes/edit-tag-messages.php:18
-msgid "Item not updated."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2176
-#: wp-admin/includes/ajax-actions.php:3841
-#: wp-admin/includes/class-wp-list-table.php:339
-#: wp-admin/includes/class-wp-themes-list-table.php:92
-#: wp-includes/media-template.php:1518
-#: wp-includes/media.php:4606
-msgid "No items found."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2179
-#: wp-admin/includes/class-wp-posts-list-table.php:1638
-#: wp-admin/includes/dashboard.php:592
-#: wp-admin/includes/media.php:1391
-#: wp-admin/includes/media.php:2569
-#: wp-admin/includes/media.php:2892
-#: wp-includes/class-wp-editor.php:1209
-#: wp-includes/media-template.php:511
-#: wp-includes/media-template.php:756
-#: wp-includes/revision.php:32
-msgid "Title"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2179
-msgid "Type"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2179
-#: wp-admin/includes/class-wp-posts-list-table.php:717
-#: wp-admin/includes/class-wp-posts-list-table.php:1657
-#: wp-includes/customize/class-wp-customize-date-time-control.php:127
-msgid "Date"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2179
-#: wp-admin/includes/class-wp-posts-list-table.php:1937
-#: wp-admin/includes/class-wp-privacy-requests-table.php:44
-msgid "Status"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2182
-#: wp-admin/includes/media.php:3262
-#: wp-admin/includes/revision.php:59
-#: wp-admin/includes/revision.php:62
-#: wp-admin/includes/template.php:1973
-#: wp-includes/media.php:4173
-#: wp-includes/script-loader.php:1057
-#: wp-includes/widgets/class-wp-widget-recent-posts.php:107
-#: wp-admin/js/inline-edit-post.js:356
-msgid "(no title)"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2188
-#: wp-admin/includes/class-wp-posts-list-table.php:1180
-#: wp-admin/includes/class-wp-posts-list-table.php:1944
-#: wp-admin/includes/meta-boxes.php:112
-#: wp-admin/includes/meta-boxes.php:152
-#: wp-includes/post.php:939
-#: wp-includes/post.php:959
-#: wp-includes/script-loader.php:1090
-#: wp-admin/js/post.js:836
-msgid "Published"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2191
-#: wp-admin/includes/class-wp-posts-list-table.php:1185
-#: wp-admin/includes/class-wp-posts-list-table.php:1945
-#: wp-admin/includes/meta-boxes.php:115
-#: wp-admin/includes/meta-boxes.php:156
-msgid "Scheduled"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2194
-#: wp-admin/includes/class-wp-posts-list-table.php:1951
-#: wp-admin/includes/meta-boxes.php:118
-#: wp-admin/includes/meta-boxes.php:158
-#: wp-includes/post.php:937
-msgid "Pending Review"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2197
-#: wp-admin/includes/class-wp-posts-list-table.php:1952
-#: wp-admin/includes/meta-boxes.php:122
-#: wp-admin/includes/meta-boxes.php:160
-#: wp-admin/includes/meta-boxes.php:162
-#: wp-includes/post.php:936
-#: wp-includes/post.php:957
-msgid "Draft"
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2430
-msgid "Upload failed. Please reload and try again."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2466
-#: wp-includes/script-loader.php:796
-msgid "Upload failed."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2509
-msgid "Sorry, you are not allowed to attach files to this post."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:2536
-#: wp-admin/includes/class-custom-background.php:525
-#: wp-admin/includes/class-custom-image-header.php:963
-msgid "The uploaded file is not a valid image. Please try again."
-msgstr ""
-
-#. translators: %s: URL that could not be embedded.
-#: wp-admin/includes/ajax-actions.php:3733
-msgid "%s failed to embed."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:3767
-msgid "This preview is unavailable in the editor."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:3896
-msgid "Could not log out user sessions. Please try again."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:3905
-msgid "You are now logged out everywhere else."
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/ajax-actions.php:3909
-msgid "%s has been logged out."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:3934
-msgid "Image could not be processed."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4110
-#: wp-admin/includes/ajax-actions.php:4235
-#: wp-admin/includes/ajax-actions.php:4330
-msgid "No theme specified."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4123
-#: wp-admin/theme-install.php:16
-#: wp-admin/update.php:286
-#: wp-admin/update.php:328
-#: wp-admin/update.php:366
-msgid "Sorry, you are not allowed to install themes on this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4166
-#: wp-admin/includes/ajax-actions.php:4298
-#: wp-admin/includes/ajax-actions.php:4362
-#: wp-admin/includes/ajax-actions.php:4462
-#: wp-admin/includes/ajax-actions.php:4589
-#: wp-admin/includes/ajax-actions.php:4658
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:349
-msgid "Unable to connect to the filesystem. Please confirm your credentials."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4249
-#: wp-admin/update.php:235
-#: wp-admin/update.php:258
-msgid "Sorry, you are not allowed to update themes for this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4309
-#: wp-admin/includes/class-theme-upgrader.php:63
-#: wp-admin/includes/class-theme-upgrader.php:100
-msgid "Theme update failed."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4342
-msgid "Sorry, you are not allowed to delete themes on this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4347
-#: wp-admin/includes/file.php:440
-#: wp-admin/includes/file.php:450
-#: wp-admin/theme-editor.php:70
-#: wp-admin/theme-editor.php:74
-#: wp-admin/themes.php:28
-#: wp-admin/themes.php:71
-#: wp-includes/class-wp-customize-manager.php:581
-msgid "The requested theme does not exist."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4380
-msgid "Theme could not be deleted."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4404
-#: wp-admin/includes/ajax-actions.php:4513
-#: wp-admin/includes/ajax-actions.php:4621
-msgid "No plugin specified."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4415
-#: wp-admin/plugin-install.php:19
-#: wp-admin/update.php:107
-#: wp-admin/update.php:176
-#: wp-admin/update.php:214
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:245
-msgid "Sorry, you are not allowed to install plugins on this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4528
-#: wp-admin/update.php:29
-#: wp-admin/update.php:57
-#: wp-admin/update.php:80
-msgid "Sorry, you are not allowed to update plugins for this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4600
-#: wp-admin/includes/class-plugin-upgrader.php:64
-#: wp-admin/includes/class-plugin-upgrader.php:91
-msgid "Plugin update failed."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4634
-#: wp-admin/plugins.php:269
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:507
-msgid "Sorry, you are not allowed to delete plugins for this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4643
-#: wp-admin/plugins.php:623
-msgid "You cannot delete a plugin while it is active on the main site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4674
-msgid "Plugin could not be deleted."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4710
-#: wp-admin/includes/ajax-actions.php:4762
-#: wp-admin/plugins.php:13
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:116
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:166
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:429
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:499
-msgid "Sorry, you are not allowed to manage plugins for this site."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4811
-#: wp-admin/plugin-editor.php:187
-#: wp-admin/theme-editor.php:194
-msgid "File edited successfully."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4825
-#: wp-admin/includes/ajax-actions.php:5015
-#: wp-login.php:1159
-msgid "Missing request ID."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4831
-#: wp-admin/includes/ajax-actions.php:5021
-msgid "Invalid request ID."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4835
-#: wp-admin/includes/ajax-actions.php:5026
-msgid "Sorry, you are not allowed to perform this action."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4844
-#: wp-admin/includes/ajax-actions.php:5035
-msgid "Invalid request type."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4849
-msgid "A valid email address must be given."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4853
-msgid "Missing exporter index."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4859
-#: wp-admin/includes/ajax-actions.php:5051
-msgid "Missing page index."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4888
-msgid "An exporter has improperly used the registration filter."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4894
-msgid "Exporter index cannot be negative."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4898
-msgid "Exporter index is out of range."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:4902
-#: wp-admin/includes/ajax-actions.php:5090
-msgid "Page index cannot be less than one."
-msgstr ""
-
-#. translators: %s: Exporter array index.
-#: wp-admin/includes/ajax-actions.php:4912
-msgid "Expected an array describing the exporter at index %s."
-msgstr ""
-
-#. translators: %s: Exporter array index.
-#: wp-admin/includes/ajax-actions.php:4919
-msgid "Exporter array at index %s does not include a friendly name."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4928
-msgid "Exporter does not include a callback: %s."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4935
-msgid "Exporter callback is not a valid callback: %s."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4949
-msgid "Expected response as an array from exporter: %s."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4956
-msgid "Expected data in response array from exporter: %s."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4963
-msgid "Expected data array in response array from exporter: %s."
-msgstr ""
-
-#. translators: %s: Exporter friendly name.
-#: wp-admin/includes/ajax-actions.php:4970
-msgid "Expected done (boolean) in response array from exporter: %s."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5041
-msgid "Invalid email address in request."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5045
-msgid "Missing eraser index."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5082
-msgid "Eraser index cannot be less than one."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5086
-msgid "Eraser index is out of range."
-msgstr ""
-
-#. translators: %d: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5099
-msgid "Expected an array describing the eraser at index %d."
-msgstr ""
-
-#. translators: %d: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5104
-msgid "Eraser array at index %d does not include a friendly name."
-msgstr ""
-
-#. translators: %s: Eraser friendly name.
-#: wp-admin/includes/ajax-actions.php:5113
-msgid "Eraser does not include a callback: %s."
-msgstr ""
-
-#. translators: %s: Eraser friendly name.
-#: wp-admin/includes/ajax-actions.php:5123
-msgid "Eraser callback is not valid: %s."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5140
-msgid "Did not receive array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5151
-msgid "Expected items_removed key in response array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5162
-msgid "Expected items_retained key in response array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5173
-msgid "Expected messages key in response array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5184
-msgid "Expected messages key to reference an array in response array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: Eraser friendly name, 2: Eraser array index.
-#: wp-admin/includes/ajax-actions.php:5195
-msgid "Expected done flag in response array from %1$s eraser (index %2$d)."
-msgstr ""
-
-#. translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
-#: wp-admin/includes/ajax-actions.php:5248
-#: wp-admin/includes/ajax-actions.php:5281
-#: wp-admin/includes/ajax-actions.php:5314
-#: wp-admin/includes/ajax-actions.php:5364
-msgid "The Site Health check for %1$s has been replaced with %2$s."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5436
-msgid "Invalid data. No selected item."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5442
-msgid "Invalid data. Unknown state."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5447
-#: wp-admin/includes/ajax-actions.php:5472
-msgid "Invalid data. Unknown type."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5454
-msgid "Sorry, you are not allowed to modify plugins."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5464
-msgid "Sorry, you are not allowed to modify themes."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5476
-msgid "Invalid data. The item does not exist."
-msgstr ""
-
-#: wp-admin/includes/ajax-actions.php:5510
-msgid "Cannot send password reset, permission denied."
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/ajax-actions.php:5520
-msgid "A password reset link was emailed to %s."
-msgstr ""
-
-#: wp-admin/includes/bookmark.php:32
-#: wp-admin/includes/bookmark.php:379
-#: wp-admin/link-manager.php:12
-#: wp-admin/link-manager.php:92
-msgid "Sorry, you are not allowed to edit the links for this site."
-msgstr ""
-
-#: wp-admin/includes/bookmark.php:228
-msgid "Could not update link in the database."
-msgstr ""
-
-#: wp-admin/includes/bookmark.php:236
-msgid "Could not insert link into the database."
-msgstr ""
-
-#. translators: %s: A link to install the Link Manager plugin.
-#: wp-admin/includes/bookmark.php:356
-msgid "If you are looking to use the link manager, please install the <a href=\"%s\">Link Manager plugin</a>."
-msgstr ""
-
-#. translators: %s: A link to activate the Link Manager plugin.
-#: wp-admin/includes/bookmark.php:371
-msgid "Please activate the <a href=\"%s\">Link Manager plugin</a> to use the link manager."
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Number of the plugin, 3: Total number of plugins being updated.
-#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:33
-msgid "Updating Plugin %1$s (%2$d/%3$d)"
-msgstr ""
-
-#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:60
-#: wp-admin/includes/class-plugin-installer-skin.php:151
-#: wp-admin/includes/class-plugin-upgrader-skin.php:101
-msgid "Go to Plugins page"
-msgstr ""
-
-#: wp-admin/includes/class-bulk-plugin-upgrader-skin.php:65
-#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:66
-#: wp-admin/includes/class-language-pack-upgrader-skin.php:80
-msgid "Go to ClassicPress Updates page"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Number of the theme, 3: Total number of themes being updated.
-#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:34
-msgid "Updating Theme %1$s (%2$d/%3$d)"
-msgstr ""
-
-#: wp-admin/includes/class-bulk-theme-upgrader-skin.php:61
-#: wp-admin/includes/class-theme-installer-skin.php:164
-#: wp-admin/includes/class-theme-upgrader-skin.php:127
-msgid "Go to Themes page"
-msgstr ""
-
-#: wp-admin/includes/class-bulk-upgrader-skin.php:41
-msgid "The update process is starting. This process may take a while on some hosts, so please be patient."
-msgstr ""
-
-#. translators: 1: Title of an update, 2: Error message.
-#: wp-admin/includes/class-bulk-upgrader-skin.php:43
-msgid "An error occurred while updating %1$s: %2$s"
-msgstr ""
-
-#. translators: %s: Title of an update.
-#: wp-admin/includes/class-bulk-upgrader-skin.php:45
-msgid "The update of %s failed."
-msgstr ""
-
-#. translators: %s: Title of an update.
-#: wp-admin/includes/class-bulk-upgrader-skin.php:47
-msgid "%s updated successfully."
-msgstr ""
-
-#: wp-admin/includes/class-bulk-upgrader-skin.php:48
-msgid "All updates have been completed."
-msgstr ""
-
-#: wp-admin/includes/class-bulk-upgrader-skin.php:157
-msgid "Show details."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:29
-msgid "ClassicPress is at the latest version."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:30
-msgid "Another update is currently in progress."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:31
-#: wp-admin/includes/class-language-pack-upgrader.php:115
-#: wp-admin/includes/class-plugin-upgrader.php:58
-#: wp-admin/includes/class-theme-upgrader.php:57
-msgid "Update package not available."
-msgstr ""
-
-#. translators: %s: Package URL.
-#: wp-admin/includes/class-core-upgrader.php:33
-#: wp-admin/includes/class-plugin-upgrader.php:60
-#: wp-admin/includes/class-theme-upgrader.php:59
-msgid "Downloading update from %s&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:34
-#: wp-admin/includes/class-language-pack-upgrader.php:118
-#: wp-admin/includes/class-plugin-upgrader.php:61
-#: wp-admin/includes/class-theme-upgrader.php:60
-msgid "Unpacking the update&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:35
-msgid "Could not copy files."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:36
-#: wp-admin/includes/file.php:1681
-#: wp-admin/includes/file.php:1822
-msgid "Could not copy files. You may have run out of disk space."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:37
-msgid "Attempting to roll back to previous version."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:38
-msgid "Due to an error during updating, ClassicPress has rolled back to your previous version."
-msgstr ""
-
-#: wp-admin/includes/class-core-upgrader.php:199
-#: wp-admin/includes/class-wp-upgrader.php:166
-#: wp-admin/includes/update-core.php:313
-msgid "The update cannot be installed because some files could not be copied. This is usually due to inconsistent file permissions."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:66
-#: wp-admin/menu.php:220
-#: wp-includes/admin-bar.php:1016
-msgid "Background"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:91
-msgid "You can customize the look of your site without touching any of your theme&#8217;s code by using a custom background. Your background can be an image or a color."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:92
-msgid "To use a background image, simply upload it or choose an image that has already been uploaded to your Media Library by clicking the &#8220;Choose Image&#8221; button. You can display a single instance of your image, or tile it to fill the screen. You can have your background fixed in place, so your site content moves on top of it, or you can have it scroll with your site."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:93
-msgid "You can also choose a background color by clicking the Select Color button and either typing in a legitimate HTML hex value, e.g. &#8220;#ff0000&#8221; for red, or by choosing a color using the color picker."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:94
-msgid "Do not forget to click on the Save Changes button when you are finished."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:100
-msgid "<a href=\"https://codex.wordpress.org/Appearance_Background_Screen\">Documentation on Custom Background</a>"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:101
-#: wp-admin/update-core.php:868
-msgid "<a href=\"https://forums.classicpress.net/c/support\">Support Forums</a>"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:233
-#: wp-admin/includes/theme.php:320
-msgid "Custom Background"
-msgstr ""
-
-#. translators: %s: URL to background image configuration in Customizer.
-#: wp-admin/includes/class-custom-background.php:241
-msgid "You can now manage and live-preview Custom Backgrounds in the <a href=\"%s\">Customizer</a>."
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-custom-background.php:254
-msgid "Background updated. <a href=\"%s\">Visit your site</a> to see how it looks."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:260
-#: wp-admin/includes/template.php:2318
-#: wp-includes/class-wp-customize-manager.php:5459
-#: wp-includes/customize/class-wp-customize-background-image-control.php:40
-msgid "Background Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:306
-#: wp-admin/includes/class-custom-image-header.php:714
-msgid "Remove Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:310
-msgid "Remove Background Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:311
-msgid "This will remove the background image. You will not be able to restore any customizations."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:320
-#: wp-admin/includes/class-custom-background.php:324
-msgid "Restore Original Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:325
-msgid "This will restore the original background image. You will not be able to restore any customizations."
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:333
-#: wp-admin/includes/class-custom-image-header.php:578
-msgid "Select Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:336
-#: wp-admin/includes/class-custom-image-header.php:648
-msgid "Choose an image from your computer:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:340
-#: wp-admin/includes/class-custom-image-header.php:652
-#: wp-admin/includes/class-wp-theme-install-list-table.php:62
-#: wp-admin/includes/media.php:2206
-#: wp-admin/includes/media.php:2210
-msgid "Upload"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:343
-#: wp-admin/includes/class-custom-image-header.php:665
-msgid "Or choose an image from your media library:"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:345
-msgid "Choose a Background Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:346
-msgid "Set as background"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:346
-#: wp-admin/includes/class-custom-image-header.php:669
-#: wp-admin/options-general.php:322
-msgid "Choose Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:355
-msgid "Display Options"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:372
-#: wp-includes/customize/class-wp-customize-background-position-control.php:43
-msgid "Top Left"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:376
-#: wp-includes/class-wp-editor.php:1339
-#: wp-includes/customize/class-wp-customize-background-position-control.php:47
-msgid "Top"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:380
-#: wp-includes/customize/class-wp-customize-background-position-control.php:51
-msgid "Top Right"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:386
-#: wp-admin/includes/media.php:1152
-#: wp-admin/includes/media.php:2913
-#: wp-includes/class-wp-editor.php:1334
-#: wp-includes/customize/class-wp-customize-background-position-control.php:57
-#: wp-includes/media-template.php:819
-#: wp-includes/media-template.php:1075
-#: wp-includes/media-template.php:1139
-msgid "Left"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:390
-#: wp-admin/includes/continents-cities.php:185
-#: wp-admin/includes/media.php:1153
-#: wp-admin/includes/media.php:2915
-#: wp-includes/class-wp-editor.php:1335
-#: wp-includes/customize/class-wp-customize-background-position-control.php:61
-#: wp-includes/media-template.php:822
-#: wp-includes/media-template.php:1078
-#: wp-includes/media-template.php:1142
-msgid "Center"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:394
-#: wp-admin/includes/media.php:1154
-#: wp-admin/includes/media.php:2917
-#: wp-includes/class-wp-editor.php:1336
-#: wp-includes/customize/class-wp-customize-background-position-control.php:65
-#: wp-includes/media-template.php:825
-#: wp-includes/media-template.php:1081
-#: wp-includes/media-template.php:1145
-msgid "Right"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:400
-#: wp-includes/customize/class-wp-customize-background-position-control.php:71
-msgid "Bottom Left"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:404
-#: wp-includes/class-wp-editor.php:1341
-#: wp-includes/customize/class-wp-customize-background-position-control.php:75
-msgid "Bottom"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:408
-#: wp-includes/customize/class-wp-customize-background-position-control.php:79
-msgid "Bottom Right"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:415
-#: wp-admin/includes/class-custom-background.php:419
-#: wp-includes/class-wp-customize-manager.php:5535
-#: wp-includes/customize/class-wp-customize-background-position-control.php:96
-msgid "Image Position"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:439
-#: wp-admin/includes/class-custom-background.php:443
-#: wp-includes/class-wp-customize-manager.php:5557
-msgid "Image Size"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:447
-#: wp-includes/class-wp-customize-manager.php:5561
-msgctxt "Original Size"
-msgid "Original"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:448
-#: wp-includes/class-wp-customize-manager.php:5505
-#: wp-includes/class-wp-customize-manager.php:5562
-msgid "Fit to Screen"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:449
-#: wp-includes/class-wp-customize-manager.php:5504
-#: wp-includes/class-wp-customize-manager.php:5563
-msgid "Fill Screen"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:455
-#: wp-admin/includes/class-custom-background.php:459
-msgctxt "Background Repeat"
-msgid "Repeat"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:463
-#: wp-includes/class-wp-customize-manager.php:5580
-msgid "Repeat Background Image"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:468
-#: wp-admin/includes/class-custom-background.php:472
-msgctxt "Background Scroll"
-msgid "Scroll"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:476
-#: wp-includes/class-wp-customize-manager.php:5598
-msgid "Scroll with Page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-custom-background.php:481
-#: wp-admin/includes/class-custom-background.php:485
-#: wp-includes/class-wp-customize-manager.php:5313
-msgid "Background Color"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:630
-#: wp-admin/includes/image-edit.php:288
-#: wp-admin/includes/media.php:1194
-#: wp-includes/media-template.php:897
-#: wp-includes/media-template.php:977
-#: wp-includes/media-template.php:1168
-#: wp-includes/media.php:4213
-msgid "Thumbnail"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:631
-#: wp-admin/includes/media.php:1195
-#: wp-includes/media-template.php:898
-#: wp-includes/media-template.php:978
-#: wp-includes/media-template.php:1169
-#: wp-includes/media.php:4214
-msgid "Medium"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:632
-#: wp-admin/includes/media.php:1196
-#: wp-includes/media-template.php:899
-#: wp-includes/media-template.php:979
-#: wp-includes/media-template.php:1170
-#: wp-includes/media.php:4215
-msgid "Large"
-msgstr ""
-
-#: wp-admin/includes/class-custom-background.php:633
-#: wp-admin/includes/media.php:1197
-#: wp-includes/media-template.php:900
-#: wp-includes/media-template.php:980
-#: wp-includes/media-template.php:1171
-#: wp-includes/media.php:4216
-msgid "Full Size"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:74
-#: wp-admin/menu.php:215
-#: wp-includes/admin-bar.php:1030
-msgid "Header"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:102
-msgid "This screen is used to customize the header section of your theme."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:103
-msgid "You can choose from the theme&#8217;s default header images, or use one of your own. You can also customize how your Site Title and Tagline are displayed."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:110
-#: wp-admin/includes/class-custom-image-header.php:531
-#: wp-admin/includes/template.php:2290
-#: wp-admin/includes/template.php:2297
-#: wp-includes/class-wp-customize-manager.php:5350
-#: wp-includes/customize/class-wp-customize-header-image-control.php:55
-msgid "Header Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:112
-msgid "You can set a custom image header for your site. Simply upload the image and crop it, and the new header will go live immediately. Alternatively, you can use an image that has already been uploaded to your Media Library by clicking the &#8220;Choose Image&#8221; button."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:113
-msgid "Some themes come with additional header images bundled. If you see multiple images displayed, select the one you would like and click the &#8220;Save Changes&#8221; button."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:114
-msgid "If your theme has more than one default header image, or you have uploaded more than one custom header image, you have the option of having ClassicPress display a randomly different image on each page of your site. Click the &#8220;Random&#8221; radio button next to the Uploaded Images or Default Images section to enable this feature."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:115
-msgid "If you do not want a header image to be displayed on your site at all, click the &#8220;Remove Header Image&#8221; button at the bottom of the Header Image section of this page. If you want to re-enable the header image later, you just have to select one of the other image options and click &#8220;Save Changes&#8221;."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:122
-#: wp-admin/includes/class-custom-image-header.php:744
-#: wp-admin/includes/class-custom-image-header.php:749
-msgid "Header Text"
-msgstr ""
-
-#. translators: %s: URL to General Settings screen.
-#: wp-admin/includes/class-custom-image-header.php:126
-msgid "For most themes, the header text is your Site Title and Tagline, as defined in the <a href=\"%s\">General Settings</a> section."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:130
-msgid "In the Header Text section of this page, you can choose whether to display this text or hide it. You can also choose a color for the text by clicking the Select Color button and either typing in a legitimate HTML hex value, e.g. &#8220;#ff0000&#8221; for red, or by choosing a color using the color picker."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:131
-msgid "Do not forget to click &#8220;Save Changes&#8221; when you are done!"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:137
-msgid "<a href=\"https://codex.wordpress.org/Appearance_Header_Screen\">Documentation on Custom Header</a>"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:317
-msgid "<strong>Random:</strong> Show a different image on each page."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:504
-#: wp-admin/includes/theme.php:322
-msgid "Custom Header"
-msgstr ""
-
-#. translators: %s: URL to header image configuration in Customizer.
-#: wp-admin/includes/class-custom-image-header.php:512
-msgid "You can now manage and live-preview Custom Header in the <a href=\"%s\">Customizer</a>."
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-custom-image-header.php:525
-msgid "Header updated. <a href=\"%s\">Visit your site</a> to see how it looks."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:580
-msgid "You can select an image to be shown at the top of your site by uploading from your computer or choosing from your media library. After selecting an image you will be able to crop it."
-msgstr ""
-
-#. translators: 1: Image width in pixels, 2: Image height in pixels.
-#: wp-admin/includes/class-custom-image-header.php:587
-msgid "Images of exactly <strong>%1$d &times; %2$d pixels</strong> will be used as-is."
-msgstr ""
-
-#. translators: %s: Size in pixels.
-#: wp-admin/includes/class-custom-image-header.php:595
-msgid "Images should be at least %s wide."
-msgstr ""
-
-#. translators: %d: Custom header width.
-#. translators: %d: Custom header height.
-#: wp-admin/includes/class-custom-image-header.php:598
-#: wp-admin/includes/class-custom-image-header.php:610
-#: wp-admin/includes/class-custom-image-header.php:626
-#: wp-admin/includes/class-custom-image-header.php:638
-msgid "%d pixels"
-msgstr ""
-
-#. translators: %s: Size in pixels.
-#: wp-admin/includes/class-custom-image-header.php:607
-msgid "Images should be at least %s tall."
-msgstr ""
-
-#. translators: %s: Size in pixels.
-#: wp-admin/includes/class-custom-image-header.php:623
-msgid "Suggested width is %s."
-msgstr ""
-
-#. translators: %s: Size in pixels.
-#: wp-admin/includes/class-custom-image-header.php:635
-msgid "Suggested height is %s."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:668
-msgid "Choose a Custom Header"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:669
-msgid "Set as header"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:684
-msgid "Uploaded Images"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:686
-msgid "You can choose one of your previously uploaded headers, or show a random one."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:697
-msgid "Default Images"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:700
-msgid "If you don&lsquo;t want to upload your own image, you can use one of these cool headers, or show a random one."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:702
-msgid "You can use one of these cool headers or show a random one on each page."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:716
-msgid "This will remove the header image. You will not be able to restore any customizations."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:717
-msgid "Remove Header Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:732
-msgid "Reset Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:734
-msgid "This will restore the original header image. You will not be able to restore any customizations."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:735
-msgid "Restore Original Header Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:752
-msgid "Show header text with your image."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:758
-msgid "Text Color"
-msgstr ""
-
-#. translators: %s: Default text color.
-#: wp-admin/includes/class-custom-image-header.php:780
-msgctxt "color"
-msgid "Default: %s"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:819
-#: wp-admin/includes/class-custom-image-header.php:1005
-msgid "The active theme does not support uploading a custom header image."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:898
-#: wp-admin/includes/class-custom-image-header.php:1057
-#: wp-admin/includes/class-custom-image-header.php:1400
-msgid "Image could not be processed. Please go back and try again."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:898
-#: wp-admin/includes/class-custom-image-header.php:1057
-msgid "Image Processing Error"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:913
-msgid "Crop Header Image"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:916
-msgid "Choose the part of the image you want to use as your header."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:917
-msgid "You need JavaScript to choose a part of the image."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:935
-msgid "Crop and Publish"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:941
-msgid "Skip Cropping, Publish Image as Is"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:969
-msgid "Image Upload Error"
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:1016
-msgid "The active theme does not support a flexible sized header image."
-msgstr ""
-
-#: wp-admin/includes/class-custom-image-header.php:1105
-msgid "Sorry, you are not allowed to customize headers."
-msgstr ""
-
-#: wp-admin/includes/class-file-upload-upgrader.php:57
-#: wp-admin/includes/class-file-upload-upgrader.php:120
-#: wp-admin/includes/class-file-upload-upgrader.php:136
-msgid "Please select a file"
-msgstr ""
-
-#: wp-admin/includes/class-file-upload-upgrader.php:92
-#: wp-admin/includes/file.php:1636
-#: wp-admin/includes/file.php:1791
-msgid "Incompatible Archive."
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader-skin.php:31
-#: wp-admin/update-core.php:667
-#: wp-admin/update-core.php:1073
-msgid "Update Translations"
-msgstr ""
-
-#. translators: 1: Project name (plugin, theme, or ClassicPress), 2: Language.
-#: wp-admin/includes/class-language-pack-upgrader-skin.php:51
-#: wp-admin/includes/class-wp-automatic-updater.php:437
-msgid "Updating translations for %1$s (%2$s)&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:113
-msgid "Some of your translations need updating. Sit tight for a few more seconds while they are updated as well."
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:114
-#: wp-admin/update-core.php:656
-msgid "Your translations are all up to date."
-msgstr ""
-
-#. translators: %s: Package URL.
-#: wp-admin/includes/class-language-pack-upgrader.php:117
-msgid "Downloading translation from %s&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:119
-msgid "Translation update failed."
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:120
-msgid "Translation updated successfully."
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:121
-msgid "Removing the old version of the translation&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-language-pack-upgrader.php:122
-msgid "Could not remove the old translation."
-msgstr ""
-
-#. translators: 1: .po, 2: .mo
-#: wp-admin/includes/class-language-pack-upgrader.php:352
-msgid "The language pack is missing either the %1$s or %2$s files."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:104
-msgid "Activate Plugin &amp; Run Importer"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:110
-msgid "Activate Plugin &amp; Go to Press This"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:116
-#: wp-admin/includes/class-plugin-upgrader-skin.php:96
-msgid "Activate Plugin"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:124
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:581
-#: wp-admin/includes/class-wp-plugins-list-table.php:599
-#: wp-admin/includes/class-wp-plugins-list-table.php:806
-#: wp-admin/js/updates.js:755
-msgid "Network Activate"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:133
-msgid "Go to Importers"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:139
-#: wp-admin/includes/class-plugin-installer-skin.php:145
-msgid "Go to Plugin Installer"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:211
-msgid "This plugin is already installed."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:216
-msgid "Plugin name"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:217
-#: wp-admin/includes/class-theme-installer-skin.php:240
-#: wp-admin/includes/class-wp-debug-data.php:71
-#: wp-admin/includes/class-wp-debug-data.php:1095
-#: wp-admin/includes/class-wp-debug-data.php:1190
-msgid "Version"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:219
-#: wp-admin/includes/class-theme-installer-skin.php:242
-msgid "Required WordPress version"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:220
-#: wp-admin/includes/class-theme-installer-skin.php:243
-msgid "Required PHP version"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:224
-msgctxt "plugin"
-msgid "Current"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:225
-msgctxt "plugin"
-msgid "Uploaded"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:259
-msgid "The plugin cannot be updated due to the following:"
-msgstr ""
-
-#. translators: 1: Current PHP version, 2: Version required by the uploaded plugin.
-#: wp-admin/includes/class-plugin-installer-skin.php:268
-#: wp-admin/includes/class-plugin-upgrader.php:449
-msgid "The PHP version on your server is %1$s, however the uploaded plugin requires %2$s."
-msgstr ""
-
-#. translators: 1: Current WordPress version, 2: Version required by the uploaded plugin.
-#. translators: 1: Current ClassicPress version, 2: Version required by the uploaded plugin.
-#: wp-admin/includes/class-plugin-installer-skin.php:280
-#: wp-admin/includes/class-plugin-upgrader.php:460
-msgid "Your ClassicPress version is %1$s, however the uploaded plugin requires %2$s."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/class-plugin-installer-skin.php:295
-msgid "You are uploading an older version of a current plugin. You can continue to install the older version, but be sure to <a href=\"%s\">back up your database and files</a> first."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:296
-#: wp-admin/includes/class-plugin-installer-skin.php:302
-#: wp-admin/includes/class-theme-installer-skin.php:331
-#: wp-admin/includes/class-theme-installer-skin.php:337
-msgid "https://wordpress.org/documentation/article/wordpress-backups/"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/class-plugin-installer-skin.php:301
-msgid "You are updating a plugin. Be sure to <a href=\"%s\">back up your database and files</a> first."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:313
-msgctxt "plugin"
-msgid "Replace current with uploaded"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:324
-#: wp-admin/includes/class-theme-installer-skin.php:359
-msgid "Cancel and go back"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-installer-skin.php:342
-#: wp-admin/includes/class-theme-installer-skin.php:377
-msgid "The uploaded file has expired. Please go back and upload it again."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader-skin.php:62
-#: wp-admin/update.php:63
-msgid "Update Plugin"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader-skin.php:85
-#: wp-admin/update-core.php:1005
-#: wp-admin/update-core.php:1046
-msgid "Update progress"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:57
-msgid "The plugin is at the latest version."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:62
-msgid "Removing the old version of the plugin&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:63
-msgid "Could not remove the old plugin."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:65
-#: wp-admin/includes/class-plugin-upgrader.php:92
-msgid "Plugin updated successfully."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:66
-msgid "Plugins updated successfully."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:75
-#: wp-admin/includes/class-theme-upgrader.php:73
-msgid "Installation package not available."
-msgstr ""
-
-#. translators: %s: Package URL.
-#: wp-admin/includes/class-plugin-upgrader.php:77
-#: wp-admin/includes/class-theme-upgrader.php:75
-msgid "Downloading installation package from %s&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:78
-#: wp-admin/includes/class-theme-upgrader.php:76
-msgid "Unpacking the package&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:79
-msgid "Installing the plugin&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:80
-msgid "Removing the current plugin&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:81
-msgid "Could not remove the current plugin."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:82
-msgid "The plugin contains no files."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:83
-msgid "Plugin installation failed."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:84
-msgid "Plugin installed successfully."
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Plugin version.
-#: wp-admin/includes/class-plugin-upgrader.php:86
-msgid "Successfully installed the plugin <strong>%1$s %2$s</strong>."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:90
-msgid "Updating the plugin&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:96
-msgid "Downgrading the plugin&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:97
-msgid "Plugin downgrade failed."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:98
-msgid "Plugin downgraded successfully."
-msgstr ""
-
-#: wp-admin/includes/class-plugin-upgrader.php:440
-msgid "No valid plugins were found."
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:131
-#: wp-admin/includes/class-theme-upgrader-skin.php:103
-#: wp-admin/includes/class-wp-themes-list-table.php:222
-#: wp-admin/includes/theme.php:1036
-#: wp-admin/includes/theme.php:1038
-#: wp-admin/theme-install.php:389
-#: wp-admin/themes.php:562
-#: wp-admin/themes.php:571
-#: wp-admin/themes.php:922
-#: wp-admin/themes.php:930
-#: wp-admin/themes.php:1153
-#: wp-admin/themes.php:1162
-#: wp-includes/customize/class-wp-customize-theme-control.php:282
-#: wp-includes/customize/class-wp-customize-theme-control.php:284
-#: wp-admin/js/updates.js:1430
-msgid "Live Preview"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Theme name.
-#: wp-admin/includes/class-theme-installer-skin.php:133
-#: wp-admin/includes/class-theme-upgrader-skin.php:105
-msgid "Live Preview &#8220;%s&#8221;"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Theme name.
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-theme-installer-skin.php:143
-#: wp-admin/includes/class-theme-upgrader-skin.php:115
-#: wp-admin/includes/class-wp-themes-list-table.php:214
-msgctxt "theme"
-msgid "Activate &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:150
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:467
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:586
-#: wp-admin/js/updates.js:1408
-msgid "Network Enable"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:158
-msgid "Go to Theme Installer"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:224
-msgid "This theme is already installed."
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:239
-msgid "Theme name"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:244
-#: wp-admin/includes/class-wp-debug-data.php:1109
-msgid "Parent theme"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:248
-msgctxt "theme"
-msgid "Active"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:248
-msgctxt "theme"
-msgid "Uploaded"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:270
-msgid "(not found)"
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:294
-msgid "The theme cannot be updated due to the following:"
-msgstr ""
-
-#. translators: 1: Current PHP version, 2: Version required by the uploaded theme.
-#: wp-admin/includes/class-theme-installer-skin.php:303
-#: wp-admin/includes/class-theme-upgrader.php:608
-msgid "The PHP version on your server is %1$s, however the uploaded theme requires %2$s."
-msgstr ""
-
-#. translators: 1: Current WordPress version, 2: Version required by the uploaded theme.
-#: wp-admin/includes/class-theme-installer-skin.php:315
-#: wp-admin/includes/class-theme-upgrader.php:618
-msgid "Your ClassicPress version is %1$s, however the uploaded theme requires %2$s."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/class-theme-installer-skin.php:330
-msgid "You are uploading an older version of the active theme. You can continue to install the older version, but be sure to <a href=\"%s\">back up your database and files</a> first."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/class-theme-installer-skin.php:336
-msgid "You are updating a theme. Be sure to <a href=\"%s\">back up your database and files</a> first."
-msgstr ""
-
-#: wp-admin/includes/class-theme-installer-skin.php:348
-msgctxt "theme"
-msgid "Replace active with uploaded"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader-skin.php:44
-#: wp-admin/update.php:243
-msgid "Update Theme"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Theme name.
-#: wp-admin/includes/class-theme-upgrader-skin.php:94
-msgid "Customize &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:56
-msgid "The theme is at the latest version."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:61
-#: wp-admin/includes/class-theme-upgrader.php:78
-msgid "Removing the old version of the theme&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:62
-#: wp-admin/includes/class-theme-upgrader.php:79
-msgid "Could not remove the old theme."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:64
-#: wp-admin/includes/class-theme-upgrader.php:101
-msgid "Theme updated successfully."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:77
-msgid "Installing the theme&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:80
-msgid "The theme contains no files."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:81
-msgid "Theme installation failed."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:82
-msgid "Theme installed successfully."
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme version.
-#: wp-admin/includes/class-theme-upgrader.php:84
-msgid "Successfully installed the theme <strong>%1$s %2$s</strong>."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:85
-msgid "This theme requires a parent theme. Checking if it is installed&#8230;"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme version.
-#: wp-admin/includes/class-theme-upgrader.php:87
-msgid "Preparing to install <strong>%1$s %2$s</strong>&#8230;"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme version.
-#: wp-admin/includes/class-theme-upgrader.php:89
-msgid "The parent theme, <strong>%1$s %2$s</strong>, is currently installed."
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme version.
-#: wp-admin/includes/class-theme-upgrader.php:91
-msgid "Successfully installed the parent theme, <strong>%1$s %2$s</strong>."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-theme-upgrader.php:93
-msgid "<strong>The parent theme could not be found.</strong> You will need to install the parent theme, %s, before you can use this child theme."
-msgstr ""
-
-#. translators: %s: Theme error.
-#: wp-admin/includes/class-theme-upgrader.php:95
-msgid "The active theme has the following error: \"%s\"."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:99
-msgid "Updating the theme&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:105
-msgid "Downgrading the theme&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:106
-msgid "Theme downgrade failed."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:107
-msgid "Theme downgraded successfully."
-msgstr ""
-
-#. translators: %s: style.css
-#: wp-admin/includes/class-theme-upgrader.php:538
-msgid "The theme is missing the %s stylesheet."
-msgstr ""
-
-#. translators: %s: style.css
-#: wp-admin/includes/class-theme-upgrader.php:564
-msgid "The %s stylesheet does not contain a valid theme header."
-msgstr ""
-
-#. translators: 1: templates/index.html, 2: index.php, 3: Documentation URL, 4: Template, 5: style.css
-#: wp-admin/includes/class-theme-upgrader.php:586
-#: wp-includes/class-wp-theme.php:343
-msgid "Template is missing. Standalone themes need to have a %1$s or %2$s template file. <a href=\"%3$s\">Child themes</a> need to have a %4$s header in the %5$s stylesheet."
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:589
-#: wp-admin/includes/class-wp-themes-list-table.php:285
-#: wp-admin/theme-editor.php:44
-#: wp-admin/theme-editor.php:376
-#: wp-admin/update-core.php:504
-#: wp-includes/class-wp-theme.php:346
-msgid "https://developer.wordpress.org/themes/advanced-topics/child-themes/"
-msgstr ""
-
-#: wp-admin/includes/class-theme-upgrader.php:601
-#: wp-admin/theme-install.php:319
-#: wp-admin/theme-install.php:524
-#: wp-includes/customize/class-wp-customize-theme-control.php:209
-msgid "FSE themes don't work with ClassicPress."
-msgstr ""
-
-#. translators: %s: Title of an invalid menu item.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:108
-#: wp-includes/class-wp-customize-nav-menus.php:526
-msgid "%s (Invalid)"
-msgstr ""
-
-#. translators: %s: Title of a menu item in draft status.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:112
-#: wp-includes/class-wp-customize-nav-menus.php:528
-msgid "%s (Pending)"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:129
-msgid "sub item"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:147
-#: wp-admin/includes/template.php:1309
-#: wp-includes/class-wp-customize-nav-menus.php:1096
-#: wp-includes/class-wp-customize-widgets.php:701
-msgid "Move up"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:164
-#: wp-admin/includes/template.php:1322
-#: wp-includes/class-wp-customize-nav-menus.php:1097
-#: wp-includes/class-wp-customize-widgets.php:700
-msgid "Move down"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:183
-msgid "Move menu item"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:185
-#: wp-admin/includes/class-walker-nav-menu-edit.php:254
-msgid "Move"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:202
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:95
-msgid "Navigation Label"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:208
-#: wp-admin/includes/nav-menu.php:1126
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:107
-msgid "Title Attribute"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:215
-#: wp-includes/class-wp-editor.php:1896
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:102
-#: wp-includes/media-template.php:1249
-#: wp-includes/widgets/class-wp-widget-media-image.php:144
-msgid "Open link in a new tab"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:220
-msgid "CSS Classes (optional)"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:234
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:127
-msgid "The description will be displayed in the menu if the active theme supports it."
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:255
-msgid "Up one"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:256
-msgid "Down one"
-msgstr ""
-
-#: wp-admin/includes/class-walker-nav-menu-edit.php:259
-msgid "To the top"
-msgstr ""
-
-#. translators: %s: Link to menu item's original object.
-#. translators: Nav menu item original title. %s: Original title.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:267
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:147
-msgid "Original: %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-walker-nav-menu-edit.php:286
-#: wp-admin/includes/class-wp-users-list-table.php:276
-#: wp-admin/includes/class-wp-users-list-table.php:487
-#: wp-includes/class-wp-customize-manager.php:5230
-#: wp-includes/class-wp-customize-widgets.php:781
-#: wp-includes/class-wp-editor.php:1388
-#: wp-includes/customize/class-wp-customize-media-control.php:228
-#: wp-includes/customize/class-wp-customize-media-control.php:238
-#: wp-includes/customize/class-wp-customize-media-control.php:249
-#: wp-includes/customize/class-wp-customize-media-control.php:259
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:152
-#: wp-includes/media-template.php:608
-#: wp-includes/media.php:4583
-msgid "Remove"
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:29
-msgid "Created"
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:30
-msgid "Last Used"
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:31
-msgid "Last IP"
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:32
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:118
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:238
-msgid "Revoke"
-msgstr ""
-
-#. translators: %s: the application password's given name.
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:117
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:237
-msgid "Revoke \"%s\""
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:156
-msgid "Revoke all application passwords"
-msgstr ""
-
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:225
-msgid "Just now"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-application-passwords-list-table.php:258
-#: wp-admin/includes/class-wp-comments-list-table.php:882
-#: wp-admin/includes/class-wp-list-table.php:650
-#: wp-admin/includes/class-wp-list-table.php:1594
-#: wp-admin/includes/update.php:919
-msgid "Show more details"
-msgstr ""
-
-#. translators: %s: The "$dir" argument.
-#: wp-admin/includes/class-wp-automatic-updater.php:81
-msgid "The \"%s\" argument must be a non-empty string."
-msgstr ""
-
-#. translators: %s: WordPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:404
-msgid "Updating to ClassicPress %s"
-msgstr ""
-
-#. translators: %s: WordPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:406
-msgid "ClassicPress %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-automatic-updater.php:418
-msgid "Updating theme: %s"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-automatic-updater.php:430
-msgid "Updating plugin: %s"
-msgstr ""
-
-#. translators: %s: Project name (plugin, theme, or WordPress).
-#: wp-admin/includes/class-wp-automatic-updater.php:435
-msgid "Translations for %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:462
-#: wp-admin/includes/class-wp-upgrader.php:151
-#: wp-admin/includes/file.php:1558
-#: wp-admin/includes/plugin.php:948
-#: wp-admin/includes/theme.php:62
-msgid "Could not access filesystem."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:477
-#: wp-admin/js/updates.js:826
-#: wp-admin/js/updates.js:1495
-msgid "Installation failed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:480
-msgid "ClassicPress updated successfully."
-msgstr ""
-
-#. translators: Site updated notification email subject. 1: Site title, 2: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:768
-msgid "[%1$s] Your site has updated to ClassicPress %2$s"
-msgstr ""
-
-#. translators: Update available notification email subject. 1: Site title, 2: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:774
-msgid "[%1$s] ClassicPress %2$s is available. Please update!"
-msgstr ""
-
-#. translators: Site down notification email subject. 1: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:779
-msgid "[%1$s] URGENT: Your site may be down due to a failed update"
-msgstr ""
-
-#. translators: 1: Home URL, 2: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:796
-msgid "Howdy! Your site at %1$s has been updated automatically to ClassicPress %2$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:802
-msgid "No further action is needed on your part."
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:808
-msgid "For more on version %s, see the About ClassicPress screen:"
-msgstr ""
-
-#. translators: %s: ClassicPress latest version.
-#: wp-admin/includes/class-wp-automatic-updater.php:813
-msgid "ClassicPress %s is also now available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:814
-#: wp-admin/includes/class-wp-automatic-updater.php:837
-msgid "Updating is easy and only takes a few moments:"
-msgstr ""
-
-#. translators: 1: Home URL, 2: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:824
-msgid "Please update your site at %1$s to ClassicPress %2$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:834
-msgid "An attempt was made, but your site could not be updated automatically."
-msgstr ""
-
-#. translators: 1: Home URL, 2: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:845
-msgid "Your site at %1$s experienced a critical failure while trying to update ClassicPress to version %2$s."
-msgstr ""
-
-#. translators: 1: Home URL, 2: ClassicPress latest version.
-#: wp-admin/includes/class-wp-automatic-updater.php:852
-msgid "Your site at %1$s experienced a critical failure while trying to update to the latest version of ClassicPress, %2$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:858
-msgid "This means your site may be offline or broken. Don't panic; this can be fixed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:860
-msgid "Please check out your site now. It's possible that everything is working. If it says you need to update, you should do so:"
-msgstr ""
-
-#. translators: %s: Support email address.
-#: wp-admin/includes/class-wp-automatic-updater.php:870
-msgid "The ClassicPress team is willing to help you. Forward this email to %s and the team will work with you to make sure your site is working."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:875
-#: wp-admin/includes/class-wp-automatic-updater.php:1309
-msgid "If you experience any issues or need support, the volunteers in the ClassicPress.net support forums may be able to help."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:876
-#: wp-admin/includes/plugin-install.php:186
-#: wp-admin/includes/theme.php:551
-#: wp-admin/includes/theme.php:566
-#: wp-admin/includes/translation-install.php:85
-#: wp-admin/includes/translation-install.php:97
-#: wp-admin/theme-install.php:65
-#: wp-includes/class-wpdb.php:1234
-#: wp-includes/class-wpdb.php:2003
-#: wp-includes/class-wpdb.php:2157
-#: wp-includes/customize/class-wp-customize-themes-section.php:90
-#: wp-includes/load.php:181
-msgid "https://wordpress.org/support/forums/"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:881
-#: wp-admin/update-core.php:840
-msgid "Keeping your site updated is important for security. It also makes the internet a safer place for you and your readers."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:885
-msgid "Reach out to ClassicPress Core developers to ensure you'll never have this problem again."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:890
-msgid "You also have some plugins or themes with updates available. Update them now:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:894
-#: wp-admin/includes/class-wp-automatic-updater.php:1311
-msgid "The ClassicPress Team"
-msgstr ""
-
-#. translators: %s: WordPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:899
-msgid "Your site was running version %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:900
-msgid "Some data that describes the error your site encountered has been put together."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:901
-msgid "Your hosting company, support forum volunteers, or a friendly developer may be able to use this information to help you:"
-msgstr ""
-
-#. translators: %s: Error code.
-#: wp-admin/includes/class-wp-automatic-updater.php:918
-msgid "Error code: %s"
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1090
-msgid "[%s] Some plugins and themes have automatically updated"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1093
-msgid "Howdy! Some plugins and themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1098
-msgid "[%s] Some plugins were automatically updated"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1101
-msgid "Howdy! Some plugins have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1106
-msgid "[%s] Some themes were automatically updated"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1109
-msgid "Howdy! Some themes have automatically updated to their latest versions on your site at %s. No further action is needed on your part."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1119
-msgid "[%s] Some plugins and themes have failed to update"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1122
-msgid "Howdy! Plugins and themes failed to update on your site at %s."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1127
-msgid "[%s] Some plugins have failed to update"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1130
-msgid "Howdy! Plugins failed to update on your site at %s."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1135
-msgid "[%s] Some themes have failed to update"
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1138
-msgid "Howdy! Themes failed to update on your site at %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1148
-msgid "Please check your site now. It’s possible that everything is working. If there are updates available, you should update."
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1153
-msgid "These plugins failed to update:"
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Current version number, 3: New version number, 4: Plugin URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1166
-#: wp-admin/includes/class-wp-automatic-updater.php:1238
-msgid "- %1$s (from version %2$s to %3$s)%4$s"
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Version number, 3: Plugin URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1175
-#: wp-admin/includes/class-wp-automatic-updater.php:1247
-msgid "- %1$s version %2$s%3$s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1192
-msgid "These themes failed to update:"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Current version number, 3: New version number.
-#: wp-admin/includes/class-wp-automatic-updater.php:1198
-#: wp-admin/includes/class-wp-automatic-updater.php:1269
-msgid "- %1$s (from version %2$s to %3$s)"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Version number.
-#: wp-admin/includes/class-wp-automatic-updater.php:1206
-#: wp-admin/includes/class-wp-automatic-updater.php:1277
-msgid "- %1$s version %2$s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1225
-msgid "These plugins are now up to date:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1263
-msgid "These themes are now up to date:"
-msgstr ""
-
-#. translators: %s: Plugins screen URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1293
-msgid "To manage plugins on your site, visit the Plugins page: %s"
-msgstr ""
-
-#. translators: %s: Themes screen URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1302
-msgid "To manage themes on your site, visit the Themes page: %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1310
-msgid "https://forums.classicpress.net/c/support/"
-msgstr ""
-
-#. translators: %s: Network home URL.
-#: wp-admin/includes/class-wp-automatic-updater.php:1368
-msgid "ClassicPress site: %s"
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:1376
-msgid "SUCCESS: ClassicPress was successfully updated to %s"
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/class-wp-automatic-updater.php:1379
-msgid "FAILED: ClassicPress failed to update to %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1396
-msgid "The following plugins were successfully updated:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1397
-msgid "The following themes were successfully updated:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1398
-msgid "The following translations were successfully updated:"
-msgstr ""
-
-#. translators: %s: Name of plugin / theme / translation.
-#: wp-admin/includes/class-wp-automatic-updater.php:1404
-msgid "SUCCESS: %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1411
-msgid "The following plugins failed to update:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1412
-msgid "The following themes failed to update:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1413
-msgid "The following translations failed to update:"
-msgstr ""
-
-#. translators: %s: Name of plugin / theme / translation.
-#: wp-admin/includes/class-wp-automatic-updater.php:1421
-msgid "FAILED: %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1438
-msgid ""
-"BETA TESTING?\n"
-"=============\n"
-"\n"
-"This debugging email is sent when you are using a development version of ClassicPress.\n"
-"\n"
-"If you think these failures might be due to a bug in ClassicPress, could you report it?\n"
-" * Open a thread in the support forums: https://wordpress.org/support/forum/alphabeta\n"
-" * Or, if you're comfortable writing a bug report: https://core.trac.wordpress.org/\n"
-"\n"
-"Thanks! -- The ClassicPress Team"
-msgstr ""
-
-#. translators: Background update failed notification email subject. %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1454
-msgid "[%s] Background Update Failed"
-msgstr ""
-
-#. translators: Background update finished notification email subject. %s: Site title.
-#: wp-admin/includes/class-wp-automatic-updater.php:1457
-msgid "[%s] Background Update Finished"
-msgstr ""
-
-#: wp-admin/includes/class-wp-automatic-updater.php:1461
-msgid ""
-"UPDATE LOG\n"
-"=========="
-msgstr ""
-
-#. translators: 1: Error code, 2: Error message.
-#: wp-admin/includes/class-wp-automatic-updater.php:1496
-msgid "Rollback Error: [%1$s] %2$s"
-msgstr ""
-
-#. translators: 1: Error code, 2: Error message.
-#: wp-admin/includes/class-wp-automatic-updater.php:1499
-msgid "Error: [%1$s] %2$s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:219
-msgid "No comments awaiting moderation."
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:221
-msgid "No comments found in Trash."
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:223
-msgid "No comments found."
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:240
-msgctxt "comments"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:247
-msgctxt "comments"
-msgid "Mine <span class=\"count\">(%s)</span>"
-msgid_plural "Mine <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:254
-msgctxt "comments"
-msgid "Pending <span class=\"count\">(%s)</span>"
-msgid_plural "Pending <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:261
-msgctxt "comments"
-msgid "Approved <span class=\"count\">(%s)</span>"
-msgid_plural "Approved <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:268
-msgctxt "comments"
-msgid "Spam <span class=\"count\">(%s)</span>"
-msgid_plural "Spam <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-comments-list-table.php:275
-msgctxt "comments"
-msgid "Trash <span class=\"count\">(%s)</span>"
-msgid_plural "Trash <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:360
-#: wp-admin/includes/class-wp-comments-list-table.php:729
-#: wp-admin/includes/class-wp-comments-list-table.php:754
-#: wp-admin/includes/dashboard.php:752
-msgid "Unapprove"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:364
-#: wp-admin/includes/class-wp-comments-list-table.php:737
-#: wp-admin/includes/class-wp-comments-list-table.php:746
-#: wp-admin/includes/dashboard.php:744
-msgid "Approve"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:372
-#: wp-admin/includes/class-wp-comments-list-table.php:783
-#: wp-admin/includes/class-wp-media-list-table.php:184
-#: wp-admin/includes/class-wp-media-list-table.php:821
-#: wp-admin/includes/class-wp-posts-list-table.php:438
-#: wp-admin/includes/class-wp-posts-list-table.php:1468
-msgid "Restore"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:374
-msgctxt "comment"
-msgid "Not spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:378
-#: wp-admin/includes/class-wp-media-list-table.php:185
-#: wp-admin/includes/class-wp-media-list-table.php:190
-#: wp-admin/includes/class-wp-posts-list-table.php:446
-#: wp-admin/includes/meta-boxes.php:366
-#: wp-admin/includes/meta-boxes.php:475
-#: wp-includes/media-template.php:572
-#: wp-includes/media-template.php:735
-#: wp-includes/media.php:4618
-msgid "Delete permanently"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:418
-#: wp-admin/includes/class-wp-links-list-table.php:120
-#: wp-admin/includes/class-wp-media-list-table.php:217
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:335
-#: wp-admin/includes/class-wp-posts-list-table.php:600
-msgid "Filter"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:426
-msgid "Empty Spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:426
-#: wp-admin/includes/class-wp-media-list-table.php:222
-#: wp-admin/includes/class-wp-posts-list-table.php:607
-msgid "Empty Trash"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:470
-#: wp-admin/includes/class-wp-post-comments-list-table.php:26
-msgctxt "column name"
-msgid "Comment"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:477
-msgctxt "column name"
-msgid "Submitted on"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:502
-#: wp-admin/includes/class-wp-posts-list-table.php:1894
-msgid "Pings"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-comments-list-table.php:510
-msgid "Filter by comment type"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:515
-msgid "All comment types"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:728
-#: wp-admin/includes/class-wp-comments-list-table.php:753
-#: wp-admin/includes/dashboard.php:751
-msgid "Unapprove this comment"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:736
-#: wp-admin/includes/class-wp-comments-list-table.php:745
-#: wp-admin/includes/dashboard.php:743
-msgid "Approve this comment"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:763
-#: wp-admin/includes/dashboard.php:774
-msgid "Mark this comment as spam"
-msgstr ""
-
-#. translators: "Mark as spam" link.
-#: wp-admin/includes/class-wp-comments-list-table.php:765
-#: wp-admin/includes/dashboard.php:776
-msgctxt "verb"
-msgid "Spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:772
-msgid "Restore this comment from the spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:773
-msgctxt "comment"
-msgid "Not Spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:782
-msgid "Restore this comment from the Trash"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:792
-#: wp-admin/includes/dashboard.php:784
-msgid "Delete this comment permanently"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:800
-#: wp-admin/includes/dashboard.php:792
-msgid "Move this comment to the Trash"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:801
-#: wp-admin/includes/class-wp-media-list-table.php:769
-#: wp-admin/includes/class-wp-media-list-table.php:829
-#: wp-admin/includes/class-wp-posts-list-table.php:1476
-#: wp-admin/includes/dashboard.php:793
-msgctxt "verb"
-msgid "Trash"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:809
-#: wp-admin/includes/dashboard.php:758
-msgid "Edit this comment"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:821
-msgid "Quick edit this comment inline"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:822
-#: wp-admin/includes/class-wp-posts-list-table.php:1457
-#: wp-admin/includes/class-wp-terms-list-table.php:483
-msgid "Quick&nbsp;Edit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:831
-#: wp-admin/includes/dashboard.php:766
-msgid "Reply to this comment"
-msgstr ""
-
-#: wp-admin/includes/class-wp-comments-list-table.php:832
-#: wp-admin/includes/dashboard.php:767
-#: wp-includes/comment-template.php:1787
-#: wp-admin/js/edit-comments.js:372
-#: wp-admin/js/edit-comments.js:1014
-msgid "Reply"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-comments-list-table.php:902
-msgid "Select comment"
-msgstr ""
-
-#. translators: %s: Latest ClassicPress version number.
-#. translators: %s: Latest plugin version number.
-#. translators: %s: Latest theme version number.
-#: wp-admin/includes/class-wp-debug-data.php:57
-#: wp-admin/includes/class-wp-debug-data.php:971
-#: wp-admin/includes/class-wp-debug-data.php:1061
-#: wp-admin/includes/class-wp-debug-data.php:1173
-#: wp-admin/includes/class-wp-debug-data.php:1293
-msgid "(Latest version: %s)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:68
-#: wp-admin/includes/class-wp-debug-data.php:73
-#: wp-admin/includes/class-wp-privacy-policy-content.php:670
-#: wp-admin/includes/media.php:531
-#: wp-admin/includes/template.php:2012
-#: wp-admin/install.php:77
-#: wp-admin/maint/repair.php:24
-#: wp-admin/setup-config.php:115
-#: wp-admin/upgrade.php:69
-msgid "ClassicPress"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:76
-#: wp-admin/network/site-new.php:240
-#: wp-admin/options-general.php:367
-msgid "Site Language"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:80
-msgid "User Language"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:84
-#: wp-admin/options-general.php:425
-msgid "Timezone"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:88
-msgid "Home URL"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:93
-msgid "Site URL"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-debug-data.php:98
-#: wp-admin/options-permalink.php:330
-#: wp-admin/options-permalink.php:336
-msgid "Permalink structure"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:99
-msgid "No permalink structure set"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:103
-msgid "Is this site using HTTPS?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:104
-#: wp-admin/includes/class-wp-debug-data.php:109
-#: wp-admin/includes/class-wp-debug-data.php:114
-#: wp-admin/includes/class-wp-debug-data.php:119
-#: wp-admin/includes/class-wp-debug-data.php:774
-#: wp-admin/includes/class-wp-debug-data.php:783
-#: wp-admin/includes/class-wp-debug-data.php:792
-#: wp-admin/includes/class-wp-links-list-table.php:264
-#: wp-signup.php:218
-msgid "Yes"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:104
-#: wp-admin/includes/class-wp-debug-data.php:109
-#: wp-admin/includes/class-wp-debug-data.php:114
-#: wp-admin/includes/class-wp-debug-data.php:119
-#: wp-admin/includes/class-wp-debug-data.php:774
-#: wp-admin/includes/class-wp-debug-data.php:783
-#: wp-admin/includes/class-wp-debug-data.php:792
-#: wp-admin/includes/class-wp-links-list-table.php:266
-#: wp-signup.php:222
-msgid "No"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:108
-msgid "Is this a multisite?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:113
-msgid "Can anyone register on this site?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:118
-msgid "Is this site discouraging search engines?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:123
-msgid "Default comment status"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:124
-msgctxt "comment status"
-msgid "Open"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:124
-msgctxt "comment status"
-msgid "Closed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:128
-msgid "Environment type"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:137
-msgid "Directories and Sizes"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:143
-msgid "Drop-ins"
-msgstr ""
-
-#. translators: %s: wp-content directory name.
-#: wp-admin/includes/class-wp-debug-data.php:147
-#: wp-admin/includes/class-wp-plugins-list-table.php:666
-msgid "Drop-ins are single files, found in the %s directory, that replace or enhance ClassicPress features in ways that are not possible for traditional plugins."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:154
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:925
-#: wp-admin/includes/theme.php:817
-#: wp-admin/themes.php:971
-msgid "Active Theme"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:159
-msgid "Parent Theme"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:164
-msgid "Inactive Themes"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:170
-msgid "Must Use Plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:176
-msgid "Active Plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:182
-msgid "Inactive Plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:188
-msgid "Media Handling"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:193
-msgid "Server"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:194
-msgid "The options shown below relate to your server setup. If changes are required, you may need your web host&#8217;s assistance."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:199
-msgid "Database"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:204
-#: wp-admin/includes/class-wp-debug-data.php:214
-#: wp-admin/includes/class-wp-debug-data.php:223
-#: wp-admin/includes/class-wp-debug-data.php:232
-#: wp-admin/includes/class-wp-debug-data.php:283
-#: wp-admin/includes/class-wp-debug-data.php:288
-#: wp-admin/includes/class-wp-debug-data.php:298
-#: wp-admin/includes/class-wp-debug-data.php:303
-#: wp-admin/includes/class-wp-debug-data.php:532
-#: wp-admin/includes/class-wp-debug-data.php:1150
-#: wp-admin/includes/class-wp-debug-data.php:1236
-msgid "Disabled"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:209
-#: wp-admin/includes/class-wp-debug-data.php:214
-#: wp-admin/includes/class-wp-debug-data.php:223
-#: wp-admin/includes/class-wp-debug-data.php:232
-#: wp-admin/includes/class-wp-debug-data.php:283
-#: wp-admin/includes/class-wp-debug-data.php:288
-#: wp-admin/includes/class-wp-debug-data.php:298
-#: wp-admin/includes/class-wp-debug-data.php:303
-#: wp-admin/includes/class-wp-debug-data.php:532
-#: wp-admin/includes/class-wp-debug-data.php:1148
-#: wp-admin/includes/class-wp-debug-data.php:1234
-msgid "Enabled"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:217
-#: wp-admin/includes/class-wp-debug-data.php:226
-#: wp-admin/includes/class-wp-debug-data.php:235
-#: wp-admin/includes/class-wp-debug-data.php:243
-#: wp-admin/includes/class-wp-debug-data.php:257
-#: wp-admin/includes/class-wp-debug-data.php:262
-#: wp-admin/includes/class-wp-debug-data.php:328
-#: wp-admin/includes/class-wp-debug-data.php:333
-#: wp-admin/includes/class-wp-debug-data.php:1105
-#: wp-admin/includes/class-wp-debug-data.php:1200
-msgid "Undefined"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:247
-msgid "ClassicPress Constants"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:248
-msgid "These settings alter where and how parts of ClassicPress are loaded."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:346
-msgid "Filesystem Permissions"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:347
-msgid "Shows whether ClassicPress is able to write to the directories it needs access to."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:350
-msgid "The main ClassicPress directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:351
-#: wp-admin/includes/class-wp-debug-data.php:356
-#: wp-admin/includes/class-wp-debug-data.php:361
-#: wp-admin/includes/class-wp-debug-data.php:366
-#: wp-admin/includes/class-wp-debug-data.php:371
-#: wp-admin/includes/class-wp-debug-data.php:1360
-msgid "Writable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:351
-#: wp-admin/includes/class-wp-debug-data.php:356
-#: wp-admin/includes/class-wp-debug-data.php:361
-#: wp-admin/includes/class-wp-debug-data.php:366
-#: wp-admin/includes/class-wp-debug-data.php:371
-#: wp-admin/includes/class-wp-debug-data.php:1360
-msgid "Not writable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:355
-msgid "The wp-content directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:360
-msgid "The uploads directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:365
-msgid "The plugins directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:370
-msgid "The themes directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:394
-msgid "Site count"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:399
-msgid "Network count"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:405
-msgid "User count"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:415
-msgid "ClassicPress directory location"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:419
-msgid "ClassicPress directory size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:424
-msgid "Uploads directory location"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:428
-msgid "Uploads directory size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:433
-msgid "Themes directory location"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:437
-msgid "Themes directory size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:442
-msgid "Plugins directory location"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:446
-msgid "Plugins directory size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:451
-msgid "Database size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:456
-msgid "Total installation size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:470
-#: wp-admin/includes/class-wp-debug-data.php:492
-#: wp-admin/includes/class-wp-debug-data.php:509
-#: wp-admin/includes/class-wp-debug-data.php:1649
-#: wp-admin/includes/ms.php:791
-msgid "Not available"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:482
-msgid "Active editor"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:496
-msgid "ImageMagick version number"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:501
-msgid "ImageMagick version string"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:508
-msgid "Imagick version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:514
-msgid "File upload settings"
-msgstr ""
-
-#. translators: %s: ini_get()
-#: wp-admin/includes/class-wp-debug-data.php:517
-#: wp-admin/includes/class-wp-debug-data.php:709
-msgid "Unable to determine some settings, as the %s function has been disabled."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:531
-#: wp-admin/includes/class-wp-site-health.php:2534
-msgid "File uploads"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:536
-msgid "Max size of post data allowed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:540
-msgid "Max size of an uploaded file"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:544
-msgid "Max effective file size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:548
-msgid "Max number of files allowed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:576
-msgid "Imagick Resource Limits"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:588
-msgid "ImageMagick supported file formats"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:589
-msgid "Unable to determine"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:602
-msgid "GD version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:629
-msgid "GD supported file formats"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:645
-msgid "Unable to determine if Ghostscript is installed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:650
-msgid "Ghostscript version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:669
-msgid "(Supports 64bit values)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:669
-msgid "(Does not support 64bit values)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:683
-msgid "Server architecture"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:684
-msgid "Unable to determine server architecture"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:688
-msgid "Web server"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:689
-msgid "Unable to determine what web server software is used"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:693
-msgid "PHP version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:698
-msgid "PHP SAPI"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:699
-msgid "Unable to determine PHP SAPI"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:706
-msgid "Server settings"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:716
-msgid "PHP max input variables"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:720
-msgid "PHP time limit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:726
-#: wp-admin/includes/class-wp-debug-data.php:735
-msgid "PHP memory limit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:730
-msgid "PHP memory limit (only for admin screens)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:741
-msgid "Max input time"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:745
-msgid "Upload max filesize"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:749
-msgid "PHP post max size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:758
-#: wp-admin/includes/class-wp-debug-data.php:763
-msgid "cURL version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:773
-msgid "Is SUHOSIN installed?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:782
-msgid "Is the Imagick library available?"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:791
-msgid "Are pretty permalinks supported?"
-msgstr ""
-
-#. translators: %s: .htaccess
-#: wp-admin/includes/class-wp-debug-data.php:807
-msgid "Custom rules have been added to your %s file."
-msgstr ""
-
-#. translators: %s: .htaccess
-#: wp-admin/includes/class-wp-debug-data.php:810
-msgid "Your %s file contains only core ClassicPress features."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:814
-msgid ".htaccess rules"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:834
-msgid "Extension"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:839
-msgid "Server version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:844
-msgid "Client version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:849
-#: wp-admin/setup-config.php:169
-msgid "Database username"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:855
-#: wp-admin/setup-config.php:171
-msgid "Database host"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:861
-#: wp-admin/setup-config.php:168
-msgid "Database name"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:867
-msgid "Table prefix"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:873
-msgid "Database charset"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:879
-msgid "Database collation"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:885
-msgid "Max allowed packet size"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:890
-msgid "Max connections number"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:901
-#: wp-admin/includes/class-wp-debug-data.php:948
-#: wp-admin/includes/class-wp-debug-data.php:1270
-msgid "No version or author information is available."
-msgstr ""
-
-#. translators: 1: Plugin version number. 2: Plugin author name.
-#. translators: 1: Theme version number. 2: Theme author name.
-#: wp-admin/includes/class-wp-debug-data.php:906
-#: wp-admin/includes/class-wp-debug-data.php:953
-#: wp-admin/includes/class-wp-debug-data.php:1275
-msgid "Version %1$s by %2$s"
-msgstr ""
-
-#. translators: %s: Plugin author name.
-#. translators: %s: Theme author name.
-#. translators: %s: Theme author.
-#. translators: %s: Plugin author.
-#. translators: %s: Theme author link.
-#: wp-admin/includes/class-wp-debug-data.php:911
-#: wp-admin/includes/class-wp-debug-data.php:958
-#: wp-admin/includes/class-wp-debug-data.php:1280
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:726
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:500
-#: wp-admin/includes/class-wp-plugins-list-table.php:1060
-#: wp-admin/includes/class-wp-theme-install-list-table.php:370
-#: wp-admin/includes/class-wp-theme-install-list-table.php:502
-#: wp-admin/includes/class-wp-themes-list-table.php:262
-#: wp-admin/includes/theme.php:828
-#: wp-admin/theme-install.php:352
-#: wp-admin/theme-install.php:464
-#: wp-admin/themes.php:529
-#: wp-admin/themes.php:888
-#: wp-admin/themes.php:982
-msgid "By %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1007
-#: wp-admin/includes/class-wp-debug-data.php:1322
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:794
-#: wp-admin/includes/class-wp-plugins-list-table.php:1168
-#: wp-admin/themes.php:700
-#: wp-admin/js/updates.js:2982
-msgid "Auto-updates enabled"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1009
-#: wp-admin/includes/class-wp-debug-data.php:1324
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:796
-#: wp-admin/includes/class-wp-plugins-list-table.php:1170
-#: wp-admin/themes.php:698
-#: wp-admin/js/updates.js:2993
-msgid "Auto-updates disabled"
-msgstr ""
-
-#. translators: 1: Theme name. 2: Theme slug.
-#. translators: Developer debugging message. 1: PHP function name, 2: Explanatory message.
-#: wp-admin/includes/class-wp-debug-data.php:1070
-#: wp-admin/includes/class-wp-debug-data.php:1089
-#: wp-admin/includes/class-wp-debug-data.php:1184
-#: wp-admin/includes/class-wp-debug-data.php:1345
-#: wp-includes/rest-api.php:664
-msgid "%1$s (%2$s)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1104
-#: wp-admin/includes/class-wp-debug-data.php:1199
-msgid "Author website"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1114
-msgid "Theme features"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1118
-#: wp-admin/includes/class-wp-debug-data.php:1204
-msgid "Theme directory location"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1157
-#: wp-admin/network/themes.php:312
-#: wp-admin/plugins.php:574
-#: wp-admin/themes.php:197
-msgid "Auto-updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1243
-msgid "Auto-update"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1359
-msgid "The must use plugins directory"
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1614
-msgid "The size cannot be calculated. The directory is not accessible. Usually caused by invalid permissions."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1621
-msgid "The directory size calculation has timed out. Usually caused by a very large number of sub-directories and files."
-msgstr ""
-
-#: wp-admin/includes/class-wp-debug-data.php:1665
-msgid "Total size is not available. Some errors were encountered when determining the size of your installation."
-msgstr ""
-
-#. translators: 1: Folder to locate, 2: Folder to start searching from.
-#: wp-admin/includes/class-wp-filesystem-base.php:266
-msgid "Looking for %1$s in %2$s"
-msgstr ""
-
-#. translators: %s: Directory name.
-#: wp-admin/includes/class-wp-filesystem-base.php:295
-msgid "Changing to %s"
-msgstr ""
-
-#. translators: %s: Directory name.
-#: wp-admin/includes/class-wp-filesystem-base.php:313
-msgid "Found %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:37
-msgid "The ftp PHP extension is not available"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:53
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:49
-msgid "FTP hostname is required"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:60
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:56
-msgid "FTP username is required"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:66
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:62
-msgid "FTP password is required"
-msgstr ""
-
-#. translators: %s: hostname:port
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:97
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:87
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:100
-msgid "Failed to connect to FTP Server %s"
-msgstr ""
-
-#. translators: %s: Username.
-#: wp-admin/includes/class-wp-filesystem-ftpext.php:110
-#: wp-admin/includes/class-wp-filesystem-ftpsockets.php:113
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:145
-msgid "Username/Password incorrect for %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:69
-msgid "The ssh2 PHP extension is not available"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:81
-msgid "SSH2 hostname is required"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:95
-msgid "SSH2 username is required"
-msgstr ""
-
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:105
-msgid "SSH2 password is required"
-msgstr ""
-
-#. translators: %s: hostname:port
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:131
-msgid "Failed to connect to SSH2 Server %s"
-msgstr ""
-
-#. translators: %s: Username.
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:158
-msgid "Public and Private keys incorrect for %s"
-msgstr ""
-
-#. translators: %s: hostname:port
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:174
-msgid "Failed to initialize a SFTP subsystem session with the SSH2 Server %s"
-msgstr ""
-
-#. translators: %s: Command.
-#: wp-admin/includes/class-wp-filesystem-ssh2.php:226
-msgid "Unable to perform command: %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-links-list-table.php:79
-msgid "No links found."
-msgstr ""
-
-#: wp-admin/includes/class-wp-links-list-table.php:135
-msgid "Relationship"
-msgstr ""
-
-#: wp-admin/includes/class-wp-links-list-table.php:136
-msgid "Visible"
-msgstr ""
-
-#: wp-admin/includes/class-wp-links-list-table.php:137
-#: wp-admin/includes/meta-boxes.php:1503
-msgid "Rating"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Link name.
-#. translators: Hidden accessibility text. %s: Attachment title.
-#. translators: %s: Site URL.
-#. translators: Hidden accessibility text. %s: Theme name
-#. translators: Hidden accessibility text. %s: User login.
-#. translators: Hidden accessibility text. %s: Plugin name.
-#. translators: %s: Post title.
-#. translators: Hidden accessibility text. %s: Taxonomy term name.
-#. translators: %s: Plugin name.
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-links-list-table.php:180
-#: wp-admin/includes/class-wp-media-list-table.php:417
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:408
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:520
-#: wp-admin/includes/class-wp-ms-users-list-table.php:241
-#: wp-admin/includes/class-wp-plugins-list-table.php:989
-#: wp-admin/includes/class-wp-posts-list-table.php:1018
-#: wp-admin/includes/class-wp-terms-list-table.php:363
-#: wp-admin/includes/class-wp-users-list-table.php:530
-#: wp-admin/update-core.php:431
-#: wp-admin/update-core.php:605
-msgid "Select %s"
-msgstr ""
-
-#. translators: %s: Link name.
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#. translators: %s: Taxonomy term name.
-#: wp-admin/includes/class-wp-links-list-table.php:200
-#: wp-admin/includes/class-wp-media-list-table.php:757
-#: wp-admin/includes/class-wp-media-list-table.php:809
-#: wp-admin/includes/class-wp-posts-list-table.php:1449
-#: wp-admin/includes/class-wp-terms-list-table.php:476
-#: wp-admin/includes/dashboard.php:676
-#: wp-admin/includes/dashboard.php:1046
-msgid "Edit &#8220;%s&#8221;"
-msgstr ""
-
-#. translators: %s: Link name.
-#: wp-admin/includes/class-wp-links-list-table.php:342
-#: wp-admin/includes/meta-boxes.php:1150
-msgid ""
-"You are about to delete this link '%s'\n"
-"  'Cancel' to stop, 'OK' to delete."
-msgstr ""
-
-#: wp-admin/includes/class-wp-list-table.php:169
-#: wp-admin/includes/class-wp-screen.php:1327
-msgid "Compact view"
-msgstr ""
-
-#: wp-admin/includes/class-wp-list-table.php:170
-#: wp-admin/includes/class-wp-screen.php:1331
-msgid "Extended view"
-msgstr ""
-
-#. translators: %s: The $link_data argument.
-#: wp-admin/includes/class-wp-list-table.php:398
-msgid "The %s argument must be an array."
-msgstr ""
-
-#. translators: %1$s: The argument name. %2$s: The view name.
-#: wp-admin/includes/class-wp-list-table.php:415
-#: wp-admin/includes/class-wp-list-table.php:430
-msgid "The %1$s argument must be a non-empty string for %2$s."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:565
-msgid "Select bulk action"
-msgstr ""
-
-#: wp-admin/includes/class-wp-list-table.php:589
-#: wp-admin/includes/class-wp-screen.php:1090
-#: wp-includes/class-wp-customize-widgets.php:779
-#: wp-includes/class-wp-editor.php:1391
-#: wp-includes/media.php:4620
-msgid "Apply"
-msgstr ""
-
-#: wp-admin/includes/class-wp-list-table.php:733
-#: wp-admin/includes/media.php:2783
-#: wp-includes/media.php:4605
-msgid "All dates"
-msgstr ""
-
-#. translators: 1: Month name, 2: 4-digit year.
-#. translators: 1: Month, 2: Year.
-#: wp-admin/includes/class-wp-list-table.php:748
-#: wp-includes/general-template.php:2044
-#: wp-includes/media.php:4502
-msgid "%1$s %2$d"
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-list-table.php:805
-msgid "%s comment"
-msgid_plural "%s comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-list-table.php:811
-msgid "%s approved comment"
-msgid_plural "%s approved comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/includes/class-wp-list-table.php:817
-msgid "%s pending comment"
-msgid_plural "%s pending comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:839
-#: wp-admin/includes/class-wp-list-table.php:873
-#: wp-admin/includes/class-wp-list-table.php:900
-msgid "No comments"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:871
-msgid "No approved comments"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:898
-msgid "No pending comments"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1026
-msgid "First page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1038
-#: wp-admin/includes/nav-menu.php:462
-#: wp-admin/includes/nav-menu.php:764
-#: wp-includes/post-template.php:955
-msgid "Previous page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1047
-#: wp-admin/includes/class-wp-list-table.php:1054
-msgid "Current Page"
-msgstr ""
-
-#. translators: 1: Current page, 2: Total pages.
-#: wp-admin/includes/class-wp-list-table.php:1063
-msgctxt "paging"
-msgid "%1$s of %2$s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1075
-#: wp-admin/includes/nav-menu.php:463
-#: wp-admin/includes/nav-menu.php:765
-#: wp-includes/post-template.php:954
-msgid "Next page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1087
-msgid "Last page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-list-table.php:1325
-#: wp-admin/includes/nav-menu.php:678
-#: wp-admin/includes/nav-menu.php:915
-#: wp-admin/update-core.php:335
-#: wp-admin/update-core.php:463
-#: wp-admin/update-core.php:515
-#: wp-admin/update-core.php:637
-msgid "Select All"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-media-list-table.php:43
-#: wp-includes/media-template.php:326
-msgid "List view"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-media-list-table.php:44
-#: wp-includes/media-template.php:334
-msgid "Grid view"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:134
-#: wp-includes/media.php:4604
-msgid "All media items"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:157
-#: wp-includes/media.php:4608
-msgctxt "media items"
-msgid "Unattached"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:162
-#: wp-includes/media.php:4609
-msgctxt "media items"
-msgid "Mine"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:169
-msgctxt "attachment filter"
-msgid "Trash"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:194
-#: wp-admin/includes/class-wp-media-list-table.php:611
-#: wp-admin/includes/class-wp-media-list-table.php:800
-msgid "Attach"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:259
-msgid "No media files found in Trash."
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:261
-msgid "No media files found."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-media-list-table.php:284
-#: wp-includes/media.php:4622
-msgid "Filter by type"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-media-list-table.php:315
-#: wp-admin/includes/class-wp-theme-install-list-table.php:58
-#: wp-admin/includes/nav-menu.php:523
-#: wp-admin/includes/nav-menu.php:589
-#: wp-admin/includes/nav-menu.php:594
-#: wp-admin/includes/nav-menu.php:825
-#: wp-admin/includes/nav-menu.php:890
-#: wp-admin/includes/nav-menu.php:895
-#: wp-admin/includes/template.php:1927
-#: wp-admin/includes/template.php:1932
-#: wp-admin/includes/theme-install.php:139
-#: wp-includes/admin-bar.php:1090
-#: wp-includes/admin-bar.php:1092
-#: wp-includes/class-wp-editor.php:1903
-#: wp-includes/media.php:4578
-#: wp-includes/media.php:4623
-msgid "Search"
-msgstr ""
-
-#. translators: Column name.
-#: wp-admin/includes/class-wp-media-list-table.php:329
-msgctxt "column name"
-msgid "File"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:360
-msgctxt "column name"
-msgid "Uploaded to"
-msgstr ""
-
-#. translators: Column name.
-#: wp-admin/includes/class-wp-media-list-table.php:373
-msgctxt "column name"
-msgid "Date"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#. translators: %s: Taxonomy term name.
-#: wp-admin/includes/class-wp-media-list-table.php:455
-#: wp-admin/includes/class-wp-posts-list-table.php:1116
-#: wp-admin/includes/class-wp-terms-list-table.php:410
-msgid "&#8220;%s&#8221; (Edit)"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-media-list-table.php:481
-#: wp-admin/includes/media.php:1636
-#: wp-admin/includes/media.php:3289
-#: wp-includes/media-template.php:452
-msgid "File name:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:530
-#: wp-admin/includes/class-wp-posts-list-table.php:1163
-msgid "Unpublished"
-msgstr ""
-
-#. translators: %s: Human-readable time difference.
-#: wp-admin/includes/class-wp-media-list-table.php:537
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:736
-#: wp-admin/includes/class-wp-privacy-requests-table.php:475
-#: wp-admin/includes/plugin-install.php:692
-#: wp-admin/includes/revision.php:250
-#: wp-admin/includes/revision.php:293
-msgid "%s ago"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:580
-msgid "(Private post)"
-msgstr ""
-
-#. translators: %s: Title of the post the attachment is attached to.
-#: wp-admin/includes/class-wp-media-list-table.php:596
-msgid "Detach from &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:597
-msgid "Detach"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:601
-msgid "(Unattached)"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#: wp-admin/includes/class-wp-media-list-table.php:610
-#: wp-admin/includes/class-wp-media-list-table.php:799
-msgid "Attach &#8220;%s&#8221; to existing content"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#: wp-admin/includes/class-wp-media-list-table.php:768
-#: wp-admin/includes/class-wp-media-list-table.php:828
-#: wp-admin/includes/class-wp-posts-list-table.php:1475
-msgid "Move &#8220;%s&#8221; to the Trash"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#: wp-admin/includes/class-wp-media-list-table.php:778
-#: wp-admin/includes/class-wp-media-list-table.php:840
-#: wp-admin/includes/class-wp-posts-list-table.php:1485
-msgid "Delete &#8220;%s&#8221; permanently"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#: wp-admin/includes/class-wp-media-list-table.php:789
-#: wp-admin/includes/class-wp-media-list-table.php:852
-#: wp-admin/includes/class-wp-posts-list-table.php:1508
-msgid "View &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:790
-#: wp-admin/includes/class-wp-media-list-table.php:853
-#: wp-admin/includes/class-wp-ms-users-list-table.php:420
-#: wp-admin/includes/class-wp-posts-list-table.php:1509
-#: wp-admin/includes/class-wp-terms-list-table.php:503
-#: wp-admin/includes/class-wp-users-list-table.php:498
-#: wp-admin/includes/dashboard.php:801
-msgid "View"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#. translators: %s: Post title.
-#: wp-admin/includes/class-wp-media-list-table.php:820
-#: wp-admin/includes/class-wp-posts-list-table.php:1467
-msgid "Restore &#8220;%s&#8221; from the Trash"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#: wp-admin/includes/class-wp-media-list-table.php:861
-msgid "Copy &#8220;%s&#8221; URL to clipboard"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:862
-msgid "Copy URL"
-msgstr ""
-
-#. translators: %s: Attachment title.
-#: wp-admin/includes/class-wp-media-list-table.php:870
-msgid "Download &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-media-list-table.php:871
-#: wp-admin/includes/media.php:3286
-#: wp-includes/media-template.php:559
-msgid "Download file"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:38
-#: wp-admin/network/site-info.php:192
-msgid "Archived"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:39
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:720
-#: wp-admin/network/site-info.php:193
-msgctxt "site"
-msgid "Spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:40
-#: wp-admin/network/site-info.php:194
-msgid "Deleted"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:41
-#: wp-admin/network/site-info.php:196
-msgid "Mature"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:206
-msgid "No sites found."
-msgstr ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:221
-msgctxt "sites"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:228
-msgid "Public <span class=\"count\">(%s)</span>"
-msgid_plural "Public <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:234
-msgid "Archived <span class=\"count\">(%s)</span>"
-msgid_plural "Archived <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:240
-msgid "Mature <span class=\"count\">(%s)</span>"
-msgid_plural "Mature <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:246
-msgctxt "sites"
-msgid "Spam <span class=\"count\">(%s)</span>"
-msgid_plural "Spam <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:253
-msgid "Deleted <span class=\"count\">(%s)</span>"
-msgid_plural "Deleted <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:287
-msgctxt "site"
-msgid "Mark as spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:288
-msgctxt "site"
-msgid "Not spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:359
-#: wp-admin/network/site-info.php:186
-msgid "Last Updated"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:360
-#: wp-admin/network/site-info.php:182
-msgctxt "site"
-msgid "Registered"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:361
-#: wp-admin/includes/ms.php:853
-#: wp-admin/includes/ms.php:1058
-#: wp-admin/menu.php:270
-#: wp-admin/network/menu.php:55
-#: wp-admin/network/users.php:34
-#: wp-admin/network/users.php:69
-#: wp-admin/network/users.php:221
-#: wp-admin/network/users.php:283
-#: wp-admin/users.php:25
-#: wp-includes/admin-bar.php:526
-msgid "Users"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:365
-#: wp-admin/includes/media.php:2517
-msgid "Actions"
-msgstr ""
-
-#. translators: 1: Site title, 2: Site tagline.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:452
-msgid "%1$s &#8211; %2$s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:476
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:497
-#: wp-admin/includes/class-wp-ms-users-list-table.php:344
-msgid "Y/m/d g:i:s a"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:479
-msgid "Never"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:616
-msgid "Main"
-msgstr ""
-
-#. translators: Network menu item.
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:703
-#: wp-admin/index.php:33
-#: wp-admin/menu.php:24
-#: wp-admin/my-sites.php:128
-#: wp-admin/network/index.php:21
-#: wp-admin/network/menu.php:11
-#: wp-admin/network/site-info.php:143
-#: wp-admin/network/site-settings.php:95
-#: wp-admin/network/site-themes.php:180
-#: wp-admin/network/site-users.php:225
-#: wp-admin/user/menu.php:10
-#: wp-includes/admin-bar.php:396
-#: wp-includes/admin-bar.php:505
-#: wp-includes/admin-bar.php:629
-#: wp-includes/deprecated.php:2812
-#: wp-includes/deprecated.php:2814
-msgid "Dashboard"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:708
-#: wp-admin/includes/class-wp-plugins-list-table.php:603
-#: wp-admin/includes/class-wp-plugins-list-table.php:844
-msgid "Deactivate"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:712
-msgid "Unarchive"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:714
-msgctxt "verb; site"
-msgid "Archive"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:718
-msgctxt "site"
-msgid "Not Spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-sites-list-table.php:728
-#: wp-admin/my-sites.php:125
-#: wp-admin/network/site-info.php:143
-#: wp-admin/network/site-settings.php:95
-#: wp-admin/network/site-themes.php:180
-#: wp-admin/network/site-users.php:225
-msgid "Visit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:318
-msgid "No themes found."
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:320
-msgid "No themes are currently available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:330
-msgid "Theme"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:335
-#: wp-admin/includes/class-wp-plugins-list-table.php:466
-msgid "Automatic Updates"
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:378
-msgctxt "themes"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:387
-msgctxt "themes"
-msgid "Enabled <span class=\"count\">(%s)</span>"
-msgid_plural "Enabled <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:396
-msgctxt "themes"
-msgid "Disabled <span class=\"count\">(%s)</span>"
-msgid_plural "Disabled <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:405
-msgctxt "themes"
-msgid "Update Available <span class=\"count\">(%s)</span>"
-msgid_plural "Update Available <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:414
-msgctxt "themes"
-msgid "Broken <span class=\"count\">(%s)</span>"
-msgid_plural "Broken <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:423
-#: wp-admin/includes/class-wp-plugins-list-table.php:561
-msgid "Auto-updates Enabled <span class=\"count\">(%s)</span>"
-msgid_plural "Auto-updates Enabled <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of themes.
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:431
-#: wp-admin/includes/class-wp-plugins-list-table.php:569
-msgid "Auto-updates Disabled <span class=\"count\">(%s)</span>"
-msgid_plural "Auto-updates Disabled <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:467
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:586
-msgid "Enable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:470
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:612
-msgid "Disable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:470
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:612
-msgid "Network Disable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:483
-#: wp-admin/includes/class-wp-plugins-list-table.php:617
-msgid "Enable Auto-updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:487
-#: wp-admin/includes/class-wp-plugins-list-table.php:620
-msgid "Disable Auto-updates"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:576
-msgid "Enable %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:579
-msgid "Network Enable %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:602
-msgid "Disable %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:605
-msgid "Network Disable %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:633
-#: wp-admin/themes.php:1169
-msgctxt "theme"
-msgid "Delete %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:699
-msgid "Broken Theme:"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:730
-msgid "Visit theme site for %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:736
-msgid "Visit Theme Site"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:743
-msgid "Child theme of %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:805
-#: wp-admin/includes/class-wp-plugins-list-table.php:1179
-#: wp-admin/themes.php:703
-#: wp-admin/js/updates.js:2980
-msgid "Disable auto-updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:809
-#: wp-admin/includes/class-wp-plugins-list-table.php:1183
-#: wp-admin/themes.php:707
-#: wp-admin/js/updates.js:2991
-msgid "Enable auto-updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-themes-list-table.php:930
-msgid "Active Child Theme"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:116
-msgctxt "user"
-msgid "Mark as spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:117
-msgctxt "user"
-msgid "Not spam"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:125
-#: wp-admin/includes/class-wp-users-list-table.php:158
-#: wp-admin/includes/deprecated.php:578
-msgid "No users found."
-msgstr ""
-
-#. translators: Number of users.
-#. translators: %s: Number of users.
-#: wp-admin/includes/class-wp-ms-users-list-table.php:144
-#: wp-admin/includes/class-wp-users-list-table.php:206
-msgctxt "users"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: Number of users.
-#: wp-admin/includes/class-wp-ms-users-list-table.php:159
-msgid "Super Admin <span class=\"count\">(%s)</span>"
-msgid_plural "Super Admins <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:193
-#: wp-admin/includes/class-wp-users-list-table.php:373
-#: wp-admin/includes/file.php:2430
-#: wp-admin/install.php:118
-#: wp-admin/install.php:434
-#: wp-admin/network/site-users.php:321
-#: wp-admin/network/site-users.php:356
-#: wp-admin/network/user-new.php:126
-#: wp-admin/setup-config.php:230
-#: wp-admin/user-edit.php:432
-#: wp-admin/user-new.php:532
-#: wp-login.php:1079
-msgid "Username"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:196
-msgctxt "user"
-msgid "Registered"
-msgstr ""
-
-#. translators: Sites menu item.
-#: wp-admin/includes/class-wp-ms-users-list-table.php:197
-#: wp-admin/network/menu.php:51
-#: wp-admin/network/sites.php:21
-#: wp-admin/network/sites.php:367
-#: wp-includes/admin-bar.php:515
-msgid "Sites"
-msgstr ""
-
-#: wp-admin/includes/class-wp-ms-users-list-table.php:285
-#: wp-admin/includes/class-wp-users-list-table.php:455
-#: wp-admin/user-edit.php:463
-msgid "Super Admin"
-msgstr ""
-
-#. translators: 1: User's first name, 2: Last name.
-#: wp-admin/includes/class-wp-ms-users-list-table.php:303
-#: wp-admin/includes/class-wp-users-list-table.php:576
-#: wp-includes/author-template.php:513
-#: wp-includes/user.php:855
-#: wp-includes/user.php:2272
-msgctxt "Display name based on first name and last name"
-msgid "%1$s %2$s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-ms-users-list-table.php:314
-#: wp-admin/includes/class-wp-users-list-table.php:588
-msgctxt "name"
-msgid "Unknown"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:105
-#: wp-admin/includes/class-wp-theme-install-list-table.php:60
-#: wp-admin/includes/file.php:32
-#: wp-admin/js/updates.js:2575
-msgid "Search Results"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:108
-msgctxt "Plugin Installer"
-msgid "Popular"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:109
-msgctxt "Plugin Installer"
-msgid "Categories"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:114
-#: wp-admin/plugin-install.php:147
-#: wp-admin/update.php:188
-msgid "Upload Plugin"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:256
-#: wp-admin/includes/class-wp-theme-install-list-table.php:158
-#: wp-admin/setup-config.php:288
-#: wp-admin/theme-install.php:67
-msgid "Try Again"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:259
-#: wp-admin/js/updates.js:2684
-msgid "No plugins found. Try a different search."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:442
-msgctxt "Plugin installer group title"
-msgid "Performance"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:443
-msgctxt "Plugin installer group title"
-msgid "Social"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:444
-msgctxt "Plugin installer group title"
-msgid "Tools"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:531
-#: wp-admin/includes/plugin-install.php:895
-msgctxt "plugin"
-msgid "Cannot Install"
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:546
-#: wp-admin/includes/update.php:528
-#: wp-admin/js/updates.js:2138
-msgctxt "plugin"
-msgid "Update %s now"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:548
-#: wp-admin/js/updates.js:644
-msgid "Update Now"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:553
-#: wp-admin/includes/plugin-install.php:907
-msgctxt "plugin"
-msgid "Cannot Update"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:564
-msgctxt "plugin"
-msgid "Active"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:570
-#: wp-admin/includes/class-wp-plugins-list-table.php:866
-#: wp-admin/js/updates.js:762
-msgctxt "plugin"
-msgid "Activate %s"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:583
-#: wp-admin/includes/class-wp-plugins-list-table.php:805
-#: wp-admin/js/updates.js:751
-msgctxt "plugin"
-msgid "Network Activate %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:596
-#: wp-admin/includes/class-wp-plugins-list-table.php:811
-#: wp-admin/includes/class-wp-plugins-list-table.php:872
-msgctxt "plugin"
-msgid "Cannot Activate"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:602
-msgctxt "plugin"
-msgid "Installed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:620
-msgid "More Details"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:652
-#: wp-admin/includes/class-wp-plugins-list-table.php:1273
-msgid "This plugin does not work with your versions of ClassicPress and PHP."
-msgstr ""
-
-#. translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:656
-#: wp-admin/includes/class-wp-plugins-list-table.php:1277
-#: wp-admin/includes/theme.php:869
-#: wp-admin/includes/theme.php:946
-#: wp-admin/includes/update.php:732
-#: wp-admin/theme-install.php:297
-#: wp-admin/theme-install.php:502
-#: wp-admin/themes.php:418
-#: wp-admin/themes.php:478
-#: wp-admin/themes.php:769
-#: wp-admin/themes.php:833
-#: wp-admin/themes.php:994
-#: wp-admin/themes.php:1061
-#: wp-admin/update-core.php:541
-#: wp-includes/customize/class-wp-customize-theme-control.php:122
-#: wp-includes/customize/class-wp-customize-theme-control.php:187
-msgid "<a href=\"%1$s\">Please update ClassicPress</a>, and then <a href=\"%2$s\">learn more about updating PHP</a>."
-msgstr ""
-
-#. translators: %s: URL to WordPress Updates screen.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:664
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:680
-#: wp-admin/includes/class-wp-plugins-list-table.php:1285
-#: wp-admin/includes/class-wp-plugins-list-table.php:1301
-#: wp-admin/includes/theme.php:877
-#: wp-admin/includes/theme.php:899
-#: wp-admin/includes/theme.php:954
-#: wp-admin/includes/theme.php:972
-#: wp-admin/includes/update.php:740
-#: wp-admin/includes/update.php:760
-#: wp-admin/theme-install.php:305
-#: wp-admin/theme-install.php:327
-#: wp-admin/theme-install.php:510
-#: wp-admin/theme-install.php:532
-#: wp-admin/themes.php:426
-#: wp-admin/themes.php:446
-#: wp-admin/themes.php:486
-#: wp-admin/themes.php:502
-#: wp-admin/themes.php:777
-#: wp-admin/themes.php:799
-#: wp-admin/themes.php:841
-#: wp-admin/themes.php:859
-#: wp-admin/themes.php:1002
-#: wp-admin/themes.php:1020
-#: wp-admin/themes.php:1069
-#: wp-admin/themes.php:1091
-#: wp-admin/update-core.php:554
-#: wp-admin/update-core.php:575
-#: wp-includes/customize/class-wp-customize-theme-control.php:130
-#: wp-includes/customize/class-wp-customize-theme-control.php:152
-#: wp-includes/customize/class-wp-customize-theme-control.php:195
-#: wp-includes/customize/class-wp-customize-theme-control.php:217
-msgid "<a href=\"%s\">Please update ClassicPress</a>."
-msgstr ""
-
-#. translators: %s: URL to Update PHP page.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:670
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:689
-#: wp-admin/includes/class-wp-plugins-list-table.php:1291
-#: wp-admin/includes/class-wp-plugins-list-table.php:1310
-#: wp-admin/includes/plugin.php:1148
-#: wp-admin/includes/theme.php:883
-#: wp-admin/includes/theme.php:914
-#: wp-admin/includes/theme.php:960
-#: wp-admin/includes/theme.php:983
-#: wp-admin/includes/update-core.php:357
-#: wp-admin/includes/update.php:746
-#: wp-admin/includes/update.php:773
-#: wp-admin/install.php:253
-#: wp-admin/theme-install.php:311
-#: wp-admin/theme-install.php:338
-#: wp-admin/theme-install.php:516
-#: wp-admin/theme-install.php:543
-#: wp-admin/themes.php:432
-#: wp-admin/themes.php:459
-#: wp-admin/themes.php:492
-#: wp-admin/themes.php:511
-#: wp-admin/themes.php:783
-#: wp-admin/themes.php:814
-#: wp-admin/themes.php:847
-#: wp-admin/themes.php:870
-#: wp-admin/themes.php:1008
-#: wp-admin/themes.php:1031
-#: wp-admin/themes.php:1075
-#: wp-admin/themes.php:1106
-#: wp-admin/update-core.php:560
-#: wp-admin/update-core.php:584
-#: wp-admin/upgrade.php:87
-#: wp-includes/customize/class-wp-customize-theme-control.php:136
-#: wp-includes/customize/class-wp-customize-theme-control.php:167
-#: wp-includes/customize/class-wp-customize-theme-control.php:201
-#: wp-includes/customize/class-wp-customize-theme-control.php:228
-msgid "<a href=\"%s\">Learn more about updating PHP</a>."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:676
-#: wp-admin/includes/class-wp-plugins-list-table.php:1297
-msgid "This plugin does not work with your version of ClassicPress."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:685
-#: wp-admin/includes/class-wp-plugins-list-table.php:1306
-msgid "This plugin does not work with your version of PHP."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:733
-#: wp-admin/includes/plugin-install.php:689
-msgid "Last Updated:"
-msgstr ""
-
-#. translators: %s: Number of millions.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:745
-#: wp-admin/includes/plugin-install.php:720
-msgctxt "Active plugin installations"
-msgid "%s+ Million"
-msgid_plural "%s+ Million"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:749
-#: wp-admin/includes/plugin-install.php:724
-msgctxt "Active plugin installations"
-msgid "Less Than 10"
-msgstr ""
-
-#. translators: %s: Number of installations.
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:754
-msgid "%s Active Installations"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:760
-msgid "Untested with your version of ClassicPress"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:762
-msgid "<strong>Incompatible</strong> with your version of ClassicPress"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugin-install-list-table.php:764
-msgid "<strong>Compatible</strong> with your version of ClassicPress"
-msgstr ""
-
-#. translators: %s: Plugin search term.
-#: wp-admin/includes/class-wp-plugins-list-table.php:409
-msgid "No plugins found for: %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:413
-msgid "Search for plugins in the ClassicPress Plugin Directory."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:416
-msgid "No plugins found."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:418
-#: wp-admin/plugin-editor.php:32
-#: wp-admin/js/updates.js:1061
-msgid "No plugins are currently available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:446
-msgid "Search installed plugins..."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:461
-msgid "Plugin"
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:496
-msgctxt "plugins"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:505
-msgid "Active <span class=\"count\">(%s)</span>"
-msgid_plural "Active <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:513
-msgid "Recently Active <span class=\"count\">(%s)</span>"
-msgid_plural "Recently Active <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:521
-msgid "Inactive <span class=\"count\">(%s)</span>"
-msgid_plural "Inactive <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:529
-msgid "Must-Use <span class=\"count\">(%s)</span>"
-msgid_plural "Must-Use <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:537
-msgid "Drop-in <span class=\"count\">(%s)</span>"
-msgid_plural "Drop-ins <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:545
-msgid "Paused <span class=\"count\">(%s)</span>"
-msgid_plural "Paused <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/class-wp-plugins-list-table.php:553
-msgid "Update Available <span class=\"count\">(%s)</span>"
-msgid_plural "Update Available <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:603
-#: wp-admin/includes/class-wp-plugins-list-table.php:794
-msgid "Network Deactivate"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:656
-msgid "Clear List"
-msgstr ""
-
-#. translators: %s: mu-plugins directory name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:660
-msgid "Files in the %s directory are executed automatically."
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:764
-msgid "Inactive:"
-msgstr ""
-
-#. translators: 1: Drop-in constant name, 2: wp-config.php
-#: wp-admin/includes/class-wp-plugins-list-table.php:767
-msgid "Requires %1$s in %2$s file."
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:793
-msgctxt "plugin"
-msgid "Network Deactivate %s"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:822
-#: wp-admin/includes/class-wp-plugins-list-table.php:883
-msgctxt "plugin"
-msgid "Delete %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:830
-msgid "Network Active"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:834
-msgid "Network Only"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:843
-msgctxt "plugin"
-msgid "Deactivate %s"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:854
-msgctxt "plugin"
-msgid "Resume %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:855
-#: wp-admin/themes.php:631
-msgid "Resume"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:1076
-msgid "View details"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-plugins-list-table.php:1080
-msgid "Visit plugin site for %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:1086
-msgid "Visit plugin site"
-msgstr ""
-
-#: wp-admin/includes/class-wp-plugins-list-table.php:1143
-msgid "This plugin failed to load properly and is paused during recovery mode."
-msgstr ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/includes/class-wp-posts-list-table.php:324
-msgctxt "posts"
-msgid "Mine <span class=\"count\">(%s)</span>"
-msgid_plural "Mine <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/includes/class-wp-posts-list-table.php:345
-msgctxt "posts"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/includes/class-wp-posts-list-table.php:404
-msgctxt "posts"
-msgid "Sticky <span class=\"count\">(%s)</span>"
-msgid_plural "Sticky <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-posts-list-table.php:540
-msgid "Filter by post format"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:544
-msgid "All formats"
-msgstr ""
-
-#. translators: Posts screen column name.
-#: wp-admin/includes/class-wp-posts-list-table.php:664
-msgctxt "column name"
-msgid "Title"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Post title.
-#: wp-admin/includes/class-wp-posts-list-table.php:1028
-msgid "&#8220;%s&#8221; is locked"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/class-wp-posts-list-table.php:1097
-#: wp-admin/includes/misc.php:1205
-msgid "%s is currently editing"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1183
-msgid "Missed schedule"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1188
-#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:63
-#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:177
-msgid "Last Modified"
-msgstr ""
-
-#. translators: %s: Post title.
-#. translators: %s: Taxonomy term name.
-#: wp-admin/includes/class-wp-posts-list-table.php:1456
-#: wp-admin/includes/class-wp-terms-list-table.php:482
-msgid "Quick edit &#8220;%s&#8221; inline"
-msgstr ""
-
-#. translators: %s: Post title.
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-posts-list-table.php:1499
-#: wp-admin/includes/class-wp-theme-install-list-table.php:282
-msgid "Preview &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1624
-msgid "Bulk Edit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1624
-#: wp-admin/includes/class-wp-terms-list-table.php:662
-msgid "Quick Edit"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1684
-#: wp-admin/includes/class-wp-posts-list-table.php:1787
-#: wp-admin/includes/class-wp-posts-list-table.php:1826
-#: wp-admin/includes/class-wp-posts-list-table.php:1883
-#: wp-admin/includes/class-wp-posts-list-table.php:1896
-#: wp-admin/includes/class-wp-posts-list-table.php:1940
-#: wp-admin/includes/class-wp-posts-list-table.php:1963
-#: wp-admin/includes/class-wp-posts-list-table.php:1988
-msgid "&mdash; No Change &mdash;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1720
-#: wp-admin/includes/file.php:2431
-#: wp-admin/install.php:137
-#: wp-admin/install.php:438
-#: wp-admin/options-writing.php:172
-#: wp-admin/setup-config.php:235
-#: wp-admin/user-new.php:582
-#: wp-includes/general-template.php:496
-#: wp-login.php:1424
-msgid "Password"
-msgstr ""
-
-#. translators: Between password field and private checkbox on post quick edit interface.
-#: wp-admin/includes/class-wp-posts-list-table.php:1727
-msgid "&ndash;OR&ndash;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1732
-#: wp-admin/includes/class-wp-posts-list-table.php:1947
-#: wp-admin/includes/meta-boxes.php:180
-#: wp-admin/includes/meta-boxes.php:220
-#: wp-includes/post.php:938
-#: wp-includes/post.php:958
-#: wp-admin/js/post.js:906
-msgid "Private"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1775
-#: wp-admin/includes/meta-boxes.php:1039
-msgid "Parent"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1781
-msgid "Main Page (no parent)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1812
-#: wp-admin/includes/media.php:1412
-#: wp-admin/includes/media.php:2516
-#: wp-admin/includes/meta-boxes.php:1080
-msgid "Order"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1823
-#: wp-admin/includes/meta-boxes.php:1048
-#: wp-includes/class-wp-xmlrpc-server.php:567
-msgid "Template"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1830
-#: wp-admin/includes/meta-boxes.php:1073
-msgid "Default template"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1884
-#: wp-admin/includes/class-wp-posts-list-table.php:1897
-msgid "Allow"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1885
-#: wp-admin/includes/class-wp-posts-list-table.php:1898
-msgid "Do not allow"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1914
-msgid "Allow Comments"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1923
-msgid "Allow Pings"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1961
-#: wp-admin/includes/class-wp-posts-list-table.php:1964
-msgid "Sticky"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1965
-msgid "Not Sticky"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1973
-msgid "Make this post sticky"
-msgstr ""
-
-#: wp-admin/includes/class-wp-posts-list-table.php:1986
-#: wp-admin/includes/meta-boxes.php:1611
-#: wp-includes/taxonomy.php:178
-msgctxt "post format"
-msgid "Format"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:60
-msgid "Download personal data"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:61
-msgid "Downloading data..."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:62
-msgid "Download personal data again"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:63
-#: wp-admin/includes/class-wp-upgrader.php:160
-msgid "Download failed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:63
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:136
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:142
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:68
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:142
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:149
-msgid "Retry"
-msgstr ""
-
-#. translators: %s: Request email.
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:88
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:94
-msgid "Mark export request for &#8220;%s&#8221; as completed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:92
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:98
-msgid "Complete request"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:116
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:122
-msgid "Waiting for confirmation"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:133
-msgid "Send export link"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:134
-msgid "Sending email..."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:135
-msgid "Email sent."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:136
-msgid "Email could not be sent."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php:156
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:163
-msgid "Remove request"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:65
-msgid "Force erase personal data"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:66
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:140
-msgid "Erasing data..."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:67
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:141
-msgid "Erasure completed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:68
-msgid "Force erasure has failed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:139
-msgid "Erase personal data"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php:142
-msgid "Data erasure has failed."
-msgstr ""
-
-#. translators: %s: Privacy Policy Guide URL.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:147
-msgid "The suggested privacy policy text has changed. Please <a href=\"%s\">review the guide</a> and update your privacy policy."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-policy-content.php:335
-msgid "Need help putting together your new Privacy Policy page? Check out our guide for recommendations on what content to include, along with policies suggested by your plugins and theme."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-policy-content.php:337
-msgid "View Privacy Policy Guide."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:349
-#: wp-admin/includes/class-wp-site-health.php:753
-#: wp-admin/includes/class-wp-site-health.php:843
-#: wp-admin/includes/class-wp-site-health.php:1170
-#: wp-admin/includes/class-wp-site-health.php:1405
-#: wp-admin/includes/class-wp-site-health.php:1443
-#: wp-admin/includes/class-wp-site-health.php:1523
-#: wp-admin/includes/class-wp-site-health.php:1605
-#: wp-admin/includes/class-wp-site-health.php:1624
-#: wp-admin/includes/class-wp-site-health.php:2243
-#: wp-admin/includes/class-wp-site-health.php:2276
-#: wp-admin/includes/class-wp-site-health.php:2402
-#: wp-admin/includes/dashboard.php:1684
-#: wp-admin/includes/media.php:3172
-#: wp-admin/includes/meta-boxes.php:80
-#: wp-admin/includes/theme.php:842
-#: wp-includes/class-wp-customize-manager.php:4371
-#: wp-includes/class-wp-customize-manager.php:5694
-#: wp-includes/class-wp-customize-manager.php:5715
-#: wp-includes/customize/class-wp-customize-nav-menu-locations-control.php:58
-#: wp-includes/functions.php:8136
-#: wp-includes/media-template.php:167
-#: wp-includes/widgets/class-wp-widget-custom-html.php:318
-#: wp-login.php:631
-msgid "(opens in a new tab)"
-msgstr ""
-
-#. translators: %s: Date of plugin deactivation.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:377
-msgid "Removed %s."
-msgstr ""
-
-#. translators: %s: Date of plugin deactivation.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:380
-msgid "You deactivated this plugin on %s and may no longer need this policy."
-msgstr ""
-
-#. translators: %s: Date of privacy policy text update.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:386
-msgid "Updated %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-policy-content.php:411
-msgid "Copy suggested policy text to clipboard"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Plugin name.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:415
-msgid "Copy suggested policy text from %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-policy-content.php:437
-msgid "Suggested text:"
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:447
-msgid "Who we are"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:451
-msgid "In this section you should note your site URL, as well as the name of the company, organization, or individual behind it, and some accurate contact information."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:453
-msgid "The amount of information you may be required to show will vary depending on your local or national business regulations. You may, for example, be required to display a physical address, a registered address, or your company registration number."
-msgstr ""
-
-#. translators: Default privacy policy text. %s: Site URL.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:456
-msgid "Our website address is: %s."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:461
-msgid "What personal data we collect and why we collect it"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:463
-msgid "In this section you should note what personal data you collect from users and site visitors. This may include personal data, such as name, email address, personal account preferences; transactional data, such as purchase information; and technical data, such as information about cookies."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:465
-msgid "You should also note any collection and retention of sensitive personal data, such as data concerning health."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:467
-msgid "In addition to listing what personal data you collect, you need to note why you collect it. These explanations must note either the legal basis for your data collection and retention or the active consent the user has given."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:469
-msgid "Personal data is not just created by a user&#8217;s interactions with your site. Personal data is also generated from technical processes such as contact forms, comments, cookies, analytics, and third party embeds."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:471
-msgid "By default ClassicPress does not collect any personal data about visitors, and only collects the data shown on the User Profile screen from registered users. However some of your plugins may collect personal data. You should add the relevant information below."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:479
-msgid "In this subsection you should note what information is captured through comments. We have noted the data which ClassicPress collects by default."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:482
-msgid "When visitors leave comments on the site we collect the data shown in the comments form, and also the visitor&#8217;s IP address and browser user agent string to help spam detection."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:484
-msgid "An anonymized string created from your email address (also called a hash) may be provided to the Gravatar service to see if you are using it. The Gravatar service privacy policy is available here: https://automattic.com/privacy/. After approval of your comment, your profile picture is visible to the public in the context of your comment."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:492
-msgid "In this subsection you should note what information may be disclosed by users who can upload media files. All uploaded files are usually publicly accessible."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:495
-msgid "If you upload images to the website, you should avoid uploading images with embedded location data (EXIF GPS) included. Visitors to the website can download and extract any location data from images on the website."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:500
-msgid "Contact forms"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:502
-msgid "By default, ClassicPress does not include a contact form. If you use a contact form plugin, use this subsection to note what personal data is captured when someone submits a contact form, and how long you keep it. For example, you may note that you keep contact form submissions for a certain period for customer service purposes, but you do not use the information submitted through them for marketing purposes."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:506
-msgid "Cookies"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:510
-msgid "In this subsection you should list the cookies your web site uses, including those set by your plugins, social media, and analytics. We have provided the cookies which ClassicPress installs by default."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:513
-msgid "If you leave a comment on our site you may opt-in to saving your name, email address and website in cookies. These are for your convenience so that you do not have to fill in your details again when you leave another comment. These cookies will last for one year."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:515
-msgid "If you visit our login page, we will set a temporary cookie to determine if your browser accepts cookies. This cookie contains no personal data and is discarded when you close your browser."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:517
-msgid "When you log in, we will also set up several cookies to save your login information and your screen display choices. Login cookies last for two days, and screen options cookies last for a year. If you select &quot;Remember Me&quot;, your login will persist for two weeks. If you log out of your account, the login cookies will be removed."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:519
-msgid "If you edit or publish an article, an additional cookie will be saved in your browser. This cookie includes no personal data and simply indicates the post ID of the article you just edited. It expires after 1 day."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:524
-msgid "Embedded content from other websites"
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:526
-msgid "Articles on this site may include embedded content (e.g. videos, images, articles, etc.). Embedded content from other websites behaves in the exact same way as if the visitor has visited the other website."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:528
-msgid "These websites may collect data about you, use cookies, embed additional third-party tracking, and monitor your interaction with that embedded content, including tracking your interaction with the embedded content if you have an account and are logged in to that website."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:533
-msgid "Analytics"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:535
-msgid "In this subsection you should note what analytics package you use, how users can opt out of analytics tracking, and a link to your analytics provider&#8217;s privacy policy, if any."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:537
-msgid "By default ClassicPress does not collect any analytics data. However, many web hosting accounts collect some anonymous analytics data. You may also have installed a WordPress plugin that provides analytics services. In that case, add information from that plugin here."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:541
-msgid "Who we share your data with"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:545
-msgid "In this section you should name and list all third party providers with whom you share site data, including partners, cloud-based services, payment processors, and third party service providers, and note what data you share with them and why. Link to their own privacy policies if possible."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:547
-msgid "By default ClassicPress does not share any personal data with anyone."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:550
-msgid "If you request a password reset, your IP address will be included in the reset email."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:554
-msgid "How long we retain your data"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:558
-msgid "In this section you should explain how long you retain personal data collected or processed by the web site. While it is your responsibility to come up with the schedule of how long you keep each dataset for and why you keep it, that information does need to be listed here. For example, you may want to say that you keep contact form entries for six months, analytics records for a year, and customer purchase records for ten years."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:561
-msgid "If you leave a comment, the comment and its metadata are retained indefinitely. This is so we can recognize and approve any follow-up comments automatically instead of holding them in a moderation queue."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:563
-msgid "For users that register on our website (if any), we also store the personal information they provide in their user profile. All users can see, edit, or delete their personal information at any time (except they cannot change their username). Website administrators can also see and edit that information."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:567
-msgid "What rights you have over your data"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:571
-msgid "In this section you should explain what rights your users have over their data and how they can invoke those rights."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:574
-msgid "If you have an account on this site, or have left comments, you can request to receive an exported file of the personal data we hold about you, including any data you have provided to us. You can also request that we erase any personal data we hold about you. This does not include any data we are obliged to keep for administrative, legal, or security purposes."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:578
-msgid "Where your data is sent"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:582
-msgid "In this section you should list all transfers of your site data outside the European Union and describe the means by which that data is safeguarded to European data protection standards. This could include your web hosting, cloud storage, or other third party services."
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:584
-msgid "European data protection law requires data about European residents which is transferred outside the European Union to be safeguarded to the same standards as if the data was in Europe. So in addition to listing where data goes, you should describe how you ensure that these standards are met either by yourself or by your third party providers, whether that is through an agreement such as Privacy Shield, model clauses in your contracts, or binding corporate rules."
-msgstr ""
-
-#. translators: Default privacy policy text.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:587
-msgid "Visitor comments may be checked through an automated spam detection service."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:592
-msgid "Contact information"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:594
-msgid "In this section you should provide a contact method for privacy-specific concerns. If you are required to have a Data Protection Officer, list their name and full contact details here as well."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:599
-msgid "Additional information"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:601
-msgid "If you use your site for commercial purposes and you engage in more complex collection or processing of personal data, you should note the following information in your privacy policy in addition to the information we have already discussed."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:606
-msgid "How we protect your data"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:608
-msgid "In this section you should explain what measures you have taken to protect your users&#8217; data. This could include technical measures such as encryption; security measures such as two factor authentication; and measures such as staff training in data protection. If you have carried out a Privacy Impact Assessment, you can mention it here too."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:613
-msgid "What data breach procedures we have in place"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:615
-msgid "In this section you should explain what procedures you have in place to deal with data breaches, either potential or real, such as internal reporting systems, contact mechanisms, or bug bounties."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:620
-msgid "What third parties we receive data from"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:622
-msgid "If your web site receives data about users from third parties, including advertisers, this information must be included within the section of your privacy policy dealing with third party data."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:627
-msgid "What automated decision making and/or profiling we do with user data"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:629
-msgid "If your web site provides a service which includes automated decision making - for example, allowing customers to apply for credit, or aggregating their data into an advertising profile - you must note that this is taking place, and include information about how that information is used, what decisions are made with that aggregated data, and what rights users have over decisions made without human intervention."
-msgstr ""
-
-#. translators: Default privacy policy heading.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:634
-msgid "Industry regulatory disclosure requirements"
-msgstr ""
-
-#. translators: Privacy policy tutorial.
-#: wp-admin/includes/class-wp-privacy-policy-content.php:636
-msgid "If you are a member of a regulated industry, or if you are subject to additional privacy laws, you may be required to disclose that information here."
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:43
-msgid "Requester"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:45
-msgid "Requested"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:46
-msgid "Next steps"
-msgstr ""
-
-#. translators: %s: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:158
-msgctxt "requests"
-msgid "All <span class=\"count\">(%s)</span>"
-msgid_plural "All <span class=\"count\">(%s)</span>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:211
-msgid "Resend confirmation requests"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:212
-msgid "Mark requests as completed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-privacy-requests-table.php:213
-msgid "Delete requests"
-msgstr ""
-
-#. translators: %d: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:254
-msgid "%d confirmation request failed to resend."
-msgid_plural "%d confirmation requests failed to resend."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %d: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:271
-msgid "%d confirmation request re-sent successfully."
-msgid_plural "%d confirmation requests re-sent successfully."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %d: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:298
-msgid "%d request marked as complete."
-msgid_plural "%d requests marked as complete."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %d: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:324
-msgid "%d request failed to delete."
-msgid_plural "%d requests failed to delete."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %d: Number of requests.
-#: wp-admin/includes/class-wp-privacy-requests-table.php:341
-msgid "%d request deleted successfully."
-msgid_plural "%d requests deleted successfully."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-screen.php:288
-#: wp-admin/post.php:20
-msgid "A post ID mismatch has been detected."
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:738
-msgid "Filter items list"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:739
-msgid "Items list navigation"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:740
-msgid "Items list"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:848
-msgid "Contextual Help Tab"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:947
-msgid "Screen Options"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:980
-msgid "Additional settings"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:984
-msgid "Enable full-height editor and distraction-free functionality."
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:999
-msgctxt "Admin Post Navigation"
-msgid "Enable Previous and Next buttons"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1059
-msgid "Screen Options Tab"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1111
-msgid "Screen elements"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1113
-msgid "Some screen elements can be shown or hidden by using the checkboxes."
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1114
-msgid "Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows."
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1132
-msgctxt "Welcome panel"
-msgid "Welcome"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1153
-#: wp-includes/class-wp-editor.php:1309
-#: wp-includes/media-template.php:946
-msgid "Columns"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1202
-#: wp-admin/includes/theme.php:334
-#: wp-admin/includes/theme.php:369
-#: wp-admin/index.php:70
-msgid "Layout"
-msgstr ""
-
-#. translators: %s: Number of columns on the page.
-#: wp-admin/includes/class-wp-screen.php:1209
-msgid "%s column"
-msgid_plural "%s columns"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-screen.php:1231
-msgid "Number of items per page:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1271
-msgid "Pagination"
-msgstr ""
-
-#: wp-admin/includes/class-wp-screen.php:1324
-msgid "View mode"
-msgstr ""
-
-#. translators: 1: Name of the constant used. 2: Value of the constant used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:78
-msgid "The %1$s constant is defined as %2$s"
-msgstr ""
-
-#. translators: %s: Name of the filter used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:101
-msgid "A plugin has prevented updates by disabling %s."
-msgstr ""
-
-#. translators: %s: Name of the filter used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:122
-msgid "The %s filter is enabled."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:149
-msgid "All automatic updates are disabled."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:169
-msgid "A previous automatic background update ended with a critical failure, so updates are now disabled."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:170
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:185
-msgid "You would have received an email because of this."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:171
-msgid "When you've been able to update using the \"Update now\" button on Dashboard > Updates, this error will be cleared for future update attempts."
-msgstr ""
-
-#. translators: %s: Code of error shown.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:174
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:191
-msgid "The error code was %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:183
-msgid "A previous automatic background update could not occur."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:188
-msgid "Another attempt will be made with the next release."
-msgstr ""
-
-#. translators: 1: Folder name. 2: Version control directory. 3: Filter name.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:243
-msgid "The folder %1$s was detected as being under version control (%2$s), but the %3$s filter is allowing updates."
-msgstr ""
-
-#. translators: 1: Folder name. 2: Version control directory.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:256
-msgid "The folder %1$s was detected as being under version control (%2$s)."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:265
-msgid "No version control systems were detected."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:287
-msgid "Your installation of ClassicPress prompts for FTP credentials to perform updates."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:288
-msgid "(Your site is performing updates over FTP due to file ownership. Talk to your hosting company.)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:297
-msgid "Your installation of ClassicPress does not require FTP credentials to perform updates."
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:349
-msgid "Couldn't retrieve a list of the checksums for ClassicPress %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:352
-msgid "This could mean that connections are failing to WordPress.org or ClassicPress.net."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:378
-msgid "Some files are not writable by ClassicPress:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:383
-msgid "All of your ClassicPress files are writable."
-msgstr ""
-
-#. translators: %s: Name of the constant used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:407
-msgid "ClassicPress development updates are blocked by the %s constant."
-msgstr ""
-
-#. translators: %s: Name of the filter used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:419
-msgid "ClassicPress development updates are blocked by the %s filter."
-msgstr ""
-
-#. translators: %s: Name of the constant used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:439
-msgid "ClassicPress security and maintenance releases are blocked by %s."
-msgstr ""
-
-#. translators: %s: Name of the filter used.
-#: wp-admin/includes/class-wp-site-health-auto-updates.php:451
-msgid "ClassicPress security and maintenance releases are blocked by the %s filter."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:259
-#: wp-admin/includes/class-wp-site-health.php:737
-#: wp-admin/includes/class-wp-site-health.php:828
-#: wp-admin/includes/class-wp-site-health.php:1066
-#: wp-admin/includes/class-wp-site-health.php:1107
-#: wp-admin/includes/class-wp-site-health.php:1157
-#: wp-admin/includes/class-wp-site-health.php:1250
-#: wp-admin/includes/class-wp-site-health.php:1696
-#: wp-admin/includes/class-wp-site-health.php:1885
-#: wp-admin/includes/class-wp-site-health.php:1928
-#: wp-admin/includes/class-wp-site-health.php:1999
-#: wp-admin/includes/class-wp-site-health.php:2110
-#: wp-admin/includes/class-wp-site-health.php:2264
-#: wp-admin/includes/class-wp-site-health.php:2389
-msgid "Performance"
-msgstr ""
-
-#. translators: %s: Your current version of ClassicPress.
-#. translators: %s: Current WordPress version number.
-#: wp-admin/includes/class-wp-site-health.php:275
-#: wp-includes/class-wp-recovery-mode-email-service.php:352
-msgid "ClassicPress version %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:281
-msgid "Unable to check if any new versions of ClassicPress are available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:287
-msgid "Check for updates manually"
-msgstr ""
-
-#. translators: %s: The latest version of ClassicPress available.
-#: wp-admin/includes/class-wp-site-health.php:300
-msgid "ClassicPress update available (%s)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:307
-msgid "Install the latest version of ClassicPress"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:315
-msgid "A new version of ClassicPress is available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:320
-#: wp-admin/includes/class-wp-site-health.php:360
-#: wp-admin/includes/class-wp-site-health.php:494
-#: wp-admin/includes/class-wp-site-health.php:1197
-#: wp-admin/includes/class-wp-site-health.php:1360
-#: wp-admin/includes/class-wp-site-health.php:1430
-#: wp-admin/includes/class-wp-site-health.php:1511
-#: wp-admin/includes/class-wp-site-health.php:1650
-#: wp-admin/includes/class-wp-site-health.php:1769
-#: wp-admin/includes/class-wp-site-health.php:1842
-#: wp-admin/includes/class-wp-site-health.php:2202
-msgid "Security"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:323
-msgid "A new minor update is available for your site. Because minor updates often address security, it&#8217;s important to install them."
-msgstr ""
-
-#. translators: %s: The current version of ClassicPress installed on this site.
-#: wp-admin/includes/class-wp-site-health.php:330
-msgid "Your version of ClassicPress (%s) is up to date"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:336
-msgid "You are currently running the latest version of ClassicPress available, keep it up!"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:357
-msgid "Your plugins are all up to date"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:365
-msgid "Plugins extend your site&#8217;s functionality with things like contact forms, ecommerce and much more. That means they have deep access to your site, so it&#8217;s vital to keep them up to date."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:370
-msgid "Manage your plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:399
-msgid "You have plugins waiting to be updated"
-msgstr ""
-
-#. translators: %d: The number of outdated plugins.
-#: wp-admin/includes/class-wp-site-health.php:405
-msgid "Your site has %d plugin waiting to be updated."
-msgid_plural "Your site has %d plugins waiting to be updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:417
-msgid "Update your plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:423
-msgid "Your site has 1 active plugin, and it is up to date."
-msgstr ""
-
-#. translators: %d: The number of active plugins.
-#: wp-admin/includes/class-wp-site-health.php:430
-msgid "Your site has %d active plugin, and it is up to date."
-msgid_plural "Your site has %d active plugins, and they are all up to date."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:441
-msgid "Your site does not have any active plugins."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:452
-msgid "You should remove inactive plugins"
-msgstr ""
-
-#. translators: %d: The number of inactive plugins.
-#: wp-admin/includes/class-wp-site-health.php:458
-msgid "Your site has %d inactive plugin."
-msgid_plural "Your site has %d inactive plugins."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:465
-msgid "Inactive plugins are tempting targets for attackers. If you are not going to use a plugin, you should consider removing it."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:471
-msgid "Manage inactive plugins"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:491
-msgid "Your themes are all up to date"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:499
-msgid "Themes add your site&#8217;s look and feel. It&#8217;s important to keep them up to date, to stay consistent with your brand and keep your site secure."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:504
-msgid "Manage your themes"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:572
-msgid "You have themes waiting to be updated"
-msgstr ""
-
-#. translators: %d: The number of outdated themes.
-#: wp-admin/includes/class-wp-site-health.php:578
-msgid "Your site has %d theme waiting to be updated."
-msgid_plural "Your site has %d themes waiting to be updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:591
-msgid "Your site has 1 installed theme, and it is up to date."
-msgstr ""
-
-#. translators: %d: The number of themes.
-#: wp-admin/includes/class-wp-site-health.php:598
-msgid "Your site has %d installed theme, and it is up to date."
-msgid_plural "Your site has %d installed themes, and they are all up to date."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:609
-msgid "Your site does not have any installed themes."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:621
-#: wp-admin/includes/class-wp-site-health.php:667
-msgid "You should remove inactive themes"
-msgstr ""
-
-#. translators: %d: The number of inactive themes.
-#: wp-admin/includes/class-wp-site-health.php:628
-#: wp-admin/includes/class-wp-site-health.php:647
-msgid "Your site has %d inactive theme."
-msgid_plural "Your site has %d inactive themes."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: The currently active theme. 2: The active theme's parent theme.
-#: wp-admin/includes/class-wp-site-health.php:637
-msgid "To enhance your site&#8217;s security, you should consider removing any themes you are not using. You should keep your active theme, %1$s, and %2$s, its parent theme."
-msgstr ""
-
-#. translators: 1: The default theme for ClassicPress. 2: The currently active theme. 3: The active theme's parent theme.
-#: wp-admin/includes/class-wp-site-health.php:656
-msgid "To enhance your site&#8217;s security, you should consider removing any themes you are not using. You should keep %1$s, the default ClassicPress theme, %2$s, your active theme, and %3$s, its parent theme."
-msgstr ""
-
-#. translators: 1: The amount of inactive themes. 2: The currently active theme.
-#: wp-admin/includes/class-wp-site-health.php:674
-msgid "Your site has %1$d inactive theme, other than %2$s, your active theme."
-msgid_plural "Your site has %1$d inactive themes, other than %2$s, your active theme."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:682
-#: wp-admin/includes/class-wp-site-health.php:698
-msgid "You should consider removing any unused themes to enhance your site&#8217;s security."
-msgstr ""
-
-#. translators: 1: The amount of inactive themes. 2: The default theme for ClassicPress. 3: The currently active theme.
-#: wp-admin/includes/class-wp-site-health.php:689
-msgid "Your site has %1$d inactive theme, other than %2$s, the default ClassicPress theme, and %3$s, your active theme."
-msgid_plural "Your site has %1$d inactive themes, other than %2$s, the default ClassicPress theme, and %3$s, your active theme."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:708
-msgid "Have a default theme available"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:712
-msgid "Your site does not have any default theme. Default themes are used by ClassicPress automatically if anything is wrong with your chosen theme."
-msgstr ""
-
-#. translators: %s: The current PHP version.
-#: wp-admin/includes/class-wp-site-health.php:732
-msgid "Your site is running PHP version (%s)"
-msgstr ""
-
-#. translators: %s: The minimum recommended PHP version.
-#: wp-admin/includes/class-wp-site-health.php:744
-msgid "PHP is one of the programming languages used to build ClassicPress. Newer versions of PHP receive regular security updates and may increase your site&#8217;s performance. The minimum recommended version of PHP is %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:751
-#: wp-admin/includes/dashboard.php:1682
-msgid "Learn more about updating PHP"
-msgstr ""
-
-#. translators: %s: The server PHP version.
-#: wp-admin/includes/class-wp-site-health.php:765
-msgid "Your site is running on an older and unsupported version of PHP (%s), which should be updated"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:825
-msgid "Required and recommended modules are installed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:833
-msgid "PHP modules perform most of the tasks on the server that make your site run. Any changes to these must be made by your server administrator."
-msgstr ""
-
-#. translators: 1: Link to the hosting group page about recommended PHP modules. 2: Additional link attributes. 3: Accessibility text.
-#: wp-admin/includes/class-wp-site-health.php:836
-msgid "ClassicPress maintains a list of those modules, both recommended and required, in <a href=\"%1$s\" %2$s>the server requirements%3$s</a>."
-msgstr ""
-
-#. translators: Localized team handbook, if one exists.
-#: wp-admin/includes/class-wp-site-health.php:838
-msgid "https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-site-health.php:1002
-#: wp-admin/includes/class-wp-site-health.php:1389
-#: wp-admin/includes/class-wp-site-health.php:1801
-msgid "Error"
-msgstr ""
-
-#. translators: %s: The module name.
-#: wp-admin/includes/class-wp-site-health.php:1005
-msgid "The required module, %s, is not installed, or has been disabled."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-site-health.php:1011
-#: wp-admin/includes/class-wp-site-health.php:1810
-msgid "Warning"
-msgstr ""
-
-#. translators: %s: The module name.
-#: wp-admin/includes/class-wp-site-health.php:1014
-msgid "The optional module, %s, is not installed, or has been disabled."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1042
-msgid "One or more recommended modules are missing"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1045
-msgid "One or more required modules are missing"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1063
-msgid "PHP default timezone is valid"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1071
-msgid "PHP default timezone was configured by ClassicPress on loading. This is necessary for correct calculations of dates and times."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1080
-msgid "PHP default timezone is invalid"
-msgstr ""
-
-#. translators: %s: date_default_timezone_set()
-#: wp-admin/includes/class-wp-site-health.php:1086
-msgid "PHP default timezone was changed after ClassicPress loading by a %s function call. This interferes with correct calculations of dates and times."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1104
-msgid "No PHP sessions detected"
-msgstr ""
-
-#. translators: 1: session_start(), 2: session_write_close()
-#: wp-admin/includes/class-wp-site-health.php:1114
-msgid "PHP sessions created by a %1$s function call may interfere with REST API and loopback requests. An active session should be closed by %2$s before making any HTTP requests."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1125
-msgid "An active PHP session was detected"
-msgstr ""
-
-#. translators: 1: session_start(), 2: session_write_close()
-#: wp-admin/includes/class-wp-site-health.php:1131
-msgid "A PHP session was created by a %1$s function call. This interferes with REST API and loopback requests. The session should be closed by %2$s before making any HTTP requests."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1154
-msgid "SQL server is up to date"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1162
-msgid "The SQL server is a required piece of software for the database ClassicPress uses to store all your site&#8217;s content and settings."
-msgstr ""
-
-#. translators: Localized version of ClassicPress requirements if one exists.
-#: wp-admin/includes/class-wp-site-health.php:1167
-msgid "https://wordpress.org/about/requirements/"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1168
-msgid "Learn more about what ClassicPress requires to run."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1180
-msgid "Outdated SQL server"
-msgstr ""
-
-#. translators: 1: The database engine in use (MySQL or MariaDB). 2: Database server recommended version number.
-#: wp-admin/includes/class-wp-site-health.php:1186
-msgid "For optimal performance and security reasons, you should consider running %1$s version %2$s or higher. Contact your web hosting company to correct this."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1196
-msgid "Severely outdated SQL server"
-msgstr ""
-
-#. translators: 1: The database engine in use (MySQL or MariaDB). 2: Database server minimum version number.
-#: wp-admin/includes/class-wp-site-health.php:1203
-msgid "ClassicPress requires %1$s version %2$s or higher. Contact your web hosting company to correct this."
-msgstr ""
-
-#. translators: 1: The name of the drop-in. 2: The name of the database engine.
-#: wp-admin/includes/class-wp-site-health.php:1216
-msgid "You are using a %1$s drop-in which might mean that a %2$s database is not being used."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1247
-msgid "UTF8MB4 is supported"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1255
-msgid "UTF8MB4 is the character set ClassicPress prefers for database storage because it safely supports the widest set of characters and encodings, including Emoji, enabling better support for non-English languages."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1265
-msgid "utf8mb4 requires a MySQL update"
-msgstr ""
-
-#. translators: %s: Version number.
-#: wp-admin/includes/class-wp-site-health.php:1271
-msgid "ClassicPress&#8217; utf8mb4 support requires MySQL version %s or greater. Please contact your server administrator."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1278
-msgid "Your MySQL version supports utf8mb4."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1285
-msgid "utf8mb4 requires a MariaDB update"
-msgstr ""
-
-#. translators: %s: Version number.
-#: wp-admin/includes/class-wp-site-health.php:1291
-msgid "ClassicPress&#8217; utf8mb4 support requires MariaDB version %s or greater. Please contact your server administrator."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1298
-msgid "Your MariaDB version supports utf8mb4."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1315
-#: wp-admin/includes/class-wp-site-health.php:1331
-msgid "utf8mb4 requires a newer client library"
-msgstr ""
-
-#. translators: 1: Name of the library, 2: Number of version.
-#: wp-admin/includes/class-wp-site-health.php:1321
-#: wp-admin/includes/class-wp-site-health.php:1337
-msgid "ClassicPress&#8217; utf8mb4 support requires MySQL client library (%1$s) version %2$s or newer. Please contact your server administrator."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1357
-msgid "Can communicate with ClassicPress.net"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1365
-msgid "Communicating with the ClassicPress servers is used to check for new versions, and to both install and update ClassicPress core, themes or plugins."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1382
-msgid "Could not reach ClassicPress.net"
-msgstr ""
-
-#. translators: 1: The IP address WordPress.org resolves to. 2: The error returned by the lookup.
-#: wp-admin/includes/class-wp-site-health.php:1392
-msgid "Your site is unable to reach ClassicPress.net at %1$s, and returned the error: %2$s"
-msgstr ""
-
-#. translators: Localized Support reference.
-#: wp-admin/includes/class-wp-site-health.php:1402
-msgid "https://wordpress.org/support"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1403
-msgid "Get help resolving this issue."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1427
-msgid "Your site is not set to output debug information"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1435
-msgid "Debug mode is often enabled to gather more details about an error or site failure, but may contain sensitive information which should not be available on a publicly available website."
-msgstr ""
-
-#. translators: Documentation explaining debugging in WordPress.
-#: wp-admin/includes/class-wp-site-health.php:1440
-#: wp-includes/functions.php:5863
-msgid "https://wordpress.org/documentation/article/debugging-in-wordpress/"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1441
-msgid "Learn more about debugging in ClassicPress."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1450
-msgid "Your site is set to log errors to a potentially public file"
-msgstr ""
-
-#. translators: %s: WP_DEBUG_LOG
-#: wp-admin/includes/class-wp-site-health.php:1458
-msgid "The value, %s, has been added to this website&#8217;s configuration file. This means any errors on the site will be written to a file which is potentially available to all users."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1465
-msgid "Your site is set to display errors to site visitors"
-msgstr ""
-
-#. translators: 1: WP_DEBUG_DISPLAY, 2: WP_DEBUG
-#: wp-admin/includes/class-wp-site-health.php:1478
-msgid "The value, %1$s, has either been enabled by %2$s or added to your configuration file. This will make errors display on the front end of your site."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1508
-msgid "Your website is using an active HTTPS connection"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1516
-msgid "An HTTPS connection is a more secure way of browsing the web. Many services now have HTTPS as a requirement. HTTPS allows you to take advantage of new features that can increase site speed, improve search rankings, and gain the trust of your visitors by helping to protect their online privacy."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1521
-msgid "Learn more about why you should use HTTPS"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1532
-msgid "Your website does not use HTTPS"
-msgstr ""
-
-#. translators: %s: URL to Settings > General > Site Address.
-#: wp-admin/includes/class-wp-site-health.php:1540
-msgid "You are accessing this website using HTTPS, but your <a href=\"%s\">Site Address</a> is not set up to use HTTPS by default."
-msgstr ""
-
-#. translators: %s: URL to Settings > General > Site Address.
-#: wp-admin/includes/class-wp-site-health.php:1549
-msgid "Your <a href=\"%s\">Site Address</a> is not set up to use HTTPS."
-msgstr ""
-
-#. translators: 1: URL to Settings > General > ClassicPress Address, 2: URL to Settings > General > Site Address.
-#: wp-admin/includes/class-wp-site-health.php:1560
-msgid "You are accessing this website using HTTPS, but your <a href=\"%1$s\">ClassicPress Address</a> and <a href=\"%2$s\">Site Address</a> are not set up to use HTTPS by default."
-msgstr ""
-
-#. translators: 1: URL to Settings > General > ClassicPress Address, 2: URL to Settings > General > Site Address.
-#: wp-admin/includes/class-wp-site-health.php:1570
-msgid "Your <a href=\"%1$s\">ClassicPress Address</a> and <a href=\"%2$s\">Site Address</a> are not set up to use HTTPS."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1581
-msgid "HTTPS is already supported for your website."
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: WP_HOME, 3: WP_SITEURL
-#: wp-admin/includes/class-wp-site-health.php:1589
-msgid "However, your ClassicPress Address is currently controlled by a PHP constant and therefore cannot be updated. You need to edit your %1$s and remove or update the definitions of %2$s and %3$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1603
-#: wp-admin/includes/class-wp-site-health.php:1611
-msgid "Update your site to use HTTPS"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1622
-#: wp-admin/includes/class-wp-site-health.php:1629
-msgid "Talk to your web host about supporting HTTPS for your website."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1655
-msgid "Securely communicating between servers are needed for transactions such as fetching files, conducting sales on store sites, and much more."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1666
-msgid "Your site can communicate securely with other services"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1670
-msgid "Your site is unable to communicate securely with other services"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1674
-msgid "Talk to your web host about OpenSSL support for PHP."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1693
-msgid "Scheduled events are running"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1701
-msgid "Scheduled events are what periodically looks for updates to plugins, themes and ClassicPress itself. It is also what makes sure scheduled posts are published on time. It may also be used by various plugins to make sure that planned actions are executed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1712
-msgid "It was not possible to check your scheduled events"
-msgstr ""
-
-#. translators: %s: The error message returned while from the cron scheduler.
-#: wp-admin/includes/class-wp-site-health.php:1718
-msgid "While trying to test your site&#8217;s scheduled events, the following error was returned: %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1725
-msgid "A scheduled event has failed"
-msgstr ""
-
-#. translators: %s: The name of the failed cron event.
-#: wp-admin/includes/class-wp-site-health.php:1731
-msgid "The scheduled event, %s, failed to run. Your site still works, but this may indicate that scheduling posts or automated updates may not work as intended."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1738
-msgid "A scheduled event is late"
-msgstr ""
-
-#. translators: %s: The name of the late cron event.
-#: wp-admin/includes/class-wp-site-health.php:1744
-msgid "The scheduled event, %s, is late to run. Your site still works, but this may indicate that scheduling posts or automated updates may not work as intended."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1766
-msgid "Background updates are working"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1774
-msgid "Background updates ensure that ClassicPress can auto-update if a security update is released for the version you are currently using."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-site-health.php:1793
-msgid "Passed"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1796
-msgid "Background updates are not working as expected"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1805
-msgid "Background updates may not be working properly"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1839
-msgid "Plugin and theme auto-updates appear to be configured correctly"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1847
-msgid "Plugin and theme auto-updates ensure that the latest versions are always installed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1858
-msgid "Your site may have problems auto-updating plugins and themes"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1882
-msgid "Your site can perform loopback requests"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1890
-msgid "Loopback requests are used to run scheduled events, and are also used by the built-in editors for themes and plugins to verify code stability."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1901
-msgid "Your site could not complete a loopback request"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1925
-msgid "HTTP requests seem to be working as expected"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1933
-msgid "It is possible for site maintainers to block all, or some, communication to other sites and services. If set up incorrectly, this may prevent plugins and themes from working as intended."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1953
-msgid "HTTP requests are blocked"
-msgstr ""
-
-#. translators: %s: Name of the constant used.
-#: wp-admin/includes/class-wp-site-health.php:1959
-msgid "HTTP requests have been blocked by the %s constant, with no allowed hosts."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1968
-msgid "HTTP requests are partially blocked"
-msgstr ""
-
-#. translators: 1: Name of the constant used. 2: List of allowed hostnames.
-#: wp-admin/includes/class-wp-site-health.php:1974
-msgid "HTTP requests have been blocked by the %1$s constant, with some allowed hosts: %2$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:1996
-msgid "The REST API is available"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2004
-msgid "The REST API is one way that ClassicPress and other applications communicate with the server. For example, the block editor screen relies on the REST API to display and save your posts and pages."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2039
-msgid "The REST API encountered an error"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2043
-msgid "When testing the REST API, an error was encountered:"
-msgstr ""
-
-#. translators: %s: The REST API URL.
-#: wp-admin/includes/class-wp-site-health.php:2046
-#: wp-admin/includes/class-wp-site-health.php:2066
-msgid "REST API Endpoint: %s"
-msgstr ""
-
-#. translators: 1: The ClassicPress error code. 2: The ClassicPress error message.
-#. translators: 1: The ClassicPress error code. 2: The HTTP status code error message.
-#: wp-admin/includes/class-wp-site-health.php:2051
-#: wp-admin/includes/class-wp-site-health.php:2071
-msgid "REST API Response: (%1$s) %2$s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2059
-msgid "The REST API encountered an unexpected result"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2063
-msgid "When testing the REST API, an unexpected result was returned:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2082
-msgid "The REST API did not behave correctly"
-msgstr ""
-
-#. translators: %s: The name of the query parameter being tested.
-#: wp-admin/includes/class-wp-site-health.php:2088
-msgid "The REST API did not process the %s query parameter correctly."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2107
-msgid "Files can be uploaded"
-msgstr ""
-
-#. translators: 1: file_uploads, 2: php.ini
-#: wp-admin/includes/class-wp-site-health.php:2117
-msgid "The %1$s directive in %2$s determines if uploading files is allowed on your site."
-msgstr ""
-
-#. translators: %s: ini_get()
-#: wp-admin/includes/class-wp-site-health.php:2130
-msgid "The %s function has been disabled, some media settings are unavailable because of this."
-msgstr ""
-
-#. translators: 1: file_uploads, 2: 0
-#: wp-admin/includes/class-wp-site-health.php:2142
-msgid "%1$s is set to %2$s. You won't be able to upload files on your site."
-msgstr ""
-
-#. translators: 1: post_max_size, 2: upload_max_filesize
-#: wp-admin/includes/class-wp-site-health.php:2156
-msgid "The \"%1$s\" value is smaller than \"%2$s\""
-msgstr ""
-
-#. translators: 1: post_max_size, 2: upload_max_filesize
-#: wp-admin/includes/class-wp-site-health.php:2167
-msgid "The setting for %1$s is currently configured as 0, this could cause some problems when trying to upload files through plugin or theme features that rely on various upload methods. It is recommended to configure this setting to a fixed value, ideally matching the value of %2$s, as some upload methods read the value 0 as either unlimited, or disabled."
-msgstr ""
-
-#. translators: 1: post_max_size, 2: upload_max_filesize
-#: wp-admin/includes/class-wp-site-health.php:2177
-msgid "The setting for %1$s is smaller than %2$s, this could cause some problems when trying to upload files."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2199
-msgid "The Authorization header is working as expected"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2207
-msgid "The Authorization header is used by third-party applications you have approved for this site. Without this header, those apps cannot connect to your site."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2214
-msgid "The authorization header is missing"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2216
-msgid "The authorization header is invalid"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2224
-msgid "If you are still seeing this warning after having tried the actions below, you may need to contact your hosting provider for further assistance."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2235
-msgid "Flush permalinks"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2240
-msgid "https://developer.wordpress.org/rest-api/frequently-asked-questions/#why-is-authentication-not-working"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2241
-msgid "Learn how to configure the Authorization header."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2258
-msgid "Page cache enhances the speed and performance of your site by saving and serving static pages instead of calling for a page every time a user visits."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2259
-msgid "Page cache is detected by looking for an active page cache plugin as well as making three requests to the homepage and looking for one or more of the following HTTP client caching response headers:"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2273
-msgid "https://wordpress.org/documentation/article/optimization/#Caching"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2274
-msgid "Learn more about page cache"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2283
-msgid "Unable to detect the presence of page cache"
-msgstr ""
-
-#. translators: 1: Error message, 2: Error code.
-#: wp-admin/includes/class-wp-site-health.php:2287
-msgid "Unable to detect page cache due to possible loopback request problem. Please verify that the loopback request test is passing. Error: %1$s (Code: %2$s)"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2299
-msgid "Page cache is not detected but the server response time is OK"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2302
-msgid "Page cache is detected and the server response time is good"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2306
-msgid "Page cache is not detected and the server response time is slow"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2308
-msgid "Page cache is detected but the server response time is still slow"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2315
-msgid "Server response time could not be determined. Verify that loopback requests are working."
-msgstr ""
-
-#. translators: 1: The response time in milliseconds, 2: The recommended threshold in milliseconds.
-#: wp-admin/includes/class-wp-site-health.php:2322
-msgid "Median server response time was %1$s milliseconds. This is less than the recommended %2$s milliseconds threshold."
-msgstr ""
-
-#. translators: 1: The response time in milliseconds, 2: The recommended threshold in milliseconds.
-#: wp-admin/includes/class-wp-site-health.php:2329
-msgid "Median server response time was %1$s milliseconds. It should be less than the recommended %2$s milliseconds threshold."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2336
-msgid "No client caching response headers were detected."
-msgstr ""
-
-#. translators: %d: Number of caching headers.
-#: wp-admin/includes/class-wp-site-health.php:2341
-msgid "There was %d client caching response header detected:"
-msgid_plural "There were %d client caching response headers detected:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-site-health.php:2354
-msgid "A page cache plugin was detected."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2357
-msgid "A page cache plugin was not detected."
-msgstr ""
-
-#. translators: Localized Support reference.
-#: wp-admin/includes/class-wp-site-health.php:2382
-msgid "https://wordpress.org/documentation/article/optimization/#persistent-object-cache"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2392
-msgid "A persistent object cache is being used"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2395
-msgid "A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because ClassicPress can retrieve your site&#8217;s content and settings much more quickly."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2400
-msgid "Learn more about persistent object caching."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2411
-msgid "A persistent object cache is not required"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2418
-msgid "Your hosting provider can tell you if a persistent object cache can be enabled on your site."
-msgstr ""
-
-#. translators: Available object caching services.
-#: wp-admin/includes/class-wp-site-health.php:2423
-msgid "Your host appears to support the following object caching services: %s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2444
-msgid "You should use a persistent object cache"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2477
-msgid "ClassicPress Version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2481
-msgid "Plugin Versions"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2485
-msgid "Theme Versions"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2489
-msgid "PHP Version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2493
-msgid "PHP Extensions"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2497
-msgid "PHP Default Timezone"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2501
-msgid "PHP Sessions"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2505
-msgid "Database Server version"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2509
-msgid "MySQL utf8mb4 support"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2513
-msgid "Secure communication"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2517
-msgid "Scheduled events"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2521
-msgid "HTTP Requests"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2525
-msgid "REST API availability"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2530
-msgid "Debugging enabled"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2538
-msgid "Plugin and theme auto-updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2544
-msgid "Communication with ClassicPress.net"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2550
-msgid "Background updates"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2556
-msgid "Loopback request"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2562
-msgid "HTTPS status"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2573
-msgid "Authorization header"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2584
-msgid "Page cache"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2591
-msgid "Persistent object cache"
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2702
-msgid "No scheduled events exist on this site."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2837
-msgid "Auto-updates for plugins and/or themes appear to be disabled, but settings are still set to be displayed. This could cause auto-updates to not work as expected."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2846
-msgid "Auto-updates for plugins and themes appear to be disabled. This will prevent your site from receiving new versions automatically when available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2851
-msgid "Auto-updates for plugins appear to be disabled. This will prevent your site from receiving new versions automatically when available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2856
-msgid "Auto-updates for themes appear to be disabled. This will prevent your site from receiving new versions automatically when available."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2862
-msgid "There appear to be no issues with plugin and theme auto-updates."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2910
-msgid "The loopback request to your site failed, this means features relying on them are not currently working as expected."
-msgstr ""
-
-#. translators: 1: The ClassicPress error message. 2: The ClassicPress error code.
-#: wp-admin/includes/class-wp-site-health.php:2913
-msgid "Error: %1$s (%2$s)"
-msgstr ""
-
-#. translators: %d: The HTTP response code returned.
-#: wp-admin/includes/class-wp-site-health.php:2926
-msgid "The loopback request returned an unexpected http status code, %d, it was not possible to determine if this will prevent features from working as expected."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:2934
-msgid "The loopback request to your site completed successfully."
-msgstr ""
-
-#: wp-admin/includes/class-wp-site-health.php:3041
-#: wp-admin/js/site-health.js:340
-msgid "A test is unavailable"
-msgstr ""
-
-#: wp-admin/includes/class-wp-terms-list-table.php:198
-#: wp-admin/link-manager.php:50
-#: wp-admin/menu.php:80
-#: wp-includes/widgets/class-wp-widget-links.php:29
-msgid "Links"
-msgstr ""
-
-#: wp-admin/includes/class-wp-terms-list-table.php:200
-msgctxt "Number/count of items"
-msgid "Count"
-msgstr ""
-
-#. translators: %s: Taxonomy term name.
-#: wp-admin/includes/class-wp-terms-list-table.php:492
-msgid "Delete &#8220;%s&#8221;"
-msgstr ""
-
-#. translators: %s: Taxonomy term name.
-#: wp-admin/includes/class-wp-terms-list-table.php:502
-msgid "View &#8220;%s&#8221; archive"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-terms-list-table.php:551
-msgid "No description"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:63
-msgctxt "themes"
-msgid "Featured"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:65
-#: wp-admin/theme-install.php:195
-msgctxt "themes"
-msgid "Latest"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:66
-msgctxt "themes"
-msgid "Recently Updated"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:175
-msgid "No themes match your request."
-msgstr ""
-
-#. translators: %s: Theme version.
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/class-wp-theme-install-list-table.php:317
-#: wp-admin/includes/class-wp-theme-install-list-table.php:476
-#: wp-admin/update-core.php:74
-msgid "Update to version %s"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:325
-#: wp-admin/includes/class-wp-theme-install-list-table.php:484
-msgid "This theme is already installed and is up to date"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:326
-#: wp-admin/includes/class-wp-theme-install-list-table.php:485
-#: wp-admin/theme-install.php:286
-#: wp-includes/customize/class-wp-customize-theme-control.php:247
-#: wp-includes/customize/class-wp-customize-theme-control.php:288
-msgctxt "theme"
-msgid "Installed"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-theme-install-list-table.php:335
-#: wp-admin/theme-install.php:398
-msgctxt "theme"
-msgid "Install %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-theme-install-list-table.php:345
-msgid "Preview %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-theme-install-list-table.php:395
-#: wp-admin/theme-install.php:421
-#: wp-includes/class-wp-customize-manager.php:5722
-#: wp-includes/class-wp-editor.php:1183
-#: wp-includes/class-wp-editor.php:1880
-#: wp-includes/script-loader.php:772
-#: wp-includes/script-loader.php:871
-#: wp-includes/script-loader.php:1102
-#: wp-includes/script-loader.php:1263
-#: wp-includes/script-loader.php:1627
-msgid "Close"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:402
-#: wp-admin/theme-install.php:71
-#: wp-admin/theme-install.php:558
-msgid "Collapse Sidebar"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:404
-#: wp-admin/theme-install.php:560
-msgid "Collapse"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/class-wp-theme-install-list-table.php:493
-#: wp-admin/includes/deprecated.php:1391
-#: wp-admin/includes/network.php:370
-#: wp-admin/includes/theme.php:1043
-#: wp-admin/theme-install.php:400
-#: wp-admin/theme-install.php:452
-msgid "Install"
-msgstr ""
-
-#: wp-admin/includes/class-wp-theme-install-list-table.php:519
-#: wp-admin/includes/class-wp-themes-list-table.php:278
-#: wp-admin/includes/plugin-install.php:685
-msgid "Version:"
-msgstr ""
-
-#. translators: 1: URL to Themes tab on Edit Site screen, 2: URL to Add Themes screen.
-#: wp-admin/includes/class-wp-themes-list-table.php:101
-msgid "You only have one theme enabled for this site right now. Visit the Network Admin to <a href=\"%1$s\">enable</a> or <a href=\"%2$s\">install</a> more themes."
-msgstr ""
-
-#. translators: %s: URL to Themes tab on Edit Site screen.
-#: wp-admin/includes/class-wp-themes-list-table.php:110
-msgid "You only have one theme enabled for this site right now. Visit the Network Admin to <a href=\"%s\">enable</a> more themes."
-msgstr ""
-
-#. translators: %s: URL to Add Themes screen.
-#: wp-admin/includes/class-wp-themes-list-table.php:121
-msgid "You only have one theme installed right now. Live a little! You can choose from over 1,000 free themes in the ClassicPress Theme Directory at any time: just click on the <a href=\"%s\">Install Themes</a> tab above."
-msgstr ""
-
-#. translators: %s: Network title.
-#: wp-admin/includes/class-wp-themes-list-table.php:131
-msgid "Only the active theme is available to you. Contact the %s administrator for information about accessing additional themes."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/class-wp-themes-list-table.php:231
-msgid ""
-"You are about to delete this theme '%s'\n"
-"  'Cancel' to stop, 'OK' to delete."
-msgstr ""
-
-#. translators: 1: Link to documentation on child themes, 2: Name of parent theme.
-#: wp-admin/includes/class-wp-themes-list-table.php:284
-msgid "This <a href=\"%1$s\">child theme</a> requires its parent theme, %2$s."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:150
-msgid "Invalid data provided."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:152
-#: wp-admin/includes/plugin.php:952
-#: wp-admin/includes/theme.php:66
-msgid "Filesystem error."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:153
-msgid "Unable to locate ClassicPress root directory."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:154
-msgid "Unable to locate ClassicPress content directory (wp-content)."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:155
-#: wp-admin/includes/plugin.php:958
-msgid "Unable to locate ClassicPress plugin directory."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:156
-#: wp-admin/includes/theme.php:72
-msgid "Unable to locate ClassicPress theme directory."
-msgstr ""
-
-#. translators: %s: Directory name.
-#: wp-admin/includes/class-wp-upgrader.php:158
-msgid "Unable to locate needed folder (%s)."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:161
-msgid "Installing the latest version&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:162
-msgid "The package contains no files."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:163
-msgid "Destination folder already exists."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:164
-#: wp-admin/includes/file.php:1716
-#: wp-admin/includes/file.php:1857
-#: wp-admin/includes/file.php:1931
-#: wp-admin/includes/file.php:2014
-msgid "Could not create directory."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:165
-msgid "The package could not be installed."
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:168
-#: wp-admin/includes/update-core.php:505
-msgid "Enabling Maintenance mode&#8230;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-upgrader.php:169
-#: wp-admin/includes/update-core.php:650
-msgid "Disabling Maintenance mode&#8230;"
-msgstr ""
-
-#. translators: 1: User role name, 2: Number of users.
-#: wp-admin/includes/class-wp-users-list-table.php:231
-#: wp-admin/includes/class-wp-users-list-table.php:249
-msgid "%1$s <span class=\"count\">(%2$s)</span>"
-msgstr ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:246
-msgid "No role"
-msgstr ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:286
-#: wp-admin/includes/class-wp-users-list-table.php:506
-msgid "Send password reset"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/class-wp-users-list-table.php:309
-#: wp-admin/includes/class-wp-users-list-table.php:313
-msgid "Change role to&hellip;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:315
-#: wp-admin/user-edit.php:451
-#: wp-admin/user-edit.php:453
-#: wp-admin/users.php:127
-msgid "&mdash; No role for this site &mdash;"
-msgstr ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:318
-#: wp-login.php:340
-msgid "Change"
-msgstr ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:376
-#: wp-admin/network/site-users.php:326
-#: wp-admin/network/site-users.php:364
-#: wp-admin/user-edit.php:438
-#: wp-admin/user-new.php:467
-#: wp-admin/user-new.php:628
-msgid "Role"
-msgstr ""
-
-#. translators: %s: Author's display name.
-#: wp-admin/includes/class-wp-users-list-table.php:497
-msgid "View posts by %s"
-msgstr ""
-
-#. translators: Hidden accessibility text. %s: Number of posts.
-#: wp-admin/includes/class-wp-users-list-table.php:606
-msgid "%s post by this author"
-msgid_plural "%s posts by this author"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/class-wp-users-list-table.php:669
-msgctxt "no user roles"
-msgid "None"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:12
-msgid "Africa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:13
-msgid "Abidjan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:14
-msgid "Accra"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:15
-msgid "Addis Ababa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:16
-msgid "Algiers"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:17
-msgid "Asmara"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:18
-msgid "Asmera"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:19
-msgid "Bamako"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:20
-msgid "Bangui"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:21
-msgid "Banjul"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:22
-msgid "Bissau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:23
-msgid "Blantyre"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:24
-msgid "Brazzaville"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:25
-msgid "Bujumbura"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:26
-msgid "Cairo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:27
-msgid "Casablanca"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:28
-msgid "Ceuta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:29
-msgid "Conakry"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:30
-msgid "Dakar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:31
-msgid "Dar es Salaam"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:32
-msgid "Djibouti"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:33
-msgid "Douala"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:34
-msgid "El Aaiun"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:35
-msgid "Freetown"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:36
-msgid "Gaborone"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:37
-msgid "Harare"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:38
-msgid "Johannesburg"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:39
-msgid "Juba"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:40
-msgid "Kampala"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:41
-msgid "Khartoum"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:42
-msgid "Kigali"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:43
-msgid "Kinshasa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:44
-msgid "Lagos"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:45
-msgid "Libreville"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:46
-msgid "Lome"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:47
-msgid "Luanda"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:48
-msgid "Lubumbashi"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:49
-msgid "Lusaka"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:50
-msgid "Malabo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:51
-msgid "Maputo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:52
-msgid "Maseru"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:53
-msgid "Mbabane"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:54
-msgid "Mogadishu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:55
-msgid "Monrovia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:56
-msgid "Nairobi"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:57
-msgid "Ndjamena"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:58
-msgid "Niamey"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:59
-msgid "Nouakchott"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:60
-msgid "Ouagadougou"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:61
-msgid "Porto-Novo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:62
-msgid "Sao Tome"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:63
-msgid "Timbuktu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:64
-msgid "Tripoli"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:65
-msgid "Tunis"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:66
-msgid "Windhoek"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:68
-msgid "America"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:69
-msgid "Adak"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:70
-msgid "Anchorage"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:71
-msgid "Anguilla"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:72
-msgid "Antigua"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:73
-msgid "Araguaina"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:74
-msgid "Argentina"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:75
-msgid "Buenos Aires"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:76
-msgid "Catamarca"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:77
-msgid "ComodRivadavia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:78
-msgid "Cordoba"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:79
-msgid "Jujuy"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:80
-msgid "La Rioja"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:81
-msgid "Mendoza"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:82
-msgid "Rio Gallegos"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:83
-msgid "Salta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:84
-msgid "San Juan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:85
-msgid "San Luis"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:86
-msgid "Tucuman"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:87
-msgid "Ushuaia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:88
-msgid "Aruba"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:89
-msgid "Asuncion"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:90
-msgid "Atikokan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:91
-msgid "Atka"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:92
-msgid "Bahia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:93
-msgid "Bahia Banderas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:94
-msgid "Barbados"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:95
-msgid "Belem"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:96
-msgid "Belize"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:97
-msgid "Blanc-Sablon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:98
-msgid "Boa Vista"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:99
-msgid "Bogota"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:100
-msgid "Boise"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:101
-msgid "Cambridge Bay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:102
-msgid "Campo Grande"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:103
-msgid "Cancun"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:104
-msgid "Caracas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:105
-msgid "Cayenne"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:106
-msgid "Cayman"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:107
-msgid "Chicago"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:108
-msgid "Chihuahua"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:109
-msgid "Coral Harbour"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:110
-msgid "Costa Rica"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:111
-msgid "Creston"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:112
-msgid "Cuiaba"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:113
-msgid "Curacao"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:114
-msgid "Danmarkshavn"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:115
-msgid "Dawson"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:116
-msgid "Dawson Creek"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:117
-msgid "Denver"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:118
-msgid "Detroit"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:119
-msgid "Dominica"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:120
-msgid "Edmonton"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:121
-msgid "Eirunepe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:122
-msgid "El Salvador"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:123
-msgid "Ensenada"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:124
-msgid "Fort Nelson"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:125
-msgid "Fort Wayne"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:126
-msgid "Fortaleza"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:127
-msgid "Glace Bay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:128
-msgid "Godthab"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:129
-msgid "Goose Bay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:130
-msgid "Grand Turk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:131
-msgid "Grenada"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:132
-msgid "Guadeloupe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:133
-msgid "Guatemala"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:134
-msgid "Guayaquil"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:135
-msgid "Guyana"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:136
-msgid "Halifax"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:137
-msgid "Havana"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:138
-msgid "Hermosillo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:139
-msgid "Indiana"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:140
-msgid "Indianapolis"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:141
-msgid "Knox"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:142
-msgid "Marengo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:143
-msgid "Petersburg"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:144
-msgid "Tell City"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:145
-msgid "Vevay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:146
-msgid "Vincennes"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:147
-msgid "Winamac"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:148
-msgid "Inuvik"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:149
-msgid "Iqaluit"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:150
-msgid "Jamaica"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:151
-msgid "Juneau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:152
-msgid "Kentucky"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:153
-msgid "Louisville"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:154
-msgid "Monticello"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:155
-msgid "Knox IN"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:156
-msgid "Kralendijk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:157
-msgid "La Paz"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:158
-msgid "Lima"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:159
-msgid "Los Angeles"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:160
-msgid "Lower Princes"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:161
-msgid "Maceio"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:162
-msgid "Managua"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:163
-msgid "Manaus"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:164
-msgid "Marigot"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:165
-msgid "Martinique"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:166
-msgid "Matamoros"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:167
-msgid "Mazatlan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:168
-msgid "Menominee"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:169
-msgid "Merida"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:170
-msgid "Metlakatla"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:171
-msgid "Mexico City"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:172
-msgid "Miquelon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:173
-msgid "Moncton"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:174
-msgid "Monterrey"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:175
-msgid "Montevideo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:176
-msgid "Montreal"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:177
-msgid "Montserrat"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:178
-msgid "Nassau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:179
-msgid "New York"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:180
-msgid "Nipigon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:181
-msgid "Nome"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:182
-msgid "Noronha"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:183
-msgid "North Dakota"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:184
-msgid "Beulah"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:186
-msgid "New Salem"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:187
-msgid "Nuuk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:188
-msgid "Ojinaga"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:189
-msgid "Panama"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:190
-msgid "Pangnirtung"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:191
-msgid "Paramaribo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:192
-msgid "Phoenix"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:193
-msgid "Port-au-Prince"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:194
-msgid "Port of Spain"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:195
-msgid "Porto Acre"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:196
-msgid "Porto Velho"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:197
-msgid "Puerto Rico"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:198
-msgid "Punta Arenas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:199
-msgid "Rainy River"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:200
-msgid "Rankin Inlet"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:201
-msgid "Recife"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:202
-msgid "Regina"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:203
-msgid "Resolute"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:204
-msgid "Rio Branco"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:205
-msgid "Rosario"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:206
-msgid "Santa Isabel"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:207
-msgid "Santarem"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:208
-msgid "Santiago"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:209
-msgid "Santo Domingo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:210
-msgid "Sao Paulo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:211
-msgid "Scoresbysund"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:212
-msgid "Shiprock"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:213
-msgid "Sitka"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:214
-msgid "St Barthelemy"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:215
-msgid "St Johns"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:216
-msgid "St Kitts"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:217
-msgid "St Lucia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:218
-msgid "St Thomas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:219
-msgid "St Vincent"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:220
-msgid "Swift Current"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:221
-msgid "Tegucigalpa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:222
-msgid "Thule"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:223
-msgid "Thunder Bay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:224
-msgid "Tijuana"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:225
-msgid "Toronto"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:226
-msgid "Tortola"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:227
-msgid "Vancouver"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:228
-msgid "Virgin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:229
-msgid "Whitehorse"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:230
-msgid "Winnipeg"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:231
-msgid "Yakutat"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:232
-msgid "Yellowknife"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:234
-msgid "Antarctica"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:235
-msgid "Casey"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:236
-msgid "Davis"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:237
-msgid "DumontDUrville"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:238
-msgid "Macquarie"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:239
-msgid "Mawson"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:240
-msgid "McMurdo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:241
-msgid "Palmer"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:242
-msgid "Rothera"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:243
-msgid "South Pole"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:244
-msgid "Syowa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:245
-msgid "Troll"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:246
-msgid "Vostok"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:248
-msgid "Arctic"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:249
-msgid "Longyearbyen"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:251
-msgid "Asia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:252
-msgid "Aden"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:253
-msgid "Almaty"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:254
-msgid "Amman"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:255
-msgid "Anadyr"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:256
-msgid "Aqtau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:257
-msgid "Aqtobe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:258
-msgid "Ashgabat"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:259
-msgid "Ashkhabad"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:260
-msgid "Atyrau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:261
-msgid "Baghdad"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:262
-msgid "Bahrain"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:263
-msgid "Baku"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:264
-msgid "Bangkok"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:265
-msgid "Barnaul"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:266
-msgid "Beirut"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:267
-msgid "Bishkek"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:268
-msgid "Brunei"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:269
-msgid "Calcutta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:270
-msgid "Chita"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:271
-msgid "Choibalsan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:272
-msgid "Chongqing"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:273
-msgid "Chungking"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:274
-msgid "Colombo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:275
-msgid "Dacca"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:276
-msgid "Damascus"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:277
-msgid "Dhaka"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:278
-msgid "Dili"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:279
-msgid "Dubai"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:280
-msgid "Dushanbe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:281
-msgid "Famagusta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:282
-msgid "Gaza"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:283
-msgid "Harbin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:284
-msgid "Hebron"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:285
-msgid "Ho Chi Minh"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:286
-msgid "Hong Kong"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:287
-msgid "Hovd"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:288
-msgid "Irkutsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:289
-msgid "Jakarta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:290
-msgid "Jayapura"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:291
-msgid "Jerusalem"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:292
-msgid "Kabul"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:293
-msgid "Kamchatka"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:294
-msgid "Karachi"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:295
-msgid "Kashgar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:296
-msgid "Kathmandu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:297
-msgid "Katmandu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:298
-msgid "Khandyga"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:299
-msgid "Kolkata"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:300
-msgid "Krasnoyarsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:301
-msgid "Kuala Lumpur"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:302
-msgid "Kuching"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:303
-msgid "Kuwait"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:304
-msgid "Macao"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:305
-msgid "Macau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:306
-msgid "Magadan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:307
-msgid "Makassar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:308
-msgid "Manila"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:309
-msgid "Muscat"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:310
-msgid "Nicosia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:311
-msgid "Novokuznetsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:312
-msgid "Novosibirsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:313
-msgid "Omsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:314
-msgid "Oral"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:315
-msgid "Phnom Penh"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:316
-msgid "Pontianak"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:317
-msgid "Pyongyang"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:318
-msgid "Qatar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:319
-msgid "Qostanay"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:320
-msgid "Qyzylorda"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:321
-msgid "Rangoon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:322
-msgid "Riyadh"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:323
-msgid "Saigon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:324
-msgid "Sakhalin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:325
-msgid "Samarkand"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:326
-msgid "Seoul"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:327
-msgid "Shanghai"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:328
-msgid "Singapore"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:329
-msgid "Srednekolymsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:330
-msgid "Taipei"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:331
-msgid "Tashkent"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:332
-msgid "Tbilisi"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:333
-msgid "Tehran"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:334
-msgid "Tel Aviv"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:335
-msgid "Thimbu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:336
-msgid "Thimphu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:337
-msgid "Tokyo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:338
-msgid "Tomsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:339
-msgid "Ujung Pandang"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:340
-msgid "Ulaanbaatar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:341
-msgid "Ulan Bator"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:342
-msgid "Urumqi"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:343
-msgid "Ust-Nera"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:344
-msgid "Vientiane"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:345
-msgid "Vladivostok"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:346
-msgid "Yakutsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:347
-msgid "Yangon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:348
-msgid "Yekaterinburg"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:349
-msgid "Yerevan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:351
-msgid "Atlantic"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:352
-msgid "Azores"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:353
-msgid "Bermuda"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:354
-msgid "Canary"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:355
-msgid "Cape Verde"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:356
-msgid "Faeroe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:357
-msgid "Faroe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:358
-msgid "Jan Mayen"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:359
-msgid "Madeira"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:360
-msgid "Reykjavik"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:361
-msgid "South Georgia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:362
-msgid "St Helena"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:363
-msgid "Stanley"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:365
-msgid "Australia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:366
-msgid "ACT"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:367
-msgid "Adelaide"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:368
-msgid "Brisbane"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:369
-msgid "Broken Hill"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:370
-msgid "Canberra"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:371
-msgid "Currie"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:372
-msgid "Darwin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:373
-msgid "Eucla"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:374
-msgid "Hobart"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:375
-msgid "LHI"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:376
-msgid "Lindeman"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:377
-msgid "Lord Howe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:378
-msgid "Melbourne"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:379
-msgid "NSW"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:380
-msgid "North"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:381
-msgid "Perth"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:382
-msgid "Queensland"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:383
-msgid "South"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:384
-msgid "Sydney"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:385
-msgid "Tasmania"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:386
-msgid "Victoria"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:387
-msgid "West"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:388
-msgid "Yancowinna"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:390
-msgid "Etc"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:391
-msgid "GMT"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:392
-msgid "GMT+0"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:393
-msgid "GMT+1"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:394
-msgid "GMT+10"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:395
-msgid "GMT+11"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:396
-msgid "GMT+12"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:397
-msgid "GMT+2"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:398
-msgid "GMT+3"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:399
-msgid "GMT+4"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:400
-msgid "GMT+5"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:401
-msgid "GMT+6"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:402
-msgid "GMT+7"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:403
-msgid "GMT+8"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:404
-msgid "GMT+9"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:405
-msgid "GMT-0"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:406
-msgid "GMT-1"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:407
-msgid "GMT-10"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:408
-msgid "GMT-11"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:409
-msgid "GMT-12"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:410
-msgid "GMT-13"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:411
-msgid "GMT-14"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:412
-msgid "GMT-2"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:413
-msgid "GMT-3"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:414
-msgid "GMT-4"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:415
-msgid "GMT-5"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:416
-msgid "GMT-6"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:417
-msgid "GMT-7"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:418
-msgid "GMT-8"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:419
-msgid "GMT-9"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:420
-msgid "GMT0"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:421
-msgid "Greenwich"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:422
-msgid "UCT"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:423
-#: wp-includes/functions.php:6481
-#: wp-includes/functions.php:6486
-msgid "UTC"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:424
-msgid "Universal"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:425
-msgid "Zulu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:427
-msgid "Europe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:428
-msgid "Amsterdam"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:429
-msgid "Andorra"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:430
-msgid "Astrakhan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:431
-msgid "Athens"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:432
-msgid "Belfast"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:433
-msgid "Belgrade"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:434
-msgid "Berlin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:435
-msgid "Bratislava"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:436
-msgid "Brussels"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:437
-msgid "Bucharest"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:438
-msgid "Budapest"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:439
-msgid "Busingen"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:440
-msgid "Chisinau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:441
-msgid "Copenhagen"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:442
-msgid "Dublin"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:443
-msgid "Gibraltar"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:444
-msgid "Guernsey"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:445
-msgid "Helsinki"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:446
-msgid "Isle of Man"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:447
-msgid "Istanbul"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:448
-msgid "Jersey"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:449
-msgid "Kaliningrad"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:450
-msgid "Kiev"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:451
-msgid "Kyiv"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:452
-msgid "Kirov"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:453
-msgid "Lisbon"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:454
-msgid "Ljubljana"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:455
-msgid "London"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:456
-msgid "Luxembourg"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:457
-msgid "Madrid"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:458
-msgid "Malta"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:459
-msgid "Mariehamn"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:460
-msgid "Minsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:461
-msgid "Monaco"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:462
-msgid "Moscow"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:463
-msgid "Oslo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:464
-msgid "Paris"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:465
-msgid "Podgorica"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:466
-msgid "Prague"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:467
-msgid "Riga"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:468
-msgid "Rome"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:469
-msgid "Samara"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:470
-msgid "San Marino"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:471
-msgid "Sarajevo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:472
-msgid "Saratov"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:473
-msgid "Simferopol"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:474
-msgid "Skopje"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:475
-msgid "Sofia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:476
-msgid "Stockholm"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:477
-msgid "Tallinn"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:478
-msgid "Tirane"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:479
-msgid "Tiraspol"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:480
-msgid "Ulyanovsk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:481
-msgid "Uzhgorod"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:482
-msgid "Vaduz"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:483
-msgid "Vatican"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:484
-msgid "Vienna"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:485
-msgid "Vilnius"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:486
-msgid "Volgograd"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:487
-msgid "Warsaw"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:488
-msgid "Zagreb"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:489
-msgid "Zaporozhye"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:490
-msgid "Zurich"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:492
-msgid "Indian"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:493
-msgid "Antananarivo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:494
-msgid "Chagos"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:495
-msgid "Christmas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:496
-msgid "Cocos"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:497
-msgid "Comoro"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:498
-msgid "Kerguelen"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:499
-msgid "Mahe"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:500
-msgid "Maldives"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:501
-msgid "Mauritius"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:502
-msgid "Mayotte"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:503
-msgid "Reunion"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:505
-msgid "Pacific"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:506
-msgid "Apia"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:507
-msgid "Auckland"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:508
-msgid "Bougainville"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:509
-msgid "Chatham"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:510
-msgid "Chuuk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:511
-msgid "Easter"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:512
-msgid "Efate"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:513
-msgid "Enderbury"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:514
-msgid "Fakaofo"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:515
-msgid "Fiji"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:516
-msgid "Funafuti"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:517
-msgid "Galapagos"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:518
-msgid "Gambier"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:519
-msgid "Guadalcanal"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:520
-msgid "Guam"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:521
-msgid "Honolulu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:522
-msgid "Johnston"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:523
-msgid "Kanton"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:524
-msgid "Kiritimati"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:525
-msgid "Kosrae"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:526
-msgid "Kwajalein"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:527
-msgid "Majuro"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:528
-msgid "Marquesas"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:529
-msgid "Midway"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:530
-msgid "Nauru"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:531
-msgid "Niue"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:532
-msgid "Norfolk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:533
-msgid "Noumea"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:534
-msgid "Pago Pago"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:535
-msgid "Palau"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:536
-msgid "Pitcairn"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:537
-msgid "Pohnpei"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:538
-msgid "Ponape"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:539
-msgid "Port Moresby"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:540
-msgid "Rarotonga"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:541
-msgid "Saipan"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:542
-msgid "Samoa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:543
-msgid "Tahiti"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:544
-msgid "Tarawa"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:545
-msgid "Tongatapu"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:546
-msgid "Truk"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:547
-msgid "Wake"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:548
-msgid "Wallis"
-msgstr ""
-
-#: wp-admin/includes/continents-cities.php:549
-msgid "Yap"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:35
-msgid "You are using an insecure browser!"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:37
-msgid "Your browser is out of date!"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:50
-msgid "PHP Update Required"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:52
-msgid "PHP Update Recommended"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:68
-#: wp-admin/site-health.php:238
-msgid "Site Health Status"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:73
-msgid "At a Glance"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:77
-msgid "Right Now"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:82
-msgid "Activity"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:87
-msgid "Quick Draft"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:87
-#: wp-admin/includes/dashboard.php:660
-msgid "Your Recent Drafts"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:92
-msgid "ClassicPress News"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:99
-msgid "ClassicPress Directory"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:156
-msgid "View all"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:218
-msgid "Configure"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:259
-#: wp-admin/includes/template.php:2478
-#: wp-admin/nav-menus.php:847
-#: wp-admin/options.php:417
-msgid "Save Changes"
-msgstr ""
-
-#. translators: %s: Number of posts.
-#: wp-admin/includes/dashboard.php:320
-msgid "%s Post"
-msgid_plural "%s Posts"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of pages.
-#: wp-admin/includes/dashboard.php:323
-msgid "%s Page"
-msgid_plural "%s Pages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/dashboard.php:408
-msgid "Search engines discouraged"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:459
-msgid "Create a New Site"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:462
-msgid "Create a New User"
-msgstr ""
-
-#. translators: %s: Number of users on the network.
-#: wp-admin/includes/dashboard.php:469
-msgid "%s user"
-msgid_plural "%s users"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of sites on the network.
-#: wp-admin/includes/dashboard.php:471
-msgid "%s site"
-msgid_plural "%s sites"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: Text indicating the number of sites on the network, 2: Text indicating the number of users on the network.
-#: wp-admin/includes/dashboard.php:474
-msgid "You have %1$s and %2$s."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/dashboard.php:505
-#: wp-admin/includes/dashboard.php:509
-#: wp-admin/network/site-users.php:275
-#: wp-admin/network/users.php:308
-#: wp-admin/users.php:651
-msgid "Search Users"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/dashboard.php:518
-#: wp-admin/includes/dashboard.php:522
-#: wp-admin/network/sites.php:392
-msgid "Search Sites"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:599
-#: wp-admin/index.php:104
-#: wp-includes/revision.php:33
-msgid "Content"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:600
-msgid "What&#8217;s on your mind?"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:608
-#: wp-admin/includes/meta-boxes.php:56
-#: wp-includes/class-wp-customize-manager.php:4852
-#: wp-includes/script-loader.php:1091
-#: wp-admin/js/post.js:859
-msgid "Save Draft"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:656
-msgid "View all drafts"
-msgstr ""
-
-#. translators: Maximum number of words used in a preview of a draft on the dashboard.
-#: wp-admin/includes/dashboard.php:664
-msgctxt "draft_length"
-msgid "10"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:800
-msgid "View this comment"
-msgstr ""
-
-#. translators: 1: Comment author, 2: Post link, 3: Notification if the comment is pending.
-#: wp-admin/includes/dashboard.php:864
-msgid "From %1$s on %2$s %3$s"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:867
-#: wp-admin/includes/dashboard.php:874
-#: wp-admin/includes/dashboard.php:904
-#: wp-admin/includes/dashboard.php:911
-msgid "[Pending]"
-msgstr ""
-
-#. translators: 1: Comment author, 2: Notification if the comment is pending.
-#: wp-admin/includes/dashboard.php:872
-msgid "From %1$s %2$s"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:884
-#: wp-includes/comment-template.php:1162
-msgid "Pingback"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:887
-#: wp-includes/comment-template.php:1159
-msgid "Trackback"
-msgstr ""
-
-#. translators: 1: Type of comment, 2: Post link, 3: Notification if the comment is pending.
-#: wp-admin/includes/dashboard.php:901
-msgctxt "dashboard"
-msgid "%1$s on %2$s %3$s"
-msgstr ""
-
-#. translators: 1: Type of comment, 2: Notification if the comment is pending.
-#: wp-admin/includes/dashboard.php:909
-msgctxt "dashboard"
-msgid "%1$s %2$s"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:943
-msgid "Publishing Soon"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:952
-msgid "Recently Published"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:961
-msgid "No activity yet!"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1025
-#: wp-includes/script-loader.php:1628
-msgid "Today"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1027
-msgid "Tomorrow"
-msgstr ""
-
-#. translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/includes/dashboard.php:1030
-msgid "M jS Y"
-msgstr ""
-
-#. translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/includes/dashboard.php:1033
-msgid "M jS"
-msgstr ""
-
-#. translators: 1: Relative date, 2: Time.
-#: wp-admin/includes/dashboard.php:1043
-msgctxt "dashboard"
-msgid "%1$s, %2$s"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1107
-#: wp-includes/widgets/class-wp-widget-recent-comments.php:31
-#: wp-includes/widgets/class-wp-widget-recent-comments.php:81
-msgid "Recent Comments"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/dashboard.php:1128
-msgid "View more comments"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1176
-msgid "This widget requires JavaScript."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1281
-#: wp-includes/widgets/class-wp-widget-rss.php:84
-msgid "Unknown Feed"
-msgstr ""
-
-#. translators: link to ClassicPress blog
-#: wp-admin/includes/dashboard.php:1312
-msgid "You can always find the latest ClassicPress news on our <a href=\"%s\" target=\"_blank\">official blog <span aria-hidden=\"true\" class=\"dashicons dashicons-external\"></span></a>."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1322
-msgid "Get Help"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1323
-msgid "Feature Requests"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1324
-msgid "Volunteer"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1325
-msgid "Donate"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1349
-#: wp-admin/index.php:98
-msgid "https://www.classicpress.net/blog/"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1358
-msgid "https://www.classicpress.net/feed/"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1367
-msgid "ClassicPress Blog"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1426
-msgid "Storage Space"
-msgstr ""
-
-#. translators: %s: Number of megabytes.
-#: wp-admin/includes/dashboard.php:1433
-msgid "%s MB Space Allowed"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/dashboard.php:1441
-#: wp-admin/includes/dashboard.php:1457
-msgid "Manage Uploads"
-msgstr ""
-
-#. translators: 1: Number of megabytes, 2: Percentage.
-#: wp-admin/includes/dashboard.php:1448
-msgid "%1$s MB (%2$s%%) Space Used"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1482
-msgid "Internet Explorer does not give you the best ClassicPress experience. Switch to Microsoft Edge, or another more modern browser to get the most from your site."
-msgstr ""
-
-#. translators: %s: Browser name and link.
-#: wp-admin/includes/dashboard.php:1486
-msgid "It looks like you're using an insecure version of %s. Using an outdated browser makes your computer unsafe. For the best ClassicPress experience, please update your browser."
-msgstr ""
-
-#. translators: %s: Browser name and link.
-#: wp-admin/includes/dashboard.php:1492
-msgid "It looks like you're using an old version of %s. For the best ClassicPress experience, please update your browser."
-msgstr ""
-
-#. translators: %s: Browse Happy URL.
-#: wp-admin/includes/dashboard.php:1515
-msgid "Learn how to <a href=\"%s\" class=\"update-browser-link\">browse happy</a>"
-msgstr ""
-
-#. translators: 1: Browser update URL, 2: Browser name, 3: Browse Happy URL.
-#: wp-admin/includes/dashboard.php:1521
-msgid "<a href=\"%1$s\" class=\"update-browser-link\">Update %2$s</a> or learn how to <a href=\"%3$s\" class=\"browse-happy-link\">browse happy</a>"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1529
-msgid "Dismiss the browser warning panel"
-msgstr ""
-
-#. translators: %s: The server PHP version.
-#: wp-admin/includes/dashboard.php:1637
-msgid "Your site is running on an outdated version of PHP (%s), which does not receive security updates and soon will not be supported by WordPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress."
-msgstr ""
-
-#. translators: %s: The server PHP version.
-#: wp-admin/includes/dashboard.php:1643
-msgid "Your site is running on an outdated version of PHP (%s), which does not receive security updates. It should be updated."
-msgstr ""
-
-#. translators: %s: The server PHP version.
-#: wp-admin/includes/dashboard.php:1650
-msgid "Your site is running on an outdated version of PHP (%s), which soon will not be supported by WordPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress."
-msgstr ""
-
-#. translators: %s: The server PHP version.
-#: wp-admin/includes/dashboard.php:1656
-msgid "Your site is running on an outdated version of PHP (%s), which should be updated."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1663
-msgid "What is PHP and how does it affect my site?"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1665
-msgid "PHP is one of the programming languages used to build ClassicPress. Newer versions of PHP receive regular security updates and may increase your site&#8217;s performance."
-msgstr ""
-
-#. translators: %s: The minimum recommended PHP version.
-#: wp-admin/includes/dashboard.php:1670
-msgid "The minimum recommended version of PHP is %s."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1752
-msgid "No information yet&hellip;"
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1754
-#: wp-admin/site-health.php:127
-msgid "Results are still loading&hellip;"
-msgstr ""
-
-#. translators: %s: URL to Site Health screen.
-#: wp-admin/includes/dashboard.php:1765
-msgid "Site health checks will automatically run periodically to gather information about your site. You can also <a href=\"%s\">visit the Site Health screen</a> to gather information about your site now."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1773
-msgid "Great job! Your site currently passes all site health checks."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1775
-msgid "Your site has a critical issue that should be addressed as soon as possible to improve its performance and security."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1777
-msgid "Your site has critical issues that should be addressed as soon as possible to improve its performance and security."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1779
-msgid "Your site&#8217;s health is looking good, but there is still one thing you can do to improve its performance and security."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1781
-msgid "Your site&#8217;s health is looking good, but there are still some things you can do to improve its performance and security."
-msgstr ""
-
-#. translators: 1: Number of issues. 2: URL to Site Health screen.
-#: wp-admin/includes/dashboard.php:1791
-msgid "Take a look at the <strong>%1$d item</strong> on the <a href=\"%2$s\">Site Health screen</a>."
-msgid_plural "Take a look at the <strong>%1$d items</strong> on the <a href=\"%2$s\">Site Health screen</a>."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/dashboard.php:1828
-msgid "We would like to let you know about the ClassicPress Directory."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1829
-msgid "You can browse the new directory at <a href=\"%1$s\" target=\"_blank\">%1$s</a>."
-msgstr ""
-
-#: wp-admin/includes/dashboard.php:1841
-msgid "<a href=\"%1$s\">Install</a> the ClassicPress Directory Integration plugin to install plugins from the Plugins Menu."
-msgstr ""
-
-#. translators: 1: Starting number of users on the current page, 2: Ending number of users, 3: Total number of users.
-#: wp-admin/includes/deprecated.php:613
-msgid "Displaying %1$s&#8211;%2$s of %3$s"
-msgstr ""
-
-#: wp-admin/includes/deprecated.php:1388
-msgid "Popular Plugin"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/deprecated.php:1391
-msgctxt "plugin"
-msgid "Install %s"
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:14
-msgid "Item added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:15
-msgid "Item deleted."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:16
-msgid "Item updated."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:17
-msgid "Item not added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:19
-msgid "Items deleted."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:24
-msgid "Category added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:25
-msgid "Category deleted."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:26
-msgid "Category updated."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:27
-msgid "Category not added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:28
-msgid "Category not updated."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:29
-msgid "Categories deleted."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:34
-msgid "Tag added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:35
-msgid "Tag deleted."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:36
-msgid "Tag updated."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:37
-msgid "Tag not added."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:38
-msgid "Tag not updated."
-msgstr ""
-
-#: wp-admin/includes/edit-tag-messages.php:39
-msgid "Tags deleted."
-msgstr ""
-
-#: wp-admin/includes/file.php:16
-msgid "Theme Functions"
-msgstr ""
-
-#: wp-admin/includes/file.php:17
-msgid "Theme Header"
-msgstr ""
-
-#: wp-admin/includes/file.php:18
-msgid "Theme Footer"
-msgstr ""
-
-#: wp-admin/includes/file.php:19
-#: wp-admin/widgets-form.php:299
-#: wp-includes/widgets.php:185
-msgid "Sidebar"
-msgstr ""
-
-#: wp-admin/includes/file.php:21
-msgid "Search Form"
-msgstr ""
-
-#: wp-admin/includes/file.php:22
-msgid "404 Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:23
-msgid "Links Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:25
-msgid "Main Index Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:26
-#: wp-includes/general-template.php:1675
-#: wp-includes/theme-compat/sidebar.php:119
-#: wp-includes/widgets/class-wp-widget-archives.php:31
-#: wp-includes/widgets/class-wp-widget-archives.php:44
-msgid "Archives"
-msgstr ""
-
-#: wp-admin/includes/file.php:27
-msgid "Author Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:28
-msgid "Taxonomy Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:29
-msgid "Category Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:30
-msgid "Tag Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:31
-msgid "Posts Page"
-msgstr ""
-
-#: wp-admin/includes/file.php:33
-msgid "Date Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:35
-msgid "Singular Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:36
-msgid "Single Post"
-msgstr ""
-
-#: wp-admin/includes/file.php:37
-msgid "Single Page"
-msgstr ""
-
-#: wp-admin/includes/file.php:38
-#: wp-includes/class-wp-customize-manager.php:5661
-msgid "Homepage"
-msgstr ""
-
-#: wp-admin/includes/file.php:39
-msgid "Privacy Policy Page"
-msgstr ""
-
-#: wp-admin/includes/file.php:41
-msgid "Attachment Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:42
-msgid "Image Attachment Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:43
-msgid "Video Attachment Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:44
-msgid "Audio Attachment Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:45
-msgid "Application Attachment Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:47
-msgid "Embed Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:48
-msgid "Embed 404 Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:49
-msgid "Embed Content Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:50
-msgid "Embed Header Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:51
-msgid "Embed Footer Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:53
-#: wp-admin/includes/file.php:61
-#: wp-includes/class-wp-xmlrpc-server.php:572
-msgid "Stylesheet"
-msgstr ""
-
-#: wp-admin/includes/file.php:54
-msgid "Visual Editor Stylesheet"
-msgstr ""
-
-#: wp-admin/includes/file.php:55
-msgid "Visual Editor RTL Stylesheet"
-msgstr ""
-
-#: wp-admin/includes/file.php:56
-msgid "RTL Stylesheet"
-msgstr ""
-
-#: wp-admin/includes/file.php:58
-msgid "my-hacks.php (legacy hacks support)"
-msgstr ""
-
-#: wp-admin/includes/file.php:59
-msgid ".htaccess (for rewrite rules )"
-msgstr ""
-
-#: wp-admin/includes/file.php:62
-msgid "Comments Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:63
-msgid "Popup Comments Template"
-msgstr ""
-
-#: wp-admin/includes/file.php:64
-msgid "Popup Comments"
-msgstr ""
-
-#. translators: %s: Template name.
-#: wp-admin/includes/file.php:92
-msgid "%s Page Template"
-msgstr ""
-
-#. translators: 1: Line number, 2: File path.
-#: wp-admin/includes/file.php:312
-msgid "Your PHP code changes were rolled back due to an error on line %1$s of file %2$s. Please fix and try saving again."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/file.php:324
-#: wp-admin/plugin-editor.php:298
-#: wp-admin/theme-editor.php:328
-msgid "You need to make this file writable before you can save your changes. See <a href=\"%s\">Changing File Permissions</a> for more information."
-msgstr ""
-
-#: wp-admin/includes/file.php:325
-#: wp-admin/plugin-editor.php:299
-#: wp-admin/setup-config.php:474
-#: wp-admin/theme-editor.php:329
-msgid "https://wordpress.org/documentation/article/changing-file-permissions/"
-msgstr ""
-
-#: wp-admin/includes/file.php:336
-#: wp-includes/class-wp-customize-manager.php:4336
-msgid "Update anyway, even though it might break your site?"
-msgstr ""
-
-#: wp-admin/includes/file.php:402
-#: wp-admin/plugin-editor.php:18
-msgid "Sorry, you are not allowed to edit plugins for this site."
-msgstr ""
-
-#: wp-admin/includes/file.php:414
-#: wp-admin/includes/file.php:475
-#: wp-admin/includes/file.php:722
-#: wp-admin/includes/file.php:728
-msgid "Sorry, that file cannot be edited."
-msgstr ""
-
-#: wp-admin/includes/file.php:435
-#: wp-admin/theme-editor.php:18
-msgid "Sorry, you are not allowed to edit templates for this site."
-msgstr ""
-
-#: wp-admin/includes/file.php:488
-#: wp-admin/plugin-editor.php:110
-#: wp-admin/theme-editor.php:284
-msgid "File does not exist! Please double check the name and try again."
-msgstr ""
-
-#: wp-admin/includes/file.php:496
-#: wp-admin/plugin-editor.php:117
-msgid "Files of this type are not editable."
-msgstr ""
-
-#: wp-admin/includes/file.php:516
-msgid "Unable to write to file."
-msgstr ""
-
-#: wp-admin/includes/file.php:585
-msgid "Unable to communicate back with site to check for fatal errors, so the PHP change was reverted. You will need to upload your PHP file change by some other means, such as by using SFTP."
-msgstr ""
-
-#. translators: 1: upload_max_filesize, 2: php.ini
-#: wp-admin/includes/file.php:868
-msgid "The uploaded file exceeds the %1$s directive in %2$s."
-msgstr ""
-
-#. translators: %s: MAX_FILE_SIZE
-#: wp-admin/includes/file.php:874
-msgid "The uploaded file exceeds the %s directive that was specified in the HTML form."
-msgstr ""
-
-#: wp-admin/includes/file.php:877
-msgid "The uploaded file was only partially uploaded."
-msgstr ""
-
-#: wp-admin/includes/file.php:878
-msgid "No file was uploaded."
-msgstr ""
-
-#: wp-admin/includes/file.php:880
-msgid "Missing a temporary folder."
-msgstr ""
-
-#: wp-admin/includes/file.php:881
-msgid "Failed to write file to disk."
-msgstr ""
-
-#: wp-admin/includes/file.php:882
-msgid "File upload stopped by extension."
-msgstr ""
-
-#: wp-admin/includes/file.php:896
-msgid "Invalid form submission."
-msgstr ""
-
-#: wp-admin/includes/file.php:907
-msgid "Specified file failed upload test."
-msgstr ""
-
-#: wp-admin/includes/file.php:914
-msgid "File is empty. Please upload something more substantial."
-msgstr ""
-
-#. translators: 1: php.ini, 2: post_max_size, 3: upload_max_filesize
-#: wp-admin/includes/file.php:918
-#: wp-admin/includes/import.php:87
-msgid "File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your %1$s file or by %2$s being defined as smaller than %3$s in %1$s."
-msgstr ""
-
-#: wp-admin/includes/file.php:941
-#: wp-includes/functions.php:2871
-#: wp-includes/script-loader.php:787
-msgid "Sorry, you are not allowed to upload this file type."
-msgstr ""
-
-#. translators: %s: Destination file path.
-#: wp-admin/includes/file.php:1009
-msgid "The uploaded file could not be moved to %s."
-msgstr ""
-
-#: wp-admin/includes/file.php:1134
-msgid "Invalid URL Provided."
-msgstr ""
-
-#: wp-admin/includes/file.php:1145
-msgid "Could not create temporary file."
-msgstr ""
-
-#. translators: 1: File checksum, 2: Expected checksum value.
-#: wp-admin/includes/file.php:1343
-msgid "The checksum of the file (%1$s) does not match the expected checksum value (%2$s)."
-msgstr ""
-
-#. translators: %s: The filename of the package.
-#: wp-admin/includes/file.php:1372
-#: wp-admin/includes/file.php:1391
-#: wp-admin/includes/file.php:1426
-msgid "The authenticity of %s could not be verified as signature verification is unavailable on this system."
-msgstr ""
-
-#. translators: %s: The filename of the package.
-#: wp-admin/includes/file.php:1444
-msgid "The authenticity of %s could not be verified as no signature was found."
-msgstr ""
-
-#. translators: %s: The filename of the package.
-#: wp-admin/includes/file.php:1492
-msgid "The authenticity of %s could not be verified."
-msgstr ""
-
-#: wp-admin/includes/file.php:1645
-#: wp-admin/includes/file.php:1725
-msgid "Could not retrieve file from archive."
-msgstr ""
-
-#: wp-admin/includes/file.php:1744
-msgid "Could not extract file from archive."
-msgstr ""
-
-#: wp-admin/includes/file.php:1748
-#: wp-admin/includes/file.php:1878
-#: wp-admin/includes/file.php:1923
-#: wp-admin/includes/update-core.php:701
-msgid "Could not copy file."
-msgstr ""
-
-#: wp-admin/includes/file.php:1795
-msgid "Empty archive."
-msgstr ""
-
-#: wp-admin/includes/file.php:1906
-msgid "Directory listing failed."
-msgstr ""
-
-#: wp-admin/includes/file.php:1980
-msgid "The source and destination are the same."
-msgstr ""
-
-#: wp-admin/includes/file.php:1985
-msgid "The destination folder already exists."
-msgstr ""
-
-#: wp-admin/includes/file.php:1988
-msgid "The destination directory already exists and could not be removed."
-msgstr ""
-
-#: wp-admin/includes/file.php:2385
-msgid "<strong>Error:</strong> Could not connect to the server. Please verify the settings are correct."
-msgstr ""
-
-#: wp-admin/includes/file.php:2394
-msgid "FTP"
-msgstr ""
-
-#: wp-admin/includes/file.php:2397
-msgid "FTPS (SSL)"
-msgstr ""
-
-#: wp-admin/includes/file.php:2400
-msgid "SSH2"
-msgstr ""
-
-#: wp-admin/includes/file.php:2426
-msgid "Connection Information"
-msgstr ""
-
-#: wp-admin/includes/file.php:2432
-msgid "To perform the requested action, ClassicPress needs to access your web server."
-msgstr ""
-
-#: wp-admin/includes/file.php:2436
-msgid "Please enter your FTP or SSH credentials to proceed."
-msgstr ""
-
-#: wp-admin/includes/file.php:2437
-msgid "FTP/SSH Username"
-msgstr ""
-
-#: wp-admin/includes/file.php:2438
-msgid "FTP/SSH Password"
-msgstr ""
-
-#: wp-admin/includes/file.php:2440
-msgid "Please enter your FTP credentials to proceed."
-msgstr ""
-
-#: wp-admin/includes/file.php:2441
-msgid "FTP Username"
-msgstr ""
-
-#: wp-admin/includes/file.php:2442
-msgid "FTP Password"
-msgstr ""
-
-#: wp-admin/includes/file.php:2446
-msgid "If you do not remember your credentials, you should contact your web host."
-msgstr ""
-
-#: wp-admin/includes/file.php:2460
-msgid "Hostname"
-msgstr ""
-
-#: wp-admin/includes/file.php:2461
-msgid "example: www.wordpress.org"
-msgstr ""
-
-#: wp-admin/includes/file.php:2475
-msgid "This password will not be stored on the server."
-msgstr ""
-
-#: wp-admin/includes/file.php:2481
-msgid "Connection Type"
-msgstr ""
-
-#: wp-admin/includes/file.php:2502
-msgid "Authentication Keys"
-msgstr ""
-
-#: wp-admin/includes/file.php:2504
-msgid "Public Key:"
-msgstr ""
-
-#: wp-admin/includes/file.php:2508
-msgid "Private Key:"
-msgstr ""
-
-#: wp-admin/includes/file.php:2511
-msgid "Enter the location on the server where the public and private keys are located. If a passphrase is needed, enter that in the password field above."
-msgstr ""
-
-#: wp-admin/includes/file.php:2531
-msgid "Proceed"
-msgstr ""
-
-#. translators: %s: The function name.
-#: wp-admin/includes/file.php:2659
-msgid "%s expects a non-empty string."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:28
-#: wp-admin/includes/image-edit.php:928
-msgid "Image data does not exist. Please re-upload the image."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:62
-#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1372
-msgid "Crop"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:74
-msgid "Rotate left"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:75
-msgid "Rotate right"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:78
-msgid "Image rotation is not supported by your web host."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:84
-msgid "Flip vertical"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:85
-msgid "Flip horizontal"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:89
-#: wp-includes/class-wp-editor.php:1179
-msgid "Redo"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:114
-msgid "Scale Image"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:118
-msgid "Scale Image Help"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:122
-msgid "You can proportionally scale the original image. For best results, scaling should be done before you crop, flip, or rotate. Images can only be scaled down, not up."
-msgstr ""
-
-#. translators: %s: Image width and height in pixels.
-#: wp-admin/includes/image-edit.php:129
-msgid "Original dimensions %s"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:138
-msgid "New dimensions:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:143
-msgid "scale width"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:151
-msgid "scale height"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:156
-msgid "Scale"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:168
-msgid "Restore original image"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:172
-msgid "Discard any changes and restore the original image."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:175
-msgid "Previously edited copies of the image will not be deleted."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:180
-msgid "Restore image"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:190
-msgid "Image Crop"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:194
-msgid "Image Crop Help"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:199
-msgid "To crop the image, click on it and drag to make your selection."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:201
-msgid "Crop Aspect Ratio"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:202
-msgid "The aspect ratio is the relationship between the width and height. You can preserve the aspect ratio by holding down the shift key while resizing your selection. Use the input box to specify the aspect ratio, e.g. 1:1 (square), 4:3, 16:9, etc."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:204
-msgid "Crop Selection"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:205
-msgid "Once you have made your selection, you can adjust it by entering the size in pixels. The minimum selection size is the thumbnail size as set in the Media settings."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:210
-msgid "Aspect ratio:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:215
-msgid "crop ratio width"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:223
-msgid "crop ratio height"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:231
-msgid "Selection:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:236
-msgid "selection width"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:244
-msgid "selection height"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:260
-msgid "Thumbnail Settings"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/image-edit.php:264
-msgid "Thumbnail Settings Help"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:268
-msgid "You can edit the image while preserving the thumbnail. For example, you may wish to have a square thumbnail that displays just a section of the image."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:274
-msgid "Current thumbnail"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:279
-msgid "Apply changes to:"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:283
-msgid "All image sizes"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:293
-msgid "All sizes except thumbnail"
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:325
-msgid "There are unsaved changes that will be lost. 'OK' to continue, 'Cancel' to return to the Image Editor."
-msgstr ""
-
-#. translators: 1: $image, 2: WP_Image_Editor
-#: wp-admin/includes/image-edit.php:360
-#: wp-admin/includes/image-edit.php:449
-#: wp-admin/includes/image-edit.php:614
-msgid "%1$s needs to be a %2$s object."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:790
-msgid "Cannot load image metadata."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:850
-msgid "Cannot save image metadata."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:855
-msgid "Image metadata is inconsistent."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:857
-msgid "Image restored successfully."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:887
-msgid "Unable to create new image."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:911
-msgid "Error while saving the scaled image. Please reload the page and try again."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:920
-msgid "Nothing to save, the image has not changed."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:969
-msgid "Unable to save the image."
-msgstr ""
-
-#: wp-admin/includes/image-edit.php:1106
-msgid "Image saved"
-msgstr ""
-
-#: wp-admin/includes/image.php:167
-msgid "The attached file cannot be found."
-msgstr ""
-
-#: wp-admin/includes/import.php:186
-msgid "Blogger"
-msgstr ""
-
-#: wp-admin/includes/import.php:187
-msgid "Import posts, comments, and users from a Blogger blog."
-msgstr ""
-
-#: wp-admin/includes/import.php:192
-#: wp-admin/tools.php:48
-#: wp-admin/tools.php:73
-msgid "Categories and Tags Converter"
-msgstr ""
-
-#: wp-admin/includes/import.php:193
-msgid "Convert existing categories to tags or tags to categories, selectively."
-msgstr ""
-
-#: wp-admin/includes/import.php:198
-msgid "LiveJournal"
-msgstr ""
-
-#: wp-admin/includes/import.php:199
-msgid "Import posts from LiveJournal using their API."
-msgstr ""
-
-#: wp-admin/includes/import.php:204
-msgid "Movable Type and TypePad"
-msgstr ""
-
-#: wp-admin/includes/import.php:205
-msgid "Import posts and comments from a Movable Type or TypePad blog."
-msgstr ""
-
-#: wp-admin/includes/import.php:210
-msgid "Blogroll"
-msgstr ""
-
-#: wp-admin/includes/import.php:211
-msgid "Import links in OPML format."
-msgstr ""
-
-#: wp-admin/includes/import.php:216
-#: wp-includes/widgets/class-wp-widget-rss.php:35
-#: wp-includes/widgets/class-wp-widget-rss.php:98
-msgid "RSS"
-msgstr ""
-
-#: wp-admin/includes/import.php:217
-msgid "Import posts from an RSS feed."
-msgstr ""
-
-#: wp-admin/includes/import.php:222
-msgid "Tumblr"
-msgstr ""
-
-#: wp-admin/includes/import.php:223
-msgid "Import posts &amp; media from Tumblr using their API."
-msgstr ""
-
-#: wp-admin/includes/import.php:229
-msgid "Install the WordPress importer to import posts, pages, comments, custom fields, categories, and tags from a WordPress export file."
-msgstr ""
-
-#: wp-admin/includes/media.php:18
-msgid "From Computer"
-msgstr ""
-
-#: wp-admin/includes/media.php:19
-msgid "From URL"
-msgstr ""
-
-#: wp-admin/includes/media.php:20
-#: wp-includes/widgets/class-wp-widget-media-gallery.php:28
-msgid "Gallery"
-msgstr ""
-
-#: wp-admin/includes/media.php:21
-#: wp-admin/upload.php:164
-#: wp-admin/upload.php:309
-#: wp-includes/media.php:4598
-msgid "Media Library"
-msgstr ""
-
-#. translators: %s: Number of attachments.
-#: wp-admin/includes/media.php:64
-msgid "Gallery (%s)"
-msgstr ""
-
-#. translators: 1: Audio track title, 2: Album title, 3: Artist name.
-#: wp-admin/includes/media.php:331
-msgid "\"%1$s\" from %2$s by %3$s."
-msgstr ""
-
-#. translators: 1: Audio track title, 2: Album title.
-#: wp-admin/includes/media.php:334
-msgid "\"%1$s\" from %2$s."
-msgstr ""
-
-#. translators: 1: Audio track title, 2: Artist name.
-#: wp-admin/includes/media.php:337
-msgid "\"%1$s\" by %2$s."
-msgstr ""
-
-#. translators: %s: Audio track title.
-#: wp-admin/includes/media.php:340
-msgid "\"%s\"."
-msgstr ""
-
-#. translators: 1: Audio album title, 2: Artist name.
-#: wp-admin/includes/media.php:346
-msgid "%1$s by %2$s."
-msgstr ""
-
-#. translators: Audio file track information. %d: Year of audio track release.
-#: wp-admin/includes/media.php:358
-msgid "Released: %d."
-msgstr ""
-
-#. translators: Audio file track information. 1: Audio track number, 2: Total audio tracks.
-#: wp-admin/includes/media.php:368
-msgid "Track %1$s of %2$s."
-msgstr ""
-
-#. translators: Audio file track information. %s: Audio track number.
-#: wp-admin/includes/media.php:375
-msgid "Track %s."
-msgstr ""
-
-#. translators: Audio file genre information. %s: Audio genre name.
-#: wp-admin/includes/media.php:384
-msgid "Genre: %s."
-msgstr ""
-
-#: wp-admin/includes/media.php:531
-msgid "Uploads"
-msgstr ""
-
-#: wp-admin/includes/media.php:652
-#: wp-includes/class-wp-editor.php:1395
-msgid "Add Media"
-msgstr ""
-
-#: wp-admin/includes/media.php:957
-#: wp-includes/media-template.php:424
-#: wp-includes/media-template.php:650
-msgid "Saved."
-msgstr ""
-
-#: wp-admin/includes/media.php:1036
-msgid "Invalid image URL."
-msgstr ""
-
-#: wp-admin/includes/media.php:1245
-#: wp-includes/media-template.php:886
-#: wp-includes/media-template.php:965
-#: wp-includes/media-template.php:1157
-#: wp-includes/widgets/class-wp-widget-media-image.php:72
-msgid "Size"
-msgstr ""
-
-#: wp-admin/includes/media.php:1280
-#: wp-admin/includes/media.php:1416
-msgid "File URL"
-msgstr ""
-
-#: wp-admin/includes/media.php:1281
-msgid "Attachment Post URL"
-msgstr ""
-
-#: wp-admin/includes/media.php:1396
-#: wp-admin/includes/media.php:3181
-#: wp-includes/class-wp-editor.php:1331
-#: wp-includes/media-template.php:529
-#: wp-includes/media-template.php:626
-#: wp-includes/media-template.php:774
-#: wp-includes/media-template.php:1065
-#: wp-includes/media-template.php:1128
-#: wp-includes/widgets/class-wp-widget-media-image.php:91
-msgid "Caption"
-msgstr ""
-
-#: wp-admin/includes/media.php:1406
-msgid "Link URL"
-msgstr ""
-
-#: wp-admin/includes/media.php:1409
-#: wp-admin/includes/media.php:2929
-msgid "Enter a link URL or click above for presets."
-msgstr ""
-
-#: wp-admin/includes/media.php:1420
-msgid "Location of the uploaded file."
-msgstr ""
-
-#: wp-admin/includes/media.php:1476
-#: wp-admin/includes/media.php:2901
-#: wp-admin/includes/media.php:3158
-#: wp-includes/media-template.php:504
-#: wp-includes/media-template.php:1055
-#: wp-includes/media-template.php:1118
-#: wp-includes/widgets/class-wp-widget-media-image.php:98
-msgid "Alternative Text"
-msgstr ""
-
-#: wp-admin/includes/media.php:1477
-#: wp-admin/includes/media.php:2904
-msgid "Alt text for the image, e.g. &#8220;The Mona Lisa&#8221;"
-msgstr ""
-
-#: wp-admin/includes/media.php:1481
-#: wp-admin/includes/media.php:2908
-#: wp-includes/class-wp-editor.php:1332
-#: wp-includes/media-template.php:811
-msgid "Alignment"
-msgstr ""
-
-#: wp-admin/includes/media.php:1554
-#: wp-admin/includes/media.php:2503
-#: wp-admin/js/user-profile.js:84
-msgid "Show"
-msgstr ""
-
-#: wp-admin/includes/media.php:1555
-#: wp-admin/includes/media.php:2504
-#: wp-admin/install.php:146
-#: wp-admin/user-edit.php:701
-#: wp-admin/user-new.php:596
-#: wp-admin/js/user-profile.js:84
-msgid "Hide"
-msgstr ""
-
-#: wp-admin/includes/media.php:1618
-#: wp-admin/includes/media.php:3069
-#: wp-includes/media-template.php:414
-#: wp-includes/media-template.php:712
-msgid "Edit Image"
-msgstr ""
-
-#: wp-admin/includes/media.php:1637
-#: wp-admin/includes/media.php:3292
-#: wp-includes/media-template.php:453
-msgid "File type:"
-msgstr ""
-
-#: wp-admin/includes/media.php:1638
-msgid "Upload date:"
-msgstr ""
-
-#: wp-admin/includes/media.php:1641
-#: wp-admin/includes/media.php:3414
-#: wp-includes/media-template.php:457
-msgid "Dimensions:"
-msgstr ""
-
-#: wp-admin/includes/media.php:1663
-#: wp-admin/includes/media.php:2934
-#: wp-admin/includes/media.php:2940
-msgid "Insert into Post"
-msgstr ""
-
-#. translators: %s: File name.
-#: wp-admin/includes/media.php:1674
-msgid "You are about to delete %s."
-msgstr ""
-
-#: wp-admin/includes/media.php:1675
-#: wp-admin/upgrade.php:75
-#: wp-admin/upgrade.php:155
-msgid "Continue"
-msgstr ""
-
-#. translators: %s: https://apps.wordpress.org
-#: wp-admin/includes/media.php:2033
-#: wp-includes/media-template.php:247
-msgid "The web browser on your device cannot be used to upload files. You may be able to use the <a href=\"%s\">native app for your device</a> instead."
-msgstr ""
-
-#: wp-admin/includes/media.php:2177
-#: wp-includes/media-template.php:214
-#: wp-includes/media-template.php:221
-#: wp-includes/media-template.php:263
-msgid "Drop files to upload"
-msgstr ""
-
-#: wp-admin/includes/media.php:2178
-#: wp-includes/media-template.php:264
-msgctxt "Uploader: Drop files here - or - Select Files"
-msgid "or"
-msgstr ""
-
-#: wp-admin/includes/media.php:2179
-#: wp-includes/media-template.php:265
-msgid "Select Files"
-msgstr ""
-
-#. translators: %s: Maximum allowed file size.
-#: wp-admin/includes/media.php:2228
-#: wp-includes/media-template.php:296
-msgid "Maximum upload file size: %s."
-msgstr ""
-
-#: wp-admin/includes/media.php:2281
-msgid "Add media files from your computer"
-msgstr ""
-
-#: wp-admin/includes/media.php:2310
-#: wp-admin/includes/media.php:2527
-#: wp-admin/includes/media.php:2833
-msgid "Save all changes"
-msgstr ""
-
-#: wp-admin/includes/media.php:2348
-msgid "Insert media from another website"
-msgstr ""
-
-#: wp-admin/includes/media.php:2502
-msgid "All Tabs:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2506
-msgid "Sort Order:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2507
-#: wp-admin/includes/media.php:2584
-msgid "Ascending"
-msgstr ""
-
-#: wp-admin/includes/media.php:2508
-#: wp-admin/includes/media.php:2587
-msgid "Descending"
-msgstr ""
-
-#: wp-admin/includes/media.php:2509
-msgctxt "verb"
-msgid "Clear"
-msgstr ""
-
-#: wp-admin/includes/media.php:2543
-#: wp-includes/media-template.php:921
-msgid "Gallery Settings"
-msgstr ""
-
-#: wp-admin/includes/media.php:2548
-msgid "Link thumbnails to:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2553
-msgid "Image File"
-msgstr ""
-
-#: wp-admin/includes/media.php:2556
-#: wp-includes/media-template.php:869
-#: wp-includes/media-template.php:934
-#: wp-includes/media-template.php:1213
-msgid "Attachment Page"
-msgstr ""
-
-#: wp-admin/includes/media.php:2563
-msgid "Order images by:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2568
-msgid "Menu order"
-msgstr ""
-
-#: wp-admin/includes/media.php:2570
-msgid "Date/Time"
-msgstr ""
-
-#: wp-admin/includes/media.php:2571
-msgid "Random"
-msgstr ""
-
-#: wp-admin/includes/media.php:2579
-msgid "Order:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2594
-msgid "Gallery columns:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2614
-#: wp-includes/media.php:4645
-msgid "Insert gallery"
-msgstr ""
-
-#: wp-admin/includes/media.php:2615
-msgid "Update gallery settings"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/media.php:2677
-#: wp-admin/includes/media.php:2681
-msgid "Search Media"
-msgstr ""
-
-#: wp-admin/includes/media.php:2716
-msgid "All Types"
-msgstr ""
-
-#: wp-admin/includes/media.php:2758
-#: wp-admin/includes/nav-menu.php:462
-#: wp-admin/includes/nav-menu.php:764
-msgid "&laquo;"
-msgstr ""
-
-#: wp-admin/includes/media.php:2759
-#: wp-admin/includes/nav-menu.php:463
-#: wp-admin/includes/nav-menu.php:765
-msgid "&raquo;"
-msgstr ""
-
-#: wp-admin/includes/media.php:2808
-msgid "Filter &#187;"
-msgstr ""
-
-#: wp-admin/includes/media.php:2854
-msgid "Image Caption"
-msgstr ""
-
-#: wp-admin/includes/media.php:2877
-#: wp-includes/class-wp-editor.php:1216
-#: wp-includes/script-loader.php:770
-#: wp-includes/widgets/class-wp-widget-media-image.php:28
-msgid "Image"
-msgstr ""
-
-#: wp-admin/includes/media.php:2877
-msgid "Audio, Video, or Other File"
-msgstr ""
-
-#: wp-admin/includes/media.php:2897
-msgid "Link text, e.g. &#8220;Ransom Demands (PDF)&#8221;"
-msgstr ""
-
-#: wp-admin/includes/media.php:2923
-msgid "Link Image To:"
-msgstr ""
-
-#: wp-admin/includes/media.php:2928
-msgid "Link to image"
-msgstr ""
-
-#. translators: 1: URL to browser uploader, 2: Additional link attributes.
-#: wp-admin/includes/media.php:2968
-msgid "You are using the multi-file uploader. Problems? Try the <a href=\"%1$s\" %2$s>browser uploader</a> instead."
-msgstr ""
-
-#: wp-admin/includes/media.php:2985
-msgid "You are using the browser&#8217;s built-in file uploader. The ClassicPress uploader includes multiple file selection and drag and drop capability. <a href=\"#\">Switch to the multi-file uploader</a>."
-msgstr ""
-
-#. translators: 1: Link start tag, 2: Link end tag, 3: Width, 4: Height.
-#: wp-admin/includes/media.php:3017
-msgid "Scale images to match the large size selected in %1$simage options%2$s (%3$d &times; %4$d)."
-msgstr ""
-
-#. translators: %s: Allowed space allocation.
-#: wp-admin/includes/media.php:3032
-#: wp-admin/includes/ms-deprecated.php:35
-#: wp-admin/includes/ms.php:239
-#: wp-includes/class-wp-xmlrpc-server.php:6397
-msgid "Sorry, you have used your space allocation of %s. Please delete some files to upload more files."
-msgstr ""
-
-#. translators: 1: Link to tutorial, 2: Additional link attributes, 3: Accessibility text.
-#: wp-admin/includes/media.php:3166
-#: wp-includes/media-template.php:161
-msgid "<a href=\"%1$s\" %2$s>Learn how to describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative."
-msgstr ""
-
-#: wp-admin/includes/media.php:3202
-msgid "Displayed on attachment pages."
-msgstr ""
-
-#: wp-admin/includes/media.php:3242
-#: wp-includes/media.php:4167
-msgid "(no author)"
-msgstr ""
-
-#: wp-admin/includes/media.php:3252
-#: wp-admin/includes/media.php:3254
-#: wp-includes/media-template.php:435
-msgid "Uploaded by:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3267
-#: wp-admin/includes/media.php:3269
-#: wp-includes/media-template.php:444
-msgid "Uploaded to:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3278
-#: wp-includes/media-template.php:537
-#: wp-includes/media-template.php:782
-msgid "File URL:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3325
-#: wp-includes/media-template.php:454
-msgid "File size:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3332
-#: wp-includes/media-template.php:474
-#: wp-includes/media-template.php:717
-msgid "Length:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3333
-#: wp-includes/media-template.php:482
-msgid "Bitrate:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3380
-msgid "Audio Format:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3381
-msgid "Audio Codec:"
-msgstr ""
-
-#: wp-admin/includes/media.php:3422
-#: wp-includes/media-template.php:467
-#: wp-includes/media-template.php:706
-msgid "Original image:"
-msgstr ""
-
-#: wp-admin/includes/menu.php:364
-#: wp-admin/my-sites.php:17
-#: wp-admin/network/index.php:17
-#: wp-admin/network/settings.php:17
-#: wp-admin/network/site-info.php:32
-#: wp-admin/network/site-settings.php:32
-#: wp-admin/network/site-themes.php:57
-#: wp-admin/network/site-users.php:50
-#: wp-admin/network/sites.php:14
-#: wp-admin/network/sites.php:141
-#: wp-admin/network/upgrade.php:39
-#: wp-admin/network/user-new.php:37
-#: wp-admin/network/users.php:14
-#: wp-admin/network/users.php:24
-#: wp-admin/network/users.php:51
-#: wp-admin/network/users.php:65
-#: wp-admin/network/users.php:160
-msgid "Sorry, you are not allowed to access this page."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:59
-#: wp-admin/js/post.js:857
-msgid "Save as Pending"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:71
-msgid "Preview Changes"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:109
-#: wp-admin/includes/meta-boxes.php:154
-#: wp-admin/js/post.js:823
-#: wp-admin/js/post.js:825
-msgid "Privately Published"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:138
-msgid "Edit status"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:147
-msgid "Set status"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:165
-#: wp-admin/includes/meta-boxes.php:223
-#: wp-admin/includes/template.php:893
-#: wp-includes/class-wp-editor.php:1181
-#: wp-admin/js/post.js:1027
-msgid "OK"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:174
-msgid "Visibility:"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:183
-#: wp-admin/includes/meta-boxes.php:217
-#: wp-includes/comment-template.php:635
-msgid "Password protected"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:186
-#: wp-admin/js/post.js:903
-msgid "Public, Sticky"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:189
-#: wp-admin/includes/meta-boxes.php:211
-#: wp-admin/js/post.js:903
-msgid "Public"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:200
-msgid "Edit visibility"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:214
-msgid "Stick this post to the front page"
-msgstr ""
-
-#. translators: Post date information. %s: Date on which the post is currently scheduled to be published.
-#: wp-admin/includes/meta-boxes.php:241
-msgid "Scheduled for: %s"
-msgstr ""
-
-#. translators: Post date information. %s: Date on which the post was published.
-#: wp-admin/includes/meta-boxes.php:244
-msgid "Published on: %s"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:246
-#: wp-admin/includes/meta-boxes.php:260
-msgid "Publish <b>immediately</b>"
-msgstr ""
-
-#. translators: Post date information. %s: Date on which the post is to be published.
-#: wp-admin/includes/meta-boxes.php:249
-msgid "Schedule for: %s"
-msgstr ""
-
-#. translators: Post date information. %s: Date on which the post is to be published.
-#: wp-admin/includes/meta-boxes.php:252
-msgid "Publish on: %s"
-msgstr ""
-
-#. translators: Post revisions heading. %s: The number of available revisions.
-#: wp-admin/includes/meta-boxes.php:273
-msgid "Revisions: %s"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:275
-msgctxt "revisions"
-msgid "Browse"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:278
-msgid "Browse revisions"
-msgstr ""
-
-#. translators: %s: URL to the Customizer.
-#: wp-admin/includes/meta-boxes.php:320
-msgid "This draft comes from your <a href=\"%s\">unpublished customization changes</a>. You can edit, but there is no need to publish now. It will be published automatically with those changes."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:384
-#: wp-admin/includes/meta-boxes.php:385
-#: wp-admin/js/post.js:792
-msgctxt "post action/button label"
-msgid "Schedule"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:395
-#: wp-admin/includes/meta-boxes.php:396
-msgid "Submit for Review"
-msgstr ""
-
-#. translators: Attachment information. %s: Date the attachment was uploaded.
-#: wp-admin/includes/meta-boxes.php:446
-msgid "Uploaded on: %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:528
-#: wp-admin/includes/theme.php:329
-msgid "Post Formats"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:609
-#: wp-admin/includes/meta-boxes.php:1222
-#: wp-includes/class-wp-customize-control.php:643
-#: wp-includes/class-wp-customize-nav-menus.php:1245
-msgid "Add"
-msgstr ""
-
-#. translators: %s: Add New taxonomy label.
-#. translators: %s: Add New Page label.
-#: wp-admin/includes/meta-boxes.php:691
-#: wp-includes/class-wp-customize-control.php:632
-msgid "+ %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:760
-#: wp-admin/includes/meta-boxes.php:1652
-#: wp-admin/options-reading.php:177
-#: wp-includes/revision.php:34
-msgid "Excerpt"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/meta-boxes.php:767
-msgid "Excerpts are optional hand-crafted summaries of your content that can be used in your theme. <a href=\"%s\">Learn more about manual excerpts</a>."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:768
-msgid "https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:787
-msgid "Already pinged:"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:797
-msgid "Send trackbacks to:"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:800
-msgid "Separate multiple URLs with spaces"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/meta-boxes.php:805
-msgid "Trackbacks are a way to notify legacy blog systems that you&#8217;ve linked to them. If you link other ClassicPress sites, they&#8217;ll be notified automatically using <a href=\"%s\">pingbacks</a>, no other action necessary."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:806
-msgid "https://wordpress.org/documentation/article/introduction-to-blogging/#comments"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/meta-boxes.php:842
-msgid "Custom fields can be used to add extra metadata to a post that you can <a href=\"%s\">use in your theme</a>."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:843
-msgid "https://wordpress.org/documentation/article/assign-custom-fields/"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:861
-msgid "Allow comments"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/meta-boxes.php:866
-msgid "Allow <a href=\"%s\">trackbacks and pingbacks</a>"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:867
-msgid "https://wordpress.org/documentation/article/introduction-to-blogging/#managing-comments"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:908
-#: wp-admin/includes/template.php:506
-msgid "Add Comment"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:922
-msgid "No comments yet."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:932
-msgid "Show comments"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1020
-msgid "(no parent)"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1093
-msgid "Need help? Use the Help tab above the screen title."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1124
-msgid "Visit Link"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1132
-msgid "Keep this link private"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1190
-msgid "All categories"
-msgstr ""
-
-#. translators: Tab heading when selecting from the most used terms.
-#: wp-admin/includes/meta-boxes.php:1191
-#: wp-includes/class-wp-taxonomy.php:637
-msgctxt "categories"
-msgid "Most Used"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/meta-boxes.php:1213
-#: wp-admin/includes/meta-boxes.php:1218
-msgid "+ Add New Category"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1221
-msgid "New category name"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1249
-msgid "<code>_blank</code> &mdash; new window or tab."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1252
-msgid "<code>_top</code> &mdash; current window or tab, with no frames."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1255
-msgid "<code>_none</code> &mdash; same window or tab."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1257
-msgid "Choose the target frame for your link."
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1331
-msgid "rel:"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1335
-#: wp-admin/includes/meta-boxes.php:1340
-msgid "identity"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1345
-msgid "another web address of mine"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1349
-#: wp-admin/includes/meta-boxes.php:1354
-msgid "friendship"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1358
-msgid "contact"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1361
-msgid "acquaintance"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1364
-msgid "friend"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1367
-#: wp-admin/includes/meta-boxes.php:1418
-#: wp-admin/includes/meta-boxes.php:1447
-msgid "none"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1372
-#: wp-admin/includes/meta-boxes.php:1377
-msgid "physical"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1381
-msgid "met"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1386
-#: wp-admin/includes/meta-boxes.php:1391
-msgid "professional"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1395
-msgid "co-worker"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1398
-msgid "colleague"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1403
-#: wp-admin/includes/meta-boxes.php:1408
-msgid "geographical"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1412
-msgid "co-resident"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1415
-msgid "neighbor"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1423
-#: wp-admin/includes/meta-boxes.php:1428
-msgid "family"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1432
-#: wp-admin/nav-menus.php:530
-msgid "child"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1435
-msgid "kin"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1438
-msgid "parent"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1441
-msgid "sibling"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1444
-msgid "spouse"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#. translators: Hidden accessibility text. xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1452
-#: wp-admin/includes/meta-boxes.php:1457
-msgid "romantic"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1461
-msgid "muse"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1464
-msgid "crush"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1467
-msgid "date"
-msgstr ""
-
-#. translators: xfn: https://gmpg.org/xfn
-#: wp-admin/includes/meta-boxes.php:1470
-msgid "sweetheart"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1476
-msgid "If the link is to a person, you can specify your relationship with them using the above form. If you would like to learn more about the idea check out <a href=\"https://gmpg.org/xfn/\">XFN</a>."
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1491
-msgid "Image Address"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1495
-msgid "RSS Address"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1499
-msgid "Notes"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1514
-msgid "(Leave at 0 for no rating.)"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1593
-#: wp-admin/revision.php:112
-#: wp-includes/post.php:111
-msgid "Revisions"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1604
-#: wp-includes/media-template.php:1343
-#: wp-includes/media-template.php:1442
-msgid "Metadata"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1656
-msgid "Send Trackbacks"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1662
-msgid "Custom Fields"
-msgstr ""
-
-#: wp-admin/includes/meta-boxes.php:1686
-#: wp-admin/menu.php:339
-msgid "Discussion"
-msgstr ""
-
-#: wp-admin/includes/misc.php:42
-msgid "commit %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/misc.php:468
-#: wp-admin/includes/misc.php:570
-msgid "folder"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/misc.php:1076
-#: wp-admin/user-edit.php:321
-msgid "Admin Color Scheme"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/misc.php:1258
-msgid "%s has taken over and is currently editing."
-msgstr ""
-
-#: wp-admin/includes/misc.php:1380
-#: wp-admin/includes/post.php:2031
-#: wp-admin/widgets-form.php:366
-msgid "Error while saving."
-msgstr ""
-
-#. translators: Draft saved date format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/includes/misc.php:1384
-msgid "g:i:s a"
-msgstr ""
-
-#. translators: %s: Date and time.
-#: wp-admin/includes/misc.php:1388
-msgid "Draft saved at %s."
-msgstr ""
-
-#. translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders.
-#: wp-admin/includes/misc.php:1491
-msgid ""
-"Hello ###USERNAME###,\n"
-"\n"
-"Someone with administrator capabilities recently requested to have the\n"
-"administration email address changed on this site:\n"
-"###SITEURL###\n"
-"\n"
-"To confirm this change, please click on the following link:\n"
-"###ADMIN_URL###\n"
-"\n"
-"You can safely ignore and delete this email if you do not want to\n"
-"take this action.\n"
-"\n"
-"This email has been sent to ###EMAIL###\n"
-"\n"
-"Regards,\n"
-"All at ###SITENAME###\n"
-"###SITEURL###"
-msgstr ""
-
-#. translators: New admin email address notification email subject. %s: Site title.
-#: wp-admin/includes/misc.php:1551
-msgid "[%s] New Admin Email Address"
-msgstr ""
-
-#. translators: %s: Page title.
-#: wp-admin/includes/misc.php:1576
-msgid "%s (Draft)"
-msgstr ""
-
-#. translators: %s: Required disk space in kilobytes.
-#: wp-admin/includes/ms.php:36
-#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1293
-msgid "Not enough space to upload. %s KB needed."
-msgstr ""
-
-#. translators: %s: Maximum allowed file size in kilobytes.
-#: wp-admin/includes/ms.php:41
-#: wp-includes/ms-functions.php:2091
-#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1302
-msgid "This file is too big. Files must be less than %s KB in size."
-msgstr ""
-
-#: wp-admin/includes/ms.php:45
-#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1313
-msgid "You have used your space quota. Please delete files before uploading."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/ms.php:49
-#: wp-admin/theme-install.php:61
-#: wp-includes/class-wp-customize-nav-menus.php:1152
-#: wp-includes/class-wp-customize-panel.php:379
-#: wp-includes/class-wp-customize-section.php:374
-#: wp-includes/class-wp-customize-widgets.php:834
-#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:75
-#: wp-includes/customize/class-wp-customize-themes-panel.php:73
-#: wp-includes/media.php:4584
-msgid "Back"
-msgstr ""
-
-#. translators: Storage space that's been used. 1: Percentage of used space, 2: Total space allowed in megabytes or gigabytes.
-#: wp-admin/includes/ms.php:265
-msgid "Used: %1$s%% of %2$s"
-msgstr ""
-
-#: wp-admin/includes/ms.php:305
-msgid "Site Upload Space Quota"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/ms.php:311
-#: wp-admin/network/settings.php:410
-msgid "Size in megabytes"
-msgstr ""
-
-#: wp-admin/includes/ms.php:313
-msgid "MB (Leave blank for network default)"
-msgstr ""
-
-#. translators: 1: Site title.
-#: wp-admin/includes/ms.php:575
-#: wp-admin/includes/ms.php:584
-msgid "You attempted to access the \"%1$s\" dashboard, but you do not currently have privileges on this site. If you believe you should be able to access the \"%1$s\" dashboard, please contact your network administrator."
-msgstr ""
-
-#: wp-admin/includes/ms.php:587
-msgid "If you reached this screen by accident and meant to visit one of your own sites, here are some shortcuts to help you find your way."
-msgstr ""
-
-#: wp-admin/includes/ms.php:589
-msgid "Your Sites"
-msgstr ""
-
-#: wp-admin/includes/ms.php:595
-msgid "Visit Dashboard"
-msgstr ""
-
-#: wp-admin/includes/ms.php:596
-msgid "View Site"
-msgstr ""
-
-#: wp-admin/includes/ms.php:639
-msgid "American English"
-msgstr ""
-
-#: wp-admin/includes/ms.php:643
-msgid "British English"
-msgstr ""
-
-#: wp-admin/includes/ms.php:652
-#: wp-includes/script-loader.php:904
-msgid "English"
-msgstr ""
-
-#. translators: %s: URL to Upgrade Network screen.
-#: wp-admin/includes/ms.php:696
-msgid "Thank you for Updating! Please visit the <a href=\"%s\">Upgrade Network</a> page to update all your sites."
-msgstr ""
-
-#. translators: My Sites label.
-#: wp-admin/includes/ms.php:759
-msgid "Primary Site"
-msgstr ""
-
-#: wp-admin/includes/ms.php:856
-msgid "You have chosen to delete the user from all networks and sites."
-msgstr ""
-
-#: wp-admin/includes/ms.php:858
-msgid "You have chosen to delete the following users from all networks and sites."
-msgstr ""
-
-#. translators: %s: User login.
-#: wp-admin/includes/ms.php:879
-msgid "Warning! User %s cannot be deleted."
-msgstr ""
-
-#. translators: %s: User login.
-#: wp-admin/includes/ms.php:889
-msgid "Warning! User cannot be deleted. The user %s is a network administrator."
-msgstr ""
-
-#. translators: %s: User login.
-#: wp-admin/includes/ms.php:908
-msgid "What should be done with content owned by %s?"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/ms.php:926
-msgid "Select a user"
-msgstr ""
-
-#. translators: %s: Link to user's site.
-#: wp-admin/includes/ms.php:948
-msgid "Site: %s"
-msgstr ""
-
-#: wp-admin/includes/ms.php:952
-#: wp-admin/users.php:369
-msgid "Delete all content."
-msgstr ""
-
-#: wp-admin/includes/ms.php:954
-#: wp-admin/users.php:372
-msgid "Attribute all content to:"
-msgstr ""
-
-#: wp-admin/includes/ms.php:963
-msgid "User has no sites or content and will be deleted."
-msgstr ""
-
-#: wp-admin/includes/ms.php:978
-msgid "Once you hit &#8220;Confirm Deletion&#8221;, the user will be permanently removed."
-msgstr ""
-
-#: wp-admin/includes/ms.php:980
-msgid "Once you hit &#8220;Confirm Deletion&#8221;, these users will be permanently removed."
-msgstr ""
-
-#: wp-admin/includes/ms.php:984
-#: wp-admin/users.php:397
-msgid "Confirm Deletion"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1053
-msgid "Info"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1063
-#: wp-admin/network/menu.php:78
-#: wp-admin/network/themes.php:338
-#: wp-admin/themes.php:127
-#: wp-admin/themes.php:250
-#: wp-admin/update-core.php:480
-#: wp-admin/update-core.php:493
-#: wp-includes/admin-bar.php:537
-#: wp-includes/admin-bar.php:979
-#: wp-includes/customize/class-wp-customize-themes-panel.php:82
-msgid "Themes"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1068
-#: wp-admin/menu.php:335
-#: wp-admin/network/menu.php:109
-#: wp-admin/options.php:22
-#: wp-includes/admin-bar.php:559
-msgid "Settings"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1119
-#: wp-admin/nav-menus.php:730
-#: wp-admin/options-privacy.php:161
-#: wp-admin/privacy-policy-guide.php:44
-#: wp-admin/site-health.php:131
-msgid "Secondary menu"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1136
-msgid "The menu is for editing information specific to individual sites, particularly if the admin area of a site is unavailable."
-msgstr ""
-
-#: wp-admin/includes/ms.php:1137
-msgid "<strong>Info</strong> &mdash; The site URL is rarely edited as this can cause the site to not work properly. The Registered date and Last Updated date are displayed. Network admins can mark a site as archived, spam, deleted and mature, to remove from public listings or disable."
-msgstr ""
-
-#: wp-admin/includes/ms.php:1138
-msgid "<strong>Users</strong> &mdash; This displays the users associated with this site. You can also change their role, reset their password, or remove them from the site. Removing the user from the site does not remove the user from the network."
-msgstr ""
-
-#. translators: %s: URL to Network Themes screen.
-#: wp-admin/includes/ms.php:1141
-msgid "<strong>Themes</strong> &mdash; This area shows themes that are not already enabled across the network. Enabling a theme in this menu makes it accessible to this site. It does not activate the theme, but allows it to show in the site&#8217;s Appearance menu. To enable a theme for the entire network, see the <a href=\"%s\">Network Themes</a> screen."
-msgstr ""
-
-#: wp-admin/includes/ms.php:1144
-msgid "<strong>Settings</strong> &mdash; This page shows a list of all settings associated with this site. Some are created by ClassicPress and others are created by plugins you activate. Note that some fields are grayed out and say Serialized Data. You cannot modify these values due to the way the setting is stored in the database."
-msgstr ""
-
-#: wp-admin/includes/ms.php:1157
-#: wp-admin/network/site-new.php:32
-#: wp-admin/network/sites.php:46
-msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-sites-screen/\">Documentation on Site Management</a>"
-msgstr ""
-
-#: wp-admin/includes/ms.php:1158
-#: wp-admin/network/index.php:57
-#: wp-admin/network/site-new.php:33
-#: wp-admin/network/sites.php:47
-#: wp-admin/network/user-new.php:30
-#: wp-admin/network/users.php:243
-msgid "<a href=\"https://wordpress.org/support/forum/multisite/\">Support forums</a>"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:148
-#: wp-includes/class-wp-customize-nav-menus.php:1270
-msgid "Custom Links"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:305
-#: wp-includes/class-wp-customize-nav-menus.php:1279
-#: wp-includes/class-wp-editor.php:1891
-#: wp-includes/media-template.php:1038
-msgid "Link Text"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:311
-#: wp-admin/includes/nav-menu.php:682
-#: wp-admin/includes/nav-menu.php:919
-#: wp-includes/class-wp-customize-nav-menus.php:1284
-msgid "Add to Menu"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:392
-#: wp-includes/class-wp-customize-nav-menus.php:167
-#: wp-includes/class-wp-customize-nav-menus.php:451
-msgctxt "nav menu home label"
-msgid "Home"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:442
-#: wp-admin/includes/nav-menu.php:737
-msgid "No items."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/nav-menu.php:465
-#: wp-admin/includes/nav-menu.php:767
-msgid "Page"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:513
-#: wp-admin/includes/nav-menu.php:528
-msgid "Most Recent"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:518
-#: wp-admin/includes/nav-menu.php:820
-msgid "View All"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:606
-#: wp-admin/includes/nav-menu.php:907
-#: wp-includes/class-wp-customize-nav-menus.php:336
-#: wp-includes/script-loader.php:733
-#: wp-includes/script-loader.php:1058
-#: wp-admin/js/nav-menu.js:496
-msgid "No results found."
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1056
-msgid "Add menu items from the column on the left."
-msgstr ""
-
-#. translators: %s: Walker class name.
-#: wp-admin/includes/nav-menu.php:1080
-msgid "The Walker class named %s does not exist."
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1098
-msgid "Click Save Menu to make pending menu items public."
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1102
-msgid "There are some invalid menu items. Please check or delete them."
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1123
-msgid "Show advanced menu properties"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1125
-msgid "Link Target"
-msgstr ""
-
-#: wp-admin/includes/nav-menu.php:1127
-#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:113
-msgid "CSS Classes"
-msgstr ""
-
-#. translators: %s: Nav menu title.
-#: wp-admin/includes/nav-menu.php:1263
-msgid "%s has been updated."
-msgstr ""
-
-#. translators: %s: DO_NOT_UPGRADE_GLOBAL_TABLES
-#: wp-admin/includes/network.php:118
-msgid "The constant %s cannot be defined when creating a network."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/network.php:128
-#: wp-admin/includes/network.php:142
-#: wp-admin/includes/network.php:199
-#: wp-admin/includes/network.php:259
-#: wp-admin/includes/network.php:308
-#: wp-admin/includes/network.php:321
-#: wp-admin/includes/network.php:423
-#: wp-admin/includes/network.php:621
-#: wp-admin/includes/network.php:683
-#: wp-admin/includes/template.php:1287
-#: wp-admin/options.php:366
-msgid "Warning:"
-msgstr ""
-
-#. translators: %s: URL to Plugins screen.
-#: wp-admin/includes/network.php:130
-msgid "Please <a href=\"%s\">deactivate your plugins</a> before enabling the Network feature."
-msgstr ""
-
-#: wp-admin/includes/network.php:133
-msgid "Once the network is created, you may reactivate your plugins."
-msgstr ""
-
-#: wp-admin/includes/network.php:142
-msgid "Installing a network of sites with your server address is experimental."
-msgstr ""
-
-#. translators: %s: Port number.
-#: wp-admin/includes/network.php:145
-msgid "Use port numbers such as %s at your own risk."
-msgstr ""
-
-#: wp-admin/includes/network.php:156
-msgid "Error: The network could not be created."
-msgstr ""
-
-#. translators: %s: Default network title.
-#: wp-admin/includes/network.php:168
-msgid "%s Sites"
-msgstr ""
-
-#: wp-admin/includes/network.php:177
-msgid "Welcome to the Network installation process!"
-msgstr ""
-
-#: wp-admin/includes/network.php:178
-msgid "Fill in the information below and you&#8217;ll be on your way to creating a network of ClassicPress sites. Configuration files will be created in the next step."
-msgstr ""
-
-#: wp-admin/includes/network.php:191
-msgid "Note:"
-msgstr ""
-
-#. translators: %s: mod_rewrite
-#: wp-admin/includes/network.php:194
-msgid "Please make sure the Apache %s module is installed as it will be used at the end of this installation."
-msgstr ""
-
-#. translators: %s: mod_rewrite
-#: wp-admin/includes/network.php:202
-msgid "It looks like the Apache %s module is not installed."
-msgstr ""
-
-#. translators: 1: mod_rewrite, 2: mod_rewrite documentation URL, 3: Google search for mod_rewrite.
-#: wp-admin/includes/network.php:212
-msgid "If %1$s is disabled, ask your administrator to enable that module, or look at the <a href=\"%2$s\">Apache documentation</a> or <a href=\"%3$s\">elsewhere</a> for help setting it up."
-msgstr ""
-
-#: wp-admin/includes/network.php:223
-msgid "Addresses of Sites in your Network"
-msgstr ""
-
-#: wp-admin/includes/network.php:224
-msgid "Please choose whether you would like sites in your ClassicPress network to use sub-domains or sub-directories."
-msgstr ""
-
-#: wp-admin/includes/network.php:225
-msgid "You cannot change this later."
-msgstr ""
-
-#: wp-admin/includes/network.php:226
-msgid "You will need a wildcard DNS record if you are going to use the virtual host (sub-domain) functionality."
-msgstr ""
-
-#: wp-admin/includes/network.php:230
-msgid "Sub-domains"
-msgstr ""
-
-#. translators: 1: Host name.
-#: wp-admin/includes/network.php:235
-msgctxt "subdomain examples"
-msgid "like <code>site1.%1$s</code> and <code>site2.%1$s</code>"
-msgstr ""
-
-#: wp-admin/includes/network.php:242
-msgid "Sub-directories"
-msgstr ""
-
-#. translators: 1: Host name.
-#: wp-admin/includes/network.php:247
-msgctxt "subdirectory examples"
-msgid "like <code>%1$s/site1</code> and <code>%1$s/site2</code>"
-msgstr ""
-
-#: wp-admin/includes/network.php:259
-#: wp-admin/includes/network.php:621
-#: wp-admin/includes/network.php:683
-msgid "Subdirectory networks may not be fully compatible with custom wp-content directories."
-msgstr ""
-
-#: wp-admin/includes/network.php:265
-#: wp-admin/includes/network.php:279
-#: wp-admin/includes/network.php:339
-msgid "Server Address"
-msgstr ""
-
-#. translators: 1: Site URL, 2: Host name, 3: www.
-#: wp-admin/includes/network.php:270
-msgid "You should consider changing your site domain to %1$s before enabling the network feature. It will still be possible to visit your site using the %3$s prefix with an address like %2$s but any links will not have the %3$s prefix."
-msgstr ""
-
-#. translators: %s: Host name.
-#: wp-admin/includes/network.php:284
-#: wp-admin/includes/network.php:344
-msgid "The internet address of your network will be %s."
-msgstr ""
-
-#: wp-admin/includes/network.php:293
-msgid "Network Details"
-msgstr ""
-
-#: wp-admin/includes/network.php:297
-#: wp-admin/includes/network.php:315
-msgid "Sub-directory Installation"
-msgstr ""
-
-#. translators: 1: localhost, 2: localhost.localdomain
-#: wp-admin/includes/network.php:302
-msgid "Because you are using %1$s, the sites in your ClassicPress network must use sub-directories. Consider using %2$s if you wish to use sub-domains."
-msgstr ""
-
-#: wp-admin/includes/network.php:308
-#: wp-admin/includes/network.php:321
-#: wp-admin/includes/network.php:332
-msgid "The main site in a sub-directory installation will need to use a modified permalink structure, potentially breaking existing links."
-msgstr ""
-
-#: wp-admin/includes/network.php:318
-msgid "Because your installation is in a directory, the sites in your ClassicPress network must use sub-directories."
-msgstr ""
-
-#: wp-admin/includes/network.php:328
-msgid "Sub-domain Installation"
-msgstr ""
-
-#: wp-admin/includes/network.php:331
-msgid "Because your installation is not new, the sites in your ClassicPress network must use sub-domains."
-msgstr ""
-
-#: wp-admin/includes/network.php:352
-#: wp-admin/network/settings.php:153
-msgid "Network Title"
-msgstr ""
-
-#: wp-admin/includes/network.php:356
-msgid "What would you like to call your network?"
-msgstr ""
-
-#: wp-admin/includes/network.php:361
-#: wp-admin/network/settings.php:160
-msgid "Network Admin Email"
-msgstr ""
-
-#: wp-admin/includes/network.php:365
-msgid "Your email address."
-msgstr ""
-
-#: wp-admin/includes/network.php:418
-msgid "The original configuration steps are shown here for reference."
-msgstr ""
-
-#: wp-admin/includes/network.php:423
-msgid "An existing ClassicPress network was detected."
-msgstr ""
-
-#: wp-admin/includes/network.php:424
-msgid "Please complete the configuration steps. To create a new network, you will need to empty or remove the network database tables."
-msgstr ""
-
-#: wp-admin/includes/network.php:435
-msgid "Enabling the Network"
-msgstr ""
-
-#: wp-admin/includes/network.php:436
-msgid "Complete the following steps to enable the features for creating a network of sites."
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: .htaccess
-#. translators: 1: wp-config.php, 2: web.config
-#: wp-admin/includes/network.php:443
-#: wp-admin/includes/network.php:451
-msgid "You should back up your existing %1$s and %2$s files."
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/includes/network.php:459
-msgid "You should back up your existing %s file."
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: Location of wp-config file, 3: Translated version of "That's all, stop editing! Happy publishing."
-#: wp-admin/includes/network.php:473
-msgid "Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:"
-msgstr ""
-
-#. translators: This string should only be translated if wp-config-sample.php is localized. You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
-#: wp-admin/includes/network.php:481
-msgid "That&#8217;s all, stop editing! Happy publishing."
-msgstr ""
-
-#. translators: %s: File name (wp-config.php, .htaccess or web.config).
-#: wp-admin/includes/network.php:489
-#: wp-admin/includes/network.php:628
-#: wp-admin/includes/network.php:690
-msgid "Network configuration rules for %s"
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/includes/network.php:539
-msgid "This unique authentication key is also missing from your %s file."
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/includes/network.php:545
-msgid "These unique authentication keys are also missing from your %s file."
-msgstr ""
-
-#: wp-admin/includes/network.php:550
-msgid "To make your installation more secure, you should also add:"
-msgstr ""
-
-#: wp-admin/includes/network.php:552
-msgid "Network configuration authentication keys"
-msgstr ""
-
-#. translators: 1: File name (.htaccess or web.config), 2: File path.
-#: wp-admin/includes/network.php:615
-#: wp-admin/includes/network.php:677
-msgid "Add the following to your %1$s file in %2$s, <strong>replacing</strong> other ClassicPress rules:"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/includes/network.php:643
-msgid "It seems your network is running with Nginx web server. <a href=\"%s\">Learn more about further configuration</a>."
-msgstr ""
-
-#: wp-admin/includes/network.php:644
-msgid "https://wordpress.org/documentation/article/nginx/"
-msgstr ""
-
-#: wp-admin/includes/network.php:704
-msgid "Once you complete these steps, your network is enabled and configured. You will have to log in again."
-msgstr ""
-
-#: wp-admin/includes/network.php:704
-#: wp-admin/install.php:227
-#: wp-admin/install.php:448
-#: wp-includes/general-template.php:498
-#: wp-login.php:1395
-#: wp-login.php:1444
-msgid "Log In"
-msgstr ""
-
-#: wp-admin/includes/options.php:135
-msgid "The <a href=\"https://wordpress.org/documentation/article/wordpress-glossary/#character-set\">character encoding</a> of your site (UTF-8 is recommended)"
-msgstr ""
-
-#. translators: %s: Support forums URL.
-#. translators: %s: support forums URL
-#: wp-admin/includes/plugin-install.php:169
-#: wp-admin/includes/plugin-install.php:185
-#: wp-admin/includes/theme.php:550
-#: wp-admin/includes/theme.php:565
-#: wp-admin/includes/translation-install.php:69
-#: wp-admin/includes/translation-install.php:84
-#: wp-admin/includes/translation-install.php:96
-#: wp-includes/customize/class-wp-customize-themes-section.php:89
-msgid "An unexpected error occurred. Something may be wrong with WordPress.org, ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:170
-#: wp-admin/includes/translation-install.php:70
-#: wp-admin/includes/update-core.php:1042
-#: wp-admin/includes/update.php:138
-#: wp-includes/update.php:391
-#: wp-includes/update.php:667
-#: wp-login.php:1243
-msgid "https://forums.classicpress.net/c/support"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:171
-#: wp-includes/update.php:392
-msgid "(ClassicPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:248
-msgid "Popular tags"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:249
-msgid "You may also browse based on the most popular tags in the Plugin Directory:"
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/plugin-install.php:275
-msgid "%s plugin"
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/plugin-install.php:277
-msgid "%s plugins"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/plugin-install.php:301
-msgid "Search plugins by:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:305
-#: wp-admin/includes/theme-install.php:108
-msgid "Keyword"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:307
-msgctxt "Plugin Installer"
-msgid "Tag"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/plugin-install.php:312
-#: wp-admin/includes/plugin-install.php:316
-msgid "Search Plugins"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:315
-msgid "Search plugins..."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:329
-msgid "If you have a plugin in a .zip format, you may install or update it by uploading it here."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/plugin-install.php:335
-msgid "Plugin zip file"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:354
-msgid "If you have marked plugins as favorites on ClassicPress.net, you can browse them here."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:358
-msgid "Your ClassicPress.net username:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:360
-msgid "Get Favorites"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:375
-msgid "Forms"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:376
-#: wp-admin/widgets.php:28
-#: wp-includes/admin-bar.php:994
-#: wp-includes/class-wp-customize-widgets.php:416
-#: wp-includes/functions.php:5303
-msgid "Widgets"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:377
-msgid "Admin Utilities"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:378
-msgid "Page Builders"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:379
-msgid "eCommerce"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:381
-msgid "SEO"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:382
-msgid "Advertising"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:383
-msgid "Social Networking"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/plugin-install.php:384
-#: wp-admin/options-general.php:337
-#: wp-admin/options-general.php:341
-msgid "Membership"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:385
-msgid "Newsletters"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:386
-msgid "Forums"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:390
-msgid "These are some of the most common types of plugins. Not all categories are represented here."
-msgstr ""
-
-#. translators: %s: URL to "Features as Plugins" page.
-#: wp-admin/includes/plugin-install.php:424
-msgid "You are using a development version of ClassicPress. These feature plugins are also under development. <a href=\"%s\">Learn more</a>."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:429
-msgid "These suggestions are based on the plugins you and other users have installed."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:600
-msgctxt "Plugin installer section title"
-msgid "Description"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:601
-msgctxt "Plugin installer section title"
-msgid "Installation"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:602
-msgctxt "Plugin installer section title"
-msgid "FAQ"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:603
-msgctxt "Plugin installer section title"
-msgid "Screenshots"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:604
-msgctxt "Plugin installer section title"
-msgid "Changelog"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:605
-msgctxt "Plugin installer section title"
-msgid "Reviews"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:606
-msgctxt "Plugin installer section title"
-msgid "Other Notes"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:629
-#: wp-admin/update.php:152
-msgid "Plugin Installation"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:687
-#: wp-mail.php:248
-msgid "Author:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:697
-msgid "Requires WordPress Version:"
-msgstr ""
-
-#. translators: %s: Version number.
-#: wp-admin/includes/plugin-install.php:700
-#: wp-admin/includes/plugin-install.php:710
-msgid "%s or higher"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:704
-msgid "Compatible Up to WordPress Version:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:707
-msgid "Requires PHP Version:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:714
-msgid "Active Installations:"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:731
-msgid "WordPress.org Plugin Page &#187;"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:733
-msgid "Plugin Homepage &#187;"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:735
-#: wp-admin/includes/plugin-install.php:822
-msgid "Donate to this plugin &#187;"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:739
-msgid "Average Rating"
-msgstr ""
-
-#. translators: %s: Number of ratings.
-#: wp-admin/includes/plugin-install.php:753
-msgid "(based on %s rating)"
-msgid_plural "(based on %s ratings)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/plugin-install.php:763
-msgid "Reviews"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:764
-msgid "Read all reviews on WordPress.org or write your own!"
-msgstr ""
-
-#. translators: 1: Number of stars (used to determine singular/plural), 2: Number of reviews.
-#: wp-admin/includes/plugin-install.php:772
-msgid "Reviews with %1$d star: %2$s. Opens in a new tab."
-msgid_plural "Reviews with %1$d stars: %2$s. Opens in a new tab."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Number of stars.
-#: wp-admin/includes/plugin-install.php:790
-msgid "%d star"
-msgid_plural "%d stars"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/includes/plugin-install.php:804
-msgid "Contributors"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:837
-msgid "<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>."
-msgstr ""
-
-#. translators: %s: URL to Update PHP page.
-#: wp-admin/includes/plugin-install.php:841
-msgid "<a href=\"%s\" target=\"_blank\">Click here to learn more about updating PHP</a>."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:854
-msgid "<strong>Warning:</strong> This plugin <strong>has not been tested</strong> with your current version of ClassicPress."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:858
-msgid "<strong>Error:</strong> This plugin <strong>requires a newer version of ClassicPress</strong>."
-msgstr ""
-
-#. translators: %s: URL to WordPress Updates screen.
-#: wp-admin/includes/plugin-install.php:862
-msgid "<a href=\"%s\" target=\"_parent\">Click here to update ClassicPress</a>."
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:903
-msgid "Install Update Now"
-msgstr ""
-
-#. translators: %s: Plugin version.
-#: wp-admin/includes/plugin-install.php:914
-msgid "Newer Version (%s) Installed"
-msgstr ""
-
-#: wp-admin/includes/plugin-install.php:917
-msgid "Latest Version Installed"
-msgstr ""
-
-#. translators: 1: Site Wide Only: true, 2: Network: true
-#: wp-admin/includes/plugin.php:100
-msgid "The %1$s plugin header is deprecated. Use %2$s instead."
-msgstr ""
-
-#. translators: %s: Plugin author.
-#: wp-admin/includes/plugin.php:222
-msgid "By %s."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:502
-msgid "Advanced caching plugin."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:503
-msgid "Custom database class."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:504
-msgid "Custom database error message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:505
-msgid "Custom installation script."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:506
-msgid "Custom maintenance message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:507
-msgid "External object cache."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:508
-msgid "Custom PHP error message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:509
-msgid "Custom PHP fatal error handler."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:513
-msgid "Executed before Multisite is loaded."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:514
-msgid "Custom site deleted message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:515
-msgid "Custom site inactive message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:516
-msgid "Custom site suspended message."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:735
-msgid "The plugin generated unexpected output."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:886
-msgid "One of the plugins is invalid."
-msgstr ""
-
-#. translators: %s: Plugin filename.
-#: wp-admin/includes/plugin.php:1045
-msgid "Could not fully remove the plugin %s."
-msgstr ""
-
-#. translators: %s: Comma-separated list of plugin filenames.
-#: wp-admin/includes/plugin.php:1048
-msgid "Could not fully remove the plugins %s."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:1108
-msgid "Invalid plugin path."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:1111
-msgid "Plugin file does not exist."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:1116
-msgid "The plugin does not have a valid header."
-msgstr ""
-
-#. translators: 1: Current WordPress version, 2: Current PHP version, 3: Plugin name, 4: Required WordPress version, 5: Required PHP version.
-#: wp-admin/includes/plugin.php:1163
-msgctxt "plugin"
-msgid "<strong>Error:</strong> Current versions of ClassicPress (%1$s) and PHP (%2$s) do not meet minimum requirements for %3$s. The plugin requires WordPress %4$s and PHP %5$s."
-msgstr ""
-
-#. translators: 1: Current PHP version, 2: Plugin name, 3: Required PHP version.
-#: wp-admin/includes/plugin.php:1176
-msgctxt "plugin"
-msgid "<strong>Error:</strong> Current PHP version (%1$s) does not meet minimum requirements for %2$s. The plugin requires PHP %3$s."
-msgstr ""
-
-#. translators: 1: Current WordPress version, 2: Plugin name, 3: Required WordPress version.
-#: wp-admin/includes/plugin.php:1187
-msgctxt "plugin"
-msgid "<strong>Error:</strong> Current ClassicPress version (%1$s) does not meet minimum requirements for %2$s. The plugin requires WordPress %3$s."
-msgstr ""
-
-#. translators: %s: add_menu_page()
-#. translators: %s: add_submenu_page()
-#: wp-admin/includes/plugin.php:1345
-#: wp-admin/includes/plugin.php:1449
-msgid "The seventh parameter passed to %s should be numeric representing menu position."
-msgstr ""
-
-#. translators: %s: admin_init
-#: wp-admin/includes/plugin.php:2361
-msgid "The suggested privacy policy content should be added only in wp-admin by using the %s (or later) action."
-msgstr ""
-
-#. translators: %s: admin_init
-#: wp-admin/includes/plugin.php:2372
-msgid "The suggested privacy policy content should be added by using the %s (or later) action. Please see the inline documentation."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:2481
-msgid "Could not resume the plugin."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:2510
-msgid "One or more plugins failed to load properly."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:2511
-msgid "You can find more details and make changes on the Plugins screen."
-msgstr ""
-
-#: wp-admin/includes/plugin.php:2513
-#: wp-admin/includes/plugin.php:2591
-msgid "Go to the Plugins screen"
-msgstr ""
-
-#. translators: 1: Name of deactivated plugin, 2: Plugin version deactivated, 3: Current WP version, 4: Compatible plugin version.
-#: wp-admin/includes/plugin.php:2565
-msgid "%1$s %2$s was deactivated due to incompatibility with ClassicPress %3$s, please upgrade to %1$s %4$s or later."
-msgstr ""
-
-#. translators: 1: Name of deactivated plugin, 2: Plugin version deactivated, 3: Current WP version.
-#: wp-admin/includes/plugin.php:2574
-msgid "%1$s %2$s was deactivated due to incompatibility with ClassicPress %3$s."
-msgstr ""
-
-#. translators: %s: Name of deactivated plugin.
-#: wp-admin/includes/plugin.php:2586
-msgid "%s plugin deactivated during ClassicPress upgrade."
-msgstr ""
-
-#: wp-admin/includes/post.php:35
-#: wp-admin/includes/post.php:80
-msgid "Sorry, you are not allowed to edit pages as this user."
-msgstr ""
-
-#: wp-admin/includes/post.php:37
-#: wp-admin/includes/post.php:82
-msgid "Sorry, you are not allowed to edit posts as this user."
-msgstr ""
-
-#: wp-admin/includes/post.php:41
-#: wp-admin/includes/post.php:86
-#: wp-includes/class-wp-xmlrpc-server.php:5445
-msgid "Sorry, you are not allowed to create pages as this user."
-msgstr ""
-
-#: wp-admin/includes/post.php:43
-#: wp-admin/includes/post.php:88
-#: wp-admin/post-new.php:61
-#: wp-admin/press-this.php:20
-#: wp-includes/class-wp-xmlrpc-server.php:1490
-#: wp-includes/class-wp-xmlrpc-server.php:5440
-#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:601
-#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:617
-msgid "Sorry, you are not allowed to create posts as this user."
-msgstr ""
-
-#: wp-admin/includes/post.php:191
-#: wp-includes/post.php:3982
-#: wp-includes/rest-api.php:2157
-#: wp-includes/script-loader.php:1148
-msgid "Invalid date."
-msgstr ""
-
-#: wp-admin/includes/post.php:499
-#: wp-includes/class-wp-xmlrpc-server.php:3024
-#: wp-includes/class-wp-xmlrpc-server.php:3246
-msgid "Sorry, you are not allowed to edit pages."
-msgstr ""
-
-#: wp-admin/includes/post.php:501
-#: wp-includes/class-wp-xmlrpc-server.php:3307
-#: wp-includes/class-wp-xmlrpc-server.php:4693
-#: wp-includes/class-wp-xmlrpc-server.php:5017
-#: wp-includes/class-wp-xmlrpc-server.php:6199
-msgid "Sorry, you are not allowed to edit posts."
-msgstr ""
-
-#: wp-admin/includes/post.php:715
-msgid "Auto Draft"
-msgstr ""
-
-#: wp-admin/includes/post.php:865
-msgid "Sorry, you are not allowed to create pages on this site."
-msgstr ""
-
-#: wp-admin/includes/post.php:867
-msgid "Sorry, you are not allowed to create posts or drafts on this site."
-msgstr ""
-
-#: wp-admin/includes/post.php:1520
-#: wp-admin/includes/post.php:1545
-msgid "Permalink:"
-msgstr ""
-
-#: wp-admin/includes/post.php:1533
-msgid "Change Permalink Structure"
-msgstr ""
-
-#: wp-admin/includes/post.php:1548
-msgid "Edit permalink"
-msgstr ""
-
-#: wp-admin/includes/post.php:1622
-msgid "Click the image to edit or update"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/post.php:1815
-msgid "%s is currently editing this post. Do you want to take over?"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/post.php:1818
-msgid "%s is currently editing this post."
-msgstr ""
-
-#: wp-admin/includes/post.php:1844
-#: wp-includes/class-wp-customize-manager.php:4322
-msgid "Take over"
-msgstr ""
-
-#: wp-admin/includes/post.php:1858
-msgid "Saving revision&hellip;"
-msgstr ""
-
-#: wp-admin/includes/post.php:1859
-msgid "Your latest changes were saved as a revision."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:23
-#: wp-admin/includes/privacy-tools.php:52
-#: wp-includes/user.php:4661
-#: wp-includes/user.php:4847
-msgid "Invalid personal data request."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:31
-msgid "Unable to initiate confirmation for personal data request."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:91
-msgid "Confirmation request sent again successfully."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:107
-#: wp-admin/includes/privacy-tools.php:124
-msgid "Invalid personal data action."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:135
-msgid "Unable to add this request. A valid email address or username must be supplied."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:155
-msgid "Unable to initiate confirmation request."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:171
-msgid "Confirmation request initiated successfully."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:173
-msgid "Request added successfully."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:294
-msgid "Go to top"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:312
-msgid "Unable to generate personal data export file. ZipArchive not available."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:319
-msgid "Invalid request ID when generating personal data export file."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:325
-msgid "Invalid email address when generating personal data export file."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:333
-msgid "Unable to create personal data export folder."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:341
-msgid "Unable to protect personal data export folder from browsing."
-msgstr ""
-
-#. translators: %s: User's email address.
-#: wp-admin/includes/privacy-tools.php:361
-msgid "Personal Data Export for %s"
-msgstr ""
-
-#. translators: Header for the About section in a personal data export.
-#: wp-admin/includes/privacy-tools.php:368
-msgctxt "personal data group label"
-msgid "About"
-msgstr ""
-
-#. translators: Description for the About section in a personal data export.
-#: wp-admin/includes/privacy-tools.php:370
-msgctxt "personal data group description"
-msgid "Overview of export report."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:374
-msgctxt "email address"
-msgid "Report generated for"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:378
-msgctxt "website name"
-msgid "For site"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:382
-msgctxt "website URL"
-msgid "At URL"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:386
-msgctxt "date/time"
-msgid "On"
-msgstr ""
-
-#. translators: %s: Post meta key.
-#: wp-admin/includes/privacy-tools.php:404
-msgid "The %s post meta must be an array."
-msgstr ""
-
-#. translators: %s: Error message.
-#: wp-admin/includes/privacy-tools.php:419
-msgid "Unable to encode the personal data for export. Error: %s"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:432
-msgid "Unable to open personal data export file (JSON report) for writing."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:447
-msgid "Unable to open personal data export (HTML report) for writing."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:467
-msgid "Personal Data Export"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:472
-#: wp-includes/class-wp-editor.php:1230
-msgid "Table of Contents"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:541
-msgid "Unable to archive the personal data export file (JSON format)."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:545
-msgid "Unable to archive the personal data export file (HTML format)."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:566
-msgid "Unable to open personal data export file (archive) for writing."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:593
-msgid "Invalid request ID when sending personal data export email."
-msgstr ""
-
-#. translators: Personal data export notification email subject. %s: Site title.
-#: wp-admin/includes/privacy-tools.php:636
-msgid "[%s] Personal Data Export"
-msgstr ""
-
-#. translators: Do not translate EXPIRATION, LINK, SITENAME, SITEURL: those are placeholders.
-#: wp-admin/includes/privacy-tools.php:662
-msgid ""
-"Howdy,\n"
-"\n"
-"Your request for an export of personal data has been completed. You may\n"
-"download your personal data by clicking on the link below. For privacy\n"
-"and security, we will automatically delete the file on ###EXPIRATION###,\n"
-"so please download it before then.\n"
-"\n"
-"###LINK###\n"
-"\n"
-"Regards,\n"
-"All at ###SITENAME###\n"
-"###SITEURL###"
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:746
-msgid "Unable to send personal data export email."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:793
-msgid "Invalid request ID when merging personal data to export."
-msgstr ""
-
-#: wp-admin/includes/privacy-tools.php:944
-msgid "Invalid request ID when processing personal data to erase."
-msgstr ""
-
-#: wp-admin/includes/revision.php:95
-msgid "Removed"
-msgstr ""
-
-#: wp-admin/includes/revision.php:96
-msgid "Added"
-msgstr ""
-
-#: wp-admin/includes/revision.php:247
-#: wp-admin/includes/revision.php:290
-msgid "M j, Y @ H:i"
-msgstr ""
-
-#: wp-admin/includes/revision.php:248
-#: wp-admin/includes/revision.php:291
-msgctxt "revision date short format"
-msgid "j M @ H:i"
-msgstr ""
-
-#: wp-admin/includes/revision.php:369
-msgctxt "Button label for a previous revision"
-msgid "Previous"
-msgstr ""
-
-#: wp-admin/includes/revision.php:373
-msgctxt "Button label for a next revision"
-msgid "Next"
-msgstr ""
-
-#: wp-admin/includes/revision.php:387
-msgid "Compare any two revisions"
-msgstr ""
-
-#: wp-admin/includes/revision.php:396
-msgctxt "Followed by post revision info"
-msgid "From:"
-msgstr ""
-
-#: wp-admin/includes/revision.php:398
-msgctxt "Followed by post revision info"
-msgid "To:"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/revision.php:408
-msgid "Autosave by %s"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/revision.php:418
-msgid "Current Revision by %s"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/includes/revision.php:428
-msgid "Revision by %s"
-msgstr ""
-
-#: wp-admin/includes/revision.php:446
-msgid "Restore This Autosave"
-msgstr ""
-
-#: wp-admin/includes/revision.php:448
-msgid "Restore This Revision"
-msgstr ""
-
-#: wp-admin/includes/revision.php:460
-msgid "Sorry, something went wrong. The requested comparison could not be loaded."
-msgstr ""
-
-#. translators: default GMT offset or timezone string. Must be either a valid offset (-12 to 14) or a valid timezone string (America/New_York). See https://www.php.net/manual/en/timezones.php for all timezone strings currently supported by PHP. Important: When a previous timezone string, like `Europe/Kiev`, has been superseded by an updated one, like `Europe/Kyiv`, as a rule of thumb, the **old** timezone name should be used in the "translation" to allow for the default timezone setting to be PHP cross-version compatible, as old timezone names will be recognized in new PHP versions, while new timezone names cannot be recognized in old PHP versions. To verify which timezone strings are available in the _oldest_ PHP version supported, you can use https://3v4l.org/6YQAt#v5.6.20 and replace the "BR" (Brazil) in the code line with the country code for which you want to look up the supported timezone names.
-#: wp-admin/includes/schema.php:403
-msgctxt "default GMT offset or timezone string"
-msgid "0"
-msgstr ""
-
-#: wp-admin/includes/schema.php:413
-msgid "My Site"
-msgstr ""
-
-#. translators: Default start of the week. 0 = Sunday, 1 = Monday.
-#: wp-admin/includes/schema.php:421
-msgctxt "start of week"
-msgid "1"
-msgstr ""
-
-#. translators: Links last updated date format, see https://www.php.net/manual/datetime.format.php
-#. translators: Localized date and time format, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/includes/schema.php:442
-#: wp-includes/class-wp-locale.php:399
-#: wp-includes/script-loader.php:162
-msgid "F j, Y g:i a"
-msgstr ""
-
-#: wp-admin/includes/schema.php:989
-msgid "You must provide a domain name."
-msgstr ""
-
-#: wp-admin/includes/schema.php:992
-msgid "You must provide a name for your network of sites."
-msgstr ""
-
-#: wp-admin/includes/schema.php:999
-#: wp-admin/includes/schema.php:1003
-msgid "The network already exists."
-msgstr ""
-
-#: wp-admin/includes/schema.php:1008
-msgid "You must provide a valid email address."
-msgstr ""
-
-#: wp-admin/includes/schema.php:1111
-msgid "Warning! Wildcard DNS may not be configured correctly!"
-msgstr ""
-
-#. translators: %s: Host name.
-#: wp-admin/includes/schema.php:1115
-msgid "The installer attempted to contact a random hostname (%s) on your domain."
-msgstr ""
-
-#. translators: %s: Error message.
-#: wp-admin/includes/schema.php:1120
-msgid "This resulted in an error message: %s"
-msgstr ""
-
-#. translators: %s: Asterisk symbol (*).
-#: wp-admin/includes/schema.php:1126
-msgid "To use a subdomain configuration, you must have a wildcard entry in your DNS. This usually means adding a %s hostname record pointing at your web server in your DNS configuration tool."
-msgstr ""
-
-#: wp-admin/includes/schema.php:1130
-msgid "You can still use your site but any subdomain you create may not be accessible. If you know your DNS is correct, ignore this message."
-msgstr ""
-
-#. translators: Do not translate USERNAME, SITE_NAME, BLOG_URL, PASSWORD: those are placeholders.
-#: wp-admin/includes/schema.php:1214
-#: wp-includes/ms-functions.php:1621
-msgid ""
-"Hello USERNAME,\n"
-"\n"
-"Your new SITE_NAME site has been successfully set up at:\n"
-"BLOG_URL\n"
-"\n"
-"You can log in to the administrator account with the following information:\n"
-"\n"
-"Username: USERNAME\n"
-"Password: PASSWORD\n"
-"Log in here: BLOG_URLwp-login.php\n"
-"\n"
-"We hope you enjoy your new site. Thanks!\n"
-"\n"
-"--The Team @ SITE_NAME"
-msgstr ""
-
-#: wp-admin/includes/schema.php:1265
-msgid "My Network"
-msgstr ""
-
-#. translators: %s: Site link.
-#. translators: First post content. %s: Site link.
-#: wp-admin/includes/schema.php:1278
-#: wp-admin/includes/upgrade.php:195
-msgid "Welcome to %s. This is your first post. Edit or delete it, then start writing!"
-msgstr ""
-
-#: wp-admin/includes/taxonomy.php:136
-msgid "You did not enter a category name."
-msgstr ""
-
-#: wp-admin/includes/template.php:461
-msgid "Reply to Comment"
-msgstr ""
-
-#: wp-admin/includes/template.php:462
-msgid "Add new Comment"
-msgstr ""
-
-#: wp-admin/includes/template.php:507
-msgid "Update Comment"
-msgstr ""
-
-#: wp-admin/includes/template.php:508
-msgid "Submit Reply"
-msgstr ""
-
-#. translators: %s: Comment author, filled by Ajax.
-#: wp-admin/includes/template.php:552
-msgid "Comment by %s moved to the Trash."
-msgstr ""
-
-#. translators: %s: Comment author, filled by Ajax.
-#: wp-admin/includes/template.php:561
-msgid "Comment by %s marked as spam."
-msgstr ""
-
-#: wp-admin/includes/template.php:583
-#: wp-admin/includes/template.php:598
-#: wp-admin/includes/template.php:736
-msgctxt "meta name"
-msgid "Name"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:584
-#: wp-admin/includes/template.php:599
-#: wp-admin/includes/template.php:669
-#: wp-admin/includes/template.php:737
-msgid "Value"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:656
-msgid "Key"
-msgstr ""
-
-#: wp-admin/includes/template.php:732
-msgid "Add New Custom Field:"
-msgstr ""
-
-#: wp-admin/includes/template.php:758
-msgid "Enter new"
-msgstr ""
-
-#: wp-admin/includes/template.php:771
-msgid "Add Custom Field"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:835
-#: wp-includes/customize/class-wp-customize-date-time-control.php:130
-msgid "Month"
-msgstr ""
-
-#. translators: 1: Month number (01, 02, etc.), 2: Month abbreviation.
-#: wp-admin/includes/template.php:842
-#: wp-includes/customize/class-wp-customize-date-time-control.php:204
-msgid "%1$s-%2$s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:848
-#: wp-includes/customize/class-wp-customize-date-time-control.php:146
-msgid "Day"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:852
-#: wp-includes/customize/class-wp-customize-date-time-control.php:151
-#: wp-includes/media.php:3004
-msgid "Year"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:856
-#: wp-includes/customize/class-wp-customize-date-time-control.php:162
-msgid "Hour"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:860
-#: wp-includes/customize/class-wp-customize-date-time-control.php:167
-msgid "Minute"
-msgstr ""
-
-#. translators: 1: Month, 2: Day, 3: Year, 4: Hour, 5: Minute.
-#: wp-admin/includes/template.php:865
-#: wp-admin/js/comment.js:89
-#: wp-admin/js/post.js:809
-msgid "%1$s %2$s, %3$s at %4$s:%5$s"
-msgstr ""
-
-#: wp-admin/includes/template.php:1013
-msgid "Before you can upload your import file, you will need to fix the following error:"
-msgstr ""
-
-#: wp-admin/includes/template.php:1023
-msgid "Choose a file from your computer:"
-msgstr ""
-
-#. translators: %s: Maximum allowed file size.
-#: wp-admin/includes/template.php:1025
-msgid "Maximum size: %s"
-msgstr ""
-
-#: wp-admin/includes/template.php:1032
-msgid "Upload file and import"
-msgstr ""
-
-#. translators: %s: Meta box title.
-#: wp-admin/includes/template.php:1315
-msgid "Move %s box up"
-msgstr ""
-
-#. translators: %s: Meta box title.
-#: wp-admin/includes/template.php:1328
-msgid "Move %s box down"
-msgstr ""
-
-#. translators: %s: misc
-#. translators: %s: privacy
-#: wp-admin/includes/template.php:1530
-#: wp-admin/includes/template.php:1543
-#: wp-admin/includes/template.php:1597
-#: wp-admin/includes/template.php:1610
-#: wp-includes/option.php:2448
-#: wp-includes/option.php:2461
-#: wp-includes/option.php:2521
-#: wp-includes/option.php:2534
-msgid "The \"%s\" options group has been removed. Use another settings group."
-msgstr ""
-
-#: wp-admin/includes/template.php:1909
-msgid "Attach to existing content"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/template.php:1913
-msgid "Close media attachment panel"
-msgstr ""
-
-#: wp-admin/includes/template.php:1938
-#: wp-admin/nav-menus.php:942
-#: wp-admin/plugin-editor.php:238
-#: wp-admin/theme-editor.php:244
-#: wp-includes/media.php:4579
-msgid "Select"
-msgstr ""
-
-#: wp-admin/includes/template.php:2171
-msgctxt "post status"
-msgid "Password protected"
-msgstr ""
-
-#: wp-admin/includes/template.php:2175
-#: wp-includes/post.php:342
-msgctxt "post status"
-msgid "Private"
-msgstr ""
-
-#: wp-admin/includes/template.php:2180
-msgid "Customization Draft"
-msgstr ""
-
-#: wp-admin/includes/template.php:2182
-#: wp-includes/post.php:312
-msgctxt "post status"
-msgid "Draft"
-msgstr ""
-
-#: wp-admin/includes/template.php:2185
-msgctxt "post status"
-msgid "Customization Draft"
-msgstr ""
-
-#: wp-admin/includes/template.php:2189
-#: wp-includes/post.php:327
-msgctxt "post status"
-msgid "Pending"
-msgstr ""
-
-#: wp-admin/includes/template.php:2193
-msgctxt "post status"
-msgid "Sticky"
-msgstr ""
-
-#: wp-admin/includes/template.php:2197
-#: wp-includes/post.php:298
-msgctxt "post status"
-msgid "Scheduled"
-msgstr ""
-
-#: wp-admin/includes/template.php:2202
-msgctxt "page label"
-msgid "Front Page"
-msgstr ""
-
-#: wp-admin/includes/template.php:2206
-msgctxt "page label"
-msgid "Posts Page"
-msgstr ""
-
-#: wp-admin/includes/template.php:2211
-msgctxt "page label"
-msgid "Privacy Policy Page"
-msgstr ""
-
-#: wp-admin/includes/template.php:2302
-msgid "Current Header Image"
-msgstr ""
-
-#: wp-admin/includes/template.php:2309
-msgid "Current Header Video"
-msgstr ""
-
-#: wp-admin/includes/template.php:2322
-msgid "Current Background Image"
-msgstr ""
-
-#: wp-admin/includes/template.php:2328
-#: wp-admin/options-general.php:89
-#: wp-includes/class-wp-customize-manager.php:5192
-msgid "Site Icon"
-msgstr ""
-
-#: wp-admin/includes/template.php:2332
-#: wp-includes/class-wp-customize-manager.php:5220
-msgid "Logo"
-msgstr ""
-
-#. translators: 1: wp-admin/includes/template.php, 2: add_meta_box(), 3: add_meta_boxes
-#: wp-admin/includes/template.php:2557
-msgid "Likely direct inclusion of %1$s in order to use %2$s. This is very wrong. Hook the %2$s call into the %3$s action instead."
-msgstr ""
-
-#: wp-admin/includes/template.php:2583
-msgid "The backup of this post in your browser is different from the version below."
-msgstr ""
-
-#: wp-admin/includes/template.php:2584
-msgid "Restore the backup"
-msgstr ""
-
-#: wp-admin/includes/template.php:2587
-msgid "This will replace the current editor content with the last backup version. You can use undo and redo in the editor to get the old content back or to return to the restored version."
-msgstr ""
-
-#. translators: Hidden accessibility text. 1: The rating, 2: The number of ratings.
-#: wp-admin/includes/template.php:2640
-msgid "%1$s rating based on %2$s rating"
-msgid_plural "%1$s rating based on %2$s ratings"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: Hidden accessibility text. %s: The rating.
-#: wp-admin/includes/template.php:2644
-msgid "%s rating"
-msgstr ""
-
-#: wp-admin/includes/template.php:2670
-msgid "You are currently editing the page that shows your latest posts."
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:95
-msgid "Search for themes by keyword."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme-install.php:104
-msgid "Type of search"
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:110
-msgctxt "Theme Installer"
-msgid "Tag"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme-install.php:117
-#: wp-admin/includes/theme-install.php:134
-msgid "Search by keyword"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme-install.php:121
-msgid "Search by author"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme-install.php:125
-msgid "Search by tag"
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:152
-#: wp-admin/theme-install.php:198
-msgid "Feature Filter"
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:153
-msgid "Find a theme based on specific features."
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:185
-msgid "Find Themes"
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:197
-msgid "If you have a theme in a .zip format, you may install or update it by uploading it here."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme-install.php:203
-msgid "Theme zip file"
-msgstr ""
-
-#: wp-admin/includes/theme-install.php:264
-msgid "Theme Installation"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:102
-msgid "Could not fully remove the theme %s."
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number.
-#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number.
-#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number.
-#: wp-admin/includes/theme.php:223
-#: wp-admin/includes/update.php:488
-#: wp-admin/includes/update.php:679
-msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>."
-msgstr ""
-
-#. translators: 1: Theme name, 2: Version number.
-#. translators: 1: Plugin name, 2: Version number.
-#: wp-admin/includes/theme.php:229
-#: wp-admin/includes/theme.php:242
-#: wp-admin/includes/theme.php:255
-#: wp-admin/includes/update.php:494
-#: wp-admin/includes/update.php:507
-#: wp-admin/includes/update.php:521
-#: wp-admin/includes/update.php:540
-#: wp-admin/includes/update.php:685
-#: wp-admin/includes/update.php:698
-#: wp-admin/includes/update.php:711
-#: wp-admin/update-core.php:417
-msgid "View %1$s version %2$s details"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number.
-#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number.
-#: wp-admin/includes/theme.php:236
-#: wp-admin/includes/update.php:692
-msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this theme.</em>"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
-#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
-#. translators: 1: Theme name, 2: Details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes.
-#: wp-admin/includes/theme.php:249
-#: wp-admin/includes/update.php:515
-#: wp-admin/includes/update.php:705
-msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a> or <a href=\"%5$s\" %6$s>update now</a>."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:262
-#: wp-admin/includes/update.php:718
-msgctxt "theme"
-msgid "Update %s now"
-msgstr ""
-
-#: wp-admin/includes/theme.php:306
-#: wp-admin/includes/theme.php:371
-msgid "Subject"
-msgstr ""
-
-#: wp-admin/includes/theme.php:307
-msgid "Blog"
-msgstr ""
-
-#: wp-admin/includes/theme.php:308
-msgid "E-Commerce"
-msgstr ""
-
-#: wp-admin/includes/theme.php:309
-msgid "Education"
-msgstr ""
-
-#: wp-admin/includes/theme.php:310
-msgid "Entertainment"
-msgstr ""
-
-#: wp-admin/includes/theme.php:311
-msgid "Food & Drink"
-msgstr ""
-
-#: wp-admin/includes/theme.php:312
-msgid "Holiday"
-msgstr ""
-
-#: wp-admin/includes/theme.php:313
-msgid "News"
-msgstr ""
-
-#: wp-admin/includes/theme.php:314
-msgid "Photography"
-msgstr ""
-
-#: wp-admin/includes/theme.php:315
-msgid "Portfolio"
-msgstr ""
-
-#: wp-admin/includes/theme.php:318
-#: wp-admin/includes/theme.php:370
-msgid "Features"
-msgstr ""
-
-#: wp-admin/includes/theme.php:319
-msgid "Accessibility Ready"
-msgstr ""
-
-#: wp-admin/includes/theme.php:321
-msgid "Custom Colors"
-msgstr ""
-
-#: wp-admin/includes/theme.php:323
-msgid "Custom Logo"
-msgstr ""
-
-#: wp-admin/includes/theme.php:324
-msgid "Editor Style"
-msgstr ""
-
-#: wp-admin/includes/theme.php:325
-msgid "Featured Image Header"
-msgstr ""
-
-#: wp-admin/includes/theme.php:326
-msgid "Featured Images"
-msgstr ""
-
-#: wp-admin/includes/theme.php:327
-msgid "Footer Widgets"
-msgstr ""
-
-#: wp-admin/includes/theme.php:328
-msgid "Full Width Template"
-msgstr ""
-
-#: wp-admin/includes/theme.php:330
-msgid "Sticky Post"
-msgstr ""
-
-#: wp-admin/includes/theme.php:331
-msgid "Theme Options"
-msgstr ""
-
-#: wp-admin/includes/theme.php:335
-msgid "Grid Layout"
-msgstr ""
-
-#: wp-admin/includes/theme.php:336
-msgid "One Column"
-msgstr ""
-
-#: wp-admin/includes/theme.php:337
-msgid "Two Columns"
-msgstr ""
-
-#: wp-admin/includes/theme.php:338
-msgid "Three Columns"
-msgstr ""
-
-#: wp-admin/includes/theme.php:339
-msgid "Four Columns"
-msgstr ""
-
-#: wp-admin/includes/theme.php:340
-msgid "Left Sidebar"
-msgstr ""
-
-#: wp-admin/includes/theme.php:341
-msgid "Right Sidebar"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme.php:790
-#: wp-admin/themes.php:944
-msgid "Show previous theme"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme.php:796
-#: wp-admin/themes.php:950
-msgid "Show next theme"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/includes/theme.php:802
-#: wp-admin/themes.php:956
-msgid "Close details dialog"
-msgstr ""
-
-#. translators: %s: Theme version.
-#: wp-admin/includes/theme.php:822
-#: wp-admin/theme-install.php:490
-#: wp-admin/themes.php:976
-msgid "Version: %s"
-msgstr ""
-
-#. translators: %s: Number of ratings.
-#: wp-admin/includes/theme.php:840
-#: wp-admin/theme-install.php:479
-msgid "(%s ratings)"
-msgstr ""
-
-#: wp-admin/includes/theme.php:852
-#: wp-admin/themes.php:1044
-msgid "Update Available"
-msgstr ""
-
-#: wp-admin/includes/theme.php:857
-#: wp-admin/themes.php:1049
-msgid "Update Incompatible"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:863
-#: wp-admin/includes/update.php:726
-#: wp-admin/themes.php:412
-#: wp-admin/themes.php:763
-#: wp-admin/themes.php:1055
-#: wp-includes/customize/class-wp-customize-theme-control.php:116
-msgid "There is a new version of %s available, but it does not work with your versions of ClassicPress and PHP."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:893
-#: wp-admin/includes/update.php:754
-#: wp-admin/themes.php:440
-#: wp-admin/themes.php:793
-#: wp-admin/themes.php:1085
-#: wp-includes/customize/class-wp-customize-theme-control.php:146
-msgid "There is a new version of %s available, but it does not work with your version of ClassicPress."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:908
-#: wp-admin/includes/update.php:767
-#: wp-admin/themes.php:453
-#: wp-admin/themes.php:808
-#: wp-admin/themes.php:1100
-#: wp-includes/customize/class-wp-customize-theme-control.php:161
-msgid "There is a new version of %s available, but it does not work with your version of PHP."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:931
-#: wp-admin/themes.php:1128
-msgid "This is a child theme of %s."
-msgstr ""
-
-#: wp-admin/includes/theme.php:942
-#: wp-admin/theme-install.php:293
-#: wp-admin/theme-install.php:498
-#: wp-admin/themes.php:474
-#: wp-admin/themes.php:829
-#: wp-admin/themes.php:990
-#: wp-includes/customize/class-wp-customize-theme-control.php:183
-msgid "This theme does not work with your versions of ClassicPress and PHP."
-msgstr ""
-
-#: wp-admin/includes/theme.php:968
-#: wp-admin/theme-install.php:323
-#: wp-admin/theme-install.php:528
-#: wp-admin/themes.php:498
-#: wp-admin/themes.php:855
-#: wp-admin/themes.php:1016
-#: wp-includes/customize/class-wp-customize-theme-control.php:213
-msgid "This theme does not work with your version of ClassicPress."
-msgstr ""
-
-#: wp-admin/includes/theme.php:979
-#: wp-admin/theme-install.php:334
-#: wp-admin/theme-install.php:539
-#: wp-admin/themes.php:507
-#: wp-admin/themes.php:866
-#: wp-admin/themes.php:1027
-#: wp-includes/customize/class-wp-customize-theme-control.php:224
-msgid "This theme does not work with your version of PHP."
-msgstr ""
-
-#: wp-admin/includes/theme.php:994
-#: wp-includes/customize/class-wp-customize-theme-control.php:264
-msgid "This theme doesn't support Customizer."
-msgstr ""
-
-#. translators: %s: URL to the themes page (also it activates the theme).
-#: wp-admin/includes/theme.php:1000
-#: wp-includes/customize/class-wp-customize-theme-control.php:271
-msgid "However, you can still <a href=\"%s\">activate this theme</a>, and use the Site Editor to customize it."
-msgstr ""
-
-#: wp-admin/includes/theme.php:1011
-#: wp-admin/themes.php:1134
-msgid "Tags:"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/theme.php:1029
-#: wp-admin/theme-install.php:364
-#: wp-admin/theme-install.php:440
-#: wp-admin/themes.php:554
-#: wp-admin/themes.php:914
-#: wp-admin/themes.php:1148
-#: wp-includes/customize/class-wp-customize-theme-control.php:256
-#: wp-admin/js/updates.js:1415
-msgctxt "theme"
-msgid "Activate %s"
-msgstr ""
-
-#: wp-admin/includes/theme.php:1044
-#: wp-admin/includes/theme.php:1047
-#: wp-includes/customize/class-wp-customize-theme-control.php:295
-#: wp-includes/customize/class-wp-customize-theme-control.php:297
-msgid "Install &amp; Preview"
-msgstr ""
-
-#: wp-admin/includes/theme.php:1046
-#: wp-admin/theme-install.php:407
-#: wp-admin/theme-install.php:454
-msgctxt "theme"
-msgid "Cannot Install"
-msgstr ""
-
-#: wp-admin/includes/theme.php:1159
-msgid "Could not resume the theme."
-msgstr ""
-
-#: wp-admin/includes/theme.php:1188
-msgid "One or more themes failed to load properly."
-msgstr ""
-
-#: wp-admin/includes/theme.php:1189
-msgid "You can find more details and make changes on the Themes screen."
-msgstr ""
-
-#: wp-admin/includes/theme.php:1191
-msgid "Go to the Themes screen"
-msgstr ""
-
-#: wp-admin/includes/translation-install.php:24
-msgid "Invalid translation type."
-msgstr ""
-
-#: wp-admin/includes/translation-install.php:71
-#: wp-admin/includes/update-core.php:1043
-#: wp-admin/includes/update.php:139
-#: wp-includes/update.php:160
-msgid "(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)"
-msgstr ""
-
-#: wp-admin/includes/update-core.php:290
-msgid "Verifying the unpacked files&#8230;"
-msgstr ""
-
-#: wp-admin/includes/update-core.php:297
-msgid "The update could not be unpacked"
-msgstr ""
-
-#. translators: 1: WordPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number.
-#: wp-admin/includes/update-core.php:375
-msgid "The update cannot be installed because ClassicPress %1$s requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s."
-msgstr ""
-
-#. translators: 1: WordPress version number, 2: Minimum required PHP version number, 3: Current PHP version number.
-#: wp-admin/includes/update-core.php:388
-msgid "The update cannot be installed because ClassicPress %1$s requires PHP version %2$s or higher. You are running version %3$s."
-msgstr ""
-
-#. translators: 1: WordPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number.
-#: wp-admin/includes/update-core.php:399
-msgid "The update cannot be installed because ClassicPress %1$s requires MySQL version %2$s or higher. You are running version %3$s."
-msgstr ""
-
-#. translators: 1: WordPress version number, 2: The PHP extension name needed.
-#: wp-admin/includes/update-core.php:413
-msgid "The update cannot be installed because ClassicPress %1$s requires the %2$s PHP extension."
-msgstr ""
-
-#: wp-admin/includes/update-core.php:421
-msgid "Preparing to install the latest version&#8230;"
-msgstr ""
-
-#: wp-admin/includes/update-core.php:497
-#: wp-admin/includes/update-core.php:533
-msgid "The update cannot be installed because your site is unable to copy some files. This is usually due to inconsistent file permissions."
-msgstr ""
-
-#: wp-admin/includes/update-core.php:514
-msgid "Copying the required files&#8230;"
-msgstr ""
-
-#: wp-admin/includes/update-core.php:598
-msgid "There is not enough free disk space to complete the update."
-msgstr ""
-
-#: wp-admin/includes/update-core.php:757
-msgid "Upgrading database&#8230;"
-msgstr ""
-
-#: wp-admin/includes/update-core.php:884
-#: wp-admin/update-core.php:786
-msgid "ClassicPress updated successfully"
-msgstr ""
-
-#. translators: 1: ClassicPress version, 2: URL to About screen.
-#: wp-admin/includes/update-core.php:890
-#: wp-admin/update-core.php:787
-msgid "Welcome to ClassicPress %1$s. You will be redirected to the About ClassicPress screen. If not, click <a href=\"%2$s\">here</a>."
-msgstr ""
-
-#. translators: 1: ClassicPress version, 2: URL to About screen.
-#: wp-admin/includes/update-core.php:898
-#: wp-admin/update-core.php:788
-msgid "Welcome to ClassicPress %1$s. <a href=\"%2$s\">Learn more</a>."
-msgstr ""
-
-#. translators: %s: support forums URL
-#. translators: %s: Support forums URL.
-#: wp-admin/includes/update-core.php:1041
-#: wp-admin/includes/update.php:137
-#: wp-includes/update.php:666
-msgid "An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: ClassicPress updates admin screen URL
-#: wp-admin/includes/update.php:251
-msgid "You are using a development version (%1$s). Cool! Please <a href=\"%2$s\">stay updated</a>."
-msgstr ""
-
-#. translators: %s: WordPress version.
-#: wp-admin/includes/update.php:258
-msgid "Get Version %s"
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/includes/update.php:295
-msgid "https://www.classicpress.net/version/%s"
-msgstr ""
-
-#. translators: 1: URL to ClassicPress release notes, 2: New ClassicPress version, 3: URL to network admin, 4: Accessibility text.
-#: wp-admin/includes/update.php:302
-msgid "<a href=\"%1$s\">ClassicPress %2$s</a> is available! <a href=\"%3$s\" aria-label=\"%4$s\">Please update now</a>."
-msgstr ""
-
-#: wp-admin/includes/update.php:306
-msgid "Please update ClassicPress now"
-msgstr ""
-
-#. translators: 1: URL to ClassicPress release notes, 2: New ClassicPress version.
-#: wp-admin/includes/update.php:311
-msgid "<a href=\"%1$s\">ClassicPress %2$s</a> is available! Please notify the site administrator."
-msgstr ""
-
-#. translators: %s: WordPress version number, or 'Latest' string.
-#: wp-admin/includes/update.php:341
-msgid "Update to %s"
-msgstr ""
-
-#. translators: %s: WordPress version number, or 'Latest' string.
-#: wp-admin/includes/update.php:341
-msgid "Latest"
-msgstr ""
-
-#. translators: 1: Version number, 2: Theme name.
-#: wp-admin/includes/update.php:347
-msgid "ClassicPress %1$s running %2$s theme."
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number.
-#: wp-admin/includes/update.php:501
-msgid "There is a new version of %1$s available. <a href=\"%2$s\" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this plugin.</em>"
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number 5: URL to Update PHP page.
-#: wp-admin/includes/update.php:534
-msgid "There is a new version of %1$s available, but it does not work with your version of PHP. <a href=\"%2$s\" %3$s>View version %4$s details</a> or <a href=\"%5$s\">learn more about updating PHP</a>."
-msgstr ""
-
-#. translators: %s: URL to WordPress Updates screen.
-#: wp-admin/includes/update.php:842
-msgid "An automated ClassicPress update has failed to complete - <a href=\"%s\">please attempt the update again now</a>."
-msgstr ""
-
-#: wp-admin/includes/update.php:846
-msgid "An automated ClassicPress update has failed to complete! Please notify the site administrator."
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/update.php:881
-msgid "%s plugin successfully updated."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/update.php:886
-msgid "%s theme successfully updated."
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/includes/update.php:893
-msgid "%s plugins successfully updated."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/includes/update.php:898
-msgid "%s themes successfully updated."
-msgstr ""
-
-#. translators: %s: Number of failed updates.
-#: wp-admin/includes/update.php:908
-msgid "%s update failed."
-msgstr ""
-
-#. translators: %s: Number of failed updates.
-#: wp-admin/includes/update.php:913
-msgid "%s updates failed."
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/includes/update.php:981
-msgctxt "plugin"
-msgid "%s was successfully deleted."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/includes/update.php:989
-msgctxt "theme"
-msgid "%s was successfully deleted."
-msgstr ""
-
-#. translators: %s: Recovery Mode exit link.
-#: wp-admin/includes/update.php:1020
-msgid "You are in recovery mode. This means there may be an error with a theme or plugin. To exit recovery mode, log out or use the Exit button. <a href=\"%s\">Exit Recovery Mode</a>"
-msgstr ""
-
-#: wp-admin/includes/update.php:1097
-msgid "Automatic update not scheduled. There may be a problem with WP-Cron."
-msgstr ""
-
-#. translators: %s: Duration that WP-Cron has been overdue.
-#: wp-admin/includes/update.php:1107
-msgid "Automatic update overdue by %s. There may be a problem with WP-Cron."
-msgstr ""
-
-#. translators: %s: Time until the next update.
-#: wp-admin/includes/update.php:1113
-msgid "Automatic update scheduled in %s."
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:89
-msgid "<strong><em>Note that password</em></strong> carefully! It is a <em>random</em> password that was generated just for you."
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:96
-msgid "Your chosen password."
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:100
-msgid "User already exists. Password inherited."
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:117
-msgid "The password you chose during installation."
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:158
-#: wp-includes/category-template.php:162
-msgid "Uncategorized"
-msgstr ""
-
-#. translators: Default category slug.
-#: wp-admin/includes/upgrade.php:160
-msgctxt "Default category slug"
-msgid "Uncategorized"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:207
-msgid "Welcome to ClassicPress. This is your first post. Edit or delete it, then start writing!"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:218
-msgid "Hello world!"
-msgstr ""
-
-#. translators: Default post slug.
-#: wp-admin/includes/upgrade.php:220
-#: wp-admin/includes/upgrade.php:525
-msgctxt "Default post slug"
-msgid "hello-world"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:251
-msgid "A ClassicPress Commenter"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:254
-msgid ""
-"Hi, this is a comment.\n"
-"To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard."
-msgstr ""
-
-#. translators: First page content.
-#: wp-admin/includes/upgrade.php:279
-msgid "This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:"
-msgstr ""
-
-#. translators: First page content.
-#: wp-admin/includes/upgrade.php:281
-msgid "Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)"
-msgstr ""
-
-#. translators: First page content.
-#: wp-admin/includes/upgrade.php:283
-msgid "...or something like this:"
-msgstr ""
-
-#. translators: First page content.
-#: wp-admin/includes/upgrade.php:285
-msgid "The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community."
-msgstr ""
-
-#. translators: First page content. %s: Site admin URL.
-#: wp-admin/includes/upgrade.php:288
-msgid "As a new ClassicPress user, you should go to <a href=\"%s\">your dashboard</a> to delete this page and create new pages for your content. Have fun!"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:303
-msgid "Sample Page"
-msgstr ""
-
-#. translators: Default page slug.
-#: wp-admin/includes/upgrade.php:305
-msgid "sample-page"
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:348
-#: wp-admin/options-privacy.php:90
-#: wp-admin/privacy.php:63
-msgid "Privacy Policy"
-msgstr ""
-
-#. translators: Privacy Policy page slug.
-#: wp-admin/includes/upgrade.php:350
-msgid "privacy-policy"
-msgstr ""
-
-#. translators: New site notification email. 1: New site URL, 2: User login, 3: User password or password reset link, 4: Login URL.
-#: wp-admin/includes/upgrade.php:579
-msgid ""
-"Your new ClassicPress site has been successfully set up at:\n"
-"\n"
-"%1$s\n"
-"\n"
-"You can log in to the administrator account with the following information:\n"
-"\n"
-"Username: %2$s\n"
-"Password: %3$s\n"
-"Log in here: %4$s\n"
-"\n"
-"We hope you enjoy your new site. Thanks!\n"
-"\n"
-"--The ClassicPress Team\n"
-"https://www.classicpress.net/\n"
-""
-msgstr ""
-
-#: wp-admin/includes/upgrade.php:604
-msgid "New ClassicPress Site"
-msgstr ""
-
-#: wp-admin/includes/user.php:62
-#: wp-admin/network/site-users.php:146
-#: wp-admin/users.php:131
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1228
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1242
-msgid "Sorry, you are not allowed to give users that role."
-msgstr ""
-
-#: wp-admin/includes/user.php:152
-#: wp-includes/user.php:3337
-msgid "<strong>Error:</strong> Please enter a username."
-msgstr ""
-
-#: wp-admin/includes/user.php:157
-msgid "<strong>Error:</strong> Please enter a nickname."
-msgstr ""
-
-#: wp-admin/includes/user.php:173
-msgid "<strong>Error:</strong> Please enter a password."
-msgstr ""
-
-#: wp-admin/includes/user.php:178
-msgid "<strong>Error:</strong> Passwords may not contain the character \"\\\"."
-msgstr ""
-
-#: wp-admin/includes/user.php:183
-msgid "<strong>Error:</strong> Passwords do not match. Please enter the same password in both password fields."
-msgstr ""
-
-#: wp-admin/includes/user.php:191
-#: wp-includes/user.php:3339
-msgid "<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username."
-msgstr ""
-
-#: wp-admin/includes/user.php:195
-#: wp-includes/user.php:3342
-msgid "<strong>Error:</strong> This username is already registered. Please choose another one."
-msgstr ""
-
-#: wp-admin/includes/user.php:202
-#: wp-includes/user.php:3347
-msgid "<strong>Error:</strong> Sorry, that username is not allowed."
-msgstr ""
-
-#: wp-admin/includes/user.php:207
-msgid "<strong>Error:</strong> Please enter an email address."
-msgstr ""
-
-#: wp-admin/includes/user.php:209
-#: wp-includes/user.php:3355
-#: wp-includes/user.php:3655
-msgid "<strong>Error:</strong> The email address is not correct."
-msgstr ""
-
-#: wp-admin/includes/user.php:213
-msgid "<strong>Error:</strong> This email is already registered. Please choose another one."
-msgstr ""
-
-#: wp-admin/includes/user.php:531
-msgid "Notice:"
-msgstr ""
-
-#: wp-admin/includes/user.php:532
-msgid "You&rsquo;re using the auto-generated password for your account. Would you like to change it?"
-msgstr ""
-
-#: wp-admin/includes/user.php:534
-msgid "Yes, take me to my profile page"
-msgstr ""
-
-#: wp-admin/includes/user.php:535
-msgid "No thanks, do not remind me again"
-msgstr ""
-
-#: wp-admin/includes/user.php:571
-msgid "Use https"
-msgstr ""
-
-#: wp-admin/includes/user.php:572
-msgid "Always use https when visiting the admin"
-msgstr ""
-
-#. translators: 1: Site title, 2: Site URL, 3: User role.
-#: wp-admin/includes/user.php:595
-msgid ""
-"Hi,\n"
-"You've been invited to join '%1$s' at\n"
-"%2$s with the role of %3$s.\n"
-"If you do not want to join this site please ignore\n"
-"this email. This invitation will expire in a few days.\n"
-"\n"
-"Please click the following link to activate your user account:\n"
-"%%s"
-msgstr ""
-
-#: wp-admin/includes/user.php:655
-msgid "The application ID must be a UUID."
-msgstr ""
-
-#: wp-admin/includes/user.php:697
-#: wp-admin/includes/user.php:719
-msgid "Invalid URL format."
-msgstr ""
-
-#: wp-admin/includes/user.php:726
-msgid "The URL must be served over a secure connection."
-msgstr ""
-
-#: wp-admin/includes/widgets.php:239
-msgctxt "widget"
-msgid "Edit"
-msgstr ""
-
-#: wp-admin/includes/widgets.php:240
-msgctxt "widget"
-msgid "Add"
-msgstr ""
-
-#: wp-admin/includes/widgets.php:252
-#: wp-admin/widgets-form.php:292
-#: wp-includes/class-wp-widget.php:144
-msgid "There are no options for this widget."
-msgstr ""
-
-#: wp-admin/includes/widgets.php:273
-#: wp-includes/customize/class-wp-customize-nav-menu-control.php:57
-#: wp-includes/customize/class-wp-widget-area-customize-control.php:61
-#: wp-admin/js/set-post-thumbnail.js:21
-msgid "Done"
-msgstr ""
-
-#: wp-admin/index.php:36
-msgid "Welcome to your ClassicPress Dashboard!"
-msgstr ""
-
-#: wp-admin/index.php:37
-msgid "The Dashboard is the first place you will come to every time you log into your site. It is where you access to all the site management features of ClassicPress. You can get help for any screen by clicking the Help tab above the screen title."
-msgstr ""
-
-#: wp-admin/index.php:51
-msgid "The left-hand navigation menu provides links to all of the ClassicPress administration screens, with submenu items displayed on hover. You can minimize this menu to a narrow icon strip by clicking on the Collapse Menu arrow at the bottom."
-msgstr ""
-
-#: wp-admin/index.php:52
-msgid "Links in the Toolbar at the top of the screen connect your dashboard and the front end of your site, and provide access to your profile and helpful ClassicPress information."
-msgstr ""
-
-#: wp-admin/index.php:57
-msgid "Navigation"
-msgstr ""
-
-#: wp-admin/index.php:62
-msgid "You can use the following controls to arrange your Dashboard screen to suit your workflow. This is true on most other administration screens as well."
-msgstr ""
-
-#: wp-admin/index.php:63
-msgid "<strong>Screen Options</strong> &mdash; Use the Screen Options tab to choose which Dashboard boxes to show."
-msgstr ""
-
-#: wp-admin/index.php:64
-msgid "<strong>Drag and Drop</strong> &mdash; To rearrange the boxes, drag and drop by clicking on the title bar of the selected box and releasing when you see a gray dotted-line rectangle appear in the location you want to place the box."
-msgstr ""
-
-#: wp-admin/index.php:65
-msgid "<strong>Box Controls</strong> &mdash; Click the title bar of the box to expand or collapse it. Some boxes added by plugins may have configurable content, and will show a &#8220;Configure&#8221; link in the title bar if you hover over it."
-msgstr ""
-
-#: wp-admin/index.php:75
-msgid "The boxes on your Dashboard screen are:"
-msgstr ""
-
-#: wp-admin/index.php:78
-msgid "<strong>Welcome</strong> &mdash; Shows links for some of the most common tasks when setting up a new site."
-msgstr ""
-
-#: wp-admin/index.php:82
-msgid "<strong>Site Health Status</strong> &mdash; Informs you of any potential issues that should be addressed to improve the performance or security of your website."
-msgstr ""
-
-#: wp-admin/index.php:86
-msgid "<strong>At a Glance</strong> &mdash; Displays a summary of the content on your site and identifies which theme and version of ClassicPress you are using."
-msgstr ""
-
-#: wp-admin/index.php:89
-msgid "<strong>Activity</strong> &mdash; Shows the upcoming scheduled posts, recently published posts, and the most recent comments on your posts and allows you to moderate them."
-msgstr ""
-
-#: wp-admin/index.php:92
-msgid "<strong>Quick Draft</strong> &mdash; Allows you to create a new post and save it as a draft. Also displays links to the 3 most recent draft posts you've started."
-msgstr ""
-
-#. translators: %s: ClassicPress Planet URL.
-#: wp-admin/index.php:97
-msgid "<strong>ClassicPress News</strong> &mdash; Latest news from the official <a href=\"%s\">ClassicPress blog</a>."
-msgstr ""
-
-#: wp-admin/index.php:113
-msgid "<a href=\"https://wordpress.org/support/article/dashboard-screen/\">Documentation on Dashboard</a>"
-msgstr ""
-
-#. translators: %s: Human-readable time interval.
-#: wp-admin/index.php:143
-msgid "The admin email verification page will reappear after %s."
-msgstr ""
-
-#: wp-admin/index.php:166
-msgid "Dismiss the welcome panel"
-msgstr ""
-
-#: wp-admin/install.php:73
-msgid "ClassicPress &rsaquo; Installation"
-msgstr ""
-
-#: wp-admin/install.php:108
-msgctxt "Howdy"
-msgid "Welcome"
-msgstr ""
-
-#: wp-admin/install.php:114
-#: wp-admin/network/site-new.php:227
-#: wp-admin/options-general.php:69
-#: wp-includes/class-wp-customize-manager.php:5134
-#: wp-includes/class-wp-xmlrpc-server.php:589
-msgid "Site Title"
-msgstr ""
-
-#: wp-admin/install.php:122
-msgid "User(s) already exists."
-msgstr ""
-
-#: wp-admin/install.php:127
-msgid "Usernames can have only alphanumeric characters, spaces, underscores, hyphens, periods, and the @ symbol."
-msgstr ""
-
-#: wp-admin/install.php:144
-#: wp-admin/user-edit.php:699
-#: wp-admin/user-new.php:594
-#: wp-login.php:963
-#: wp-admin/js/user-profile.js:81
-msgid "Hide password"
-msgstr ""
-
-#: wp-admin/install.php:151
-#: wp-admin/user-edit.php:204
-msgid "Important:"
-msgstr ""
-
-#. translators: The non-breaking space prevents 1Password from thinking the text "log in" should trigger a password save prompt.
-#: wp-admin/install.php:153
-msgid "You will need this password to log&nbsp;in. Please store it in a secure location."
-msgstr ""
-
-#: wp-admin/install.php:158
-#: wp-admin/user-new.php:603
-msgid "Repeat Password"
-msgstr ""
-
-#: wp-admin/install.php:159
-#: wp-admin/user-edit.php:485
-#: wp-admin/user-edit.php:533
-#: wp-admin/user-new.php:532
-#: wp-admin/user-new.php:536
-#: wp-admin/user-new.php:583
-#: wp-admin/user-new.php:603
-msgid "(required)"
-msgstr ""
-
-#: wp-admin/install.php:167
-#: wp-admin/user-edit.php:723
-#: wp-admin/user-new.php:610
-msgid "Confirm Password"
-msgstr ""
-
-#: wp-admin/install.php:171
-#: wp-admin/user-edit.php:727
-#: wp-admin/user-new.php:614
-#: wp-login.php:970
-#: wp-admin/js/user-profile.js:52
-msgid "Confirm use of weak password"
-msgstr ""
-
-#: wp-admin/install.php:177
-msgid "Your Email"
-msgstr ""
-
-#: wp-admin/install.php:179
-msgid "Double-check your email address before continuing."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/install.php:182
-#: wp-admin/install.php:189
-#: wp-admin/options-reading.php:44
-#: wp-admin/options-reading.php:192
-#: wp-admin/options-reading.php:198
-msgid "Site visibility"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/install.php:182
-#: wp-admin/install.php:191
-#: wp-admin/options-reading.php:44
-#: wp-admin/options-reading.php:192
-#: wp-admin/options-reading.php:200
-msgid "Search engine visibility"
-msgstr ""
-
-#: wp-admin/install.php:198
-#: wp-admin/options-reading.php:205
-msgid "Allow search engines to index this site"
-msgstr ""
-
-#: wp-admin/install.php:200
-#: wp-admin/install.php:208
-#: wp-admin/options-reading.php:207
-#: wp-admin/options-reading.php:228
-msgid "Discourage search engines from indexing this site"
-msgstr ""
-
-#: wp-admin/install.php:201
-#: wp-admin/options-reading.php:208
-msgid "Note: Neither of these options blocks access to your site &mdash; it is up to search engines to honor your request."
-msgstr ""
-
-#: wp-admin/install.php:209
-#: wp-admin/options-reading.php:229
-msgid "It is up to search engines to honor this request."
-msgstr ""
-
-#: wp-admin/install.php:215
-msgid "Install ClassicPress"
-msgstr ""
-
-#: wp-admin/install.php:225
-#: wp-includes/ms-deprecated.php:619
-msgid "Already Installed"
-msgstr ""
-
-#: wp-admin/install.php:226
-#: wp-includes/ms-deprecated.php:619
-msgid "You appear to have already installed ClassicPress. To reinstall please clear your old database tables first."
-msgstr ""
-
-#. translators: 1: URL to ClassicPress release notes, 2: ClassicPress version number, 3: Minimum required PHP version number, 4: Minimum required MySQL version number, 5: Current PHP version number, 6: Current MySQL version number.
-#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number
-#. translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number
-#: wp-admin/install.php:266
-#: wp-admin/install.php:276
-#: wp-admin/install.php:284
-msgid "<a href=\""
-msgstr ""
-
-#: wp-admin/install.php:293
-#: wp-includes/load.php:190
-msgid "Requirements Not Met"
-msgstr ""
-
-#: wp-admin/install.php:299
-#: wp-admin/install.php:312
-msgid "Configuration Error"
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/install.php:302
-msgid "Your %s file has an empty database table prefix, which is not supported."
-msgstr ""
-
-#. translators: %s: DO_NOT_UPGRADE_GLOBAL_TABLES
-#: wp-admin/install.php:315
-msgid "The constant %s cannot be defined when installing ClassicPress."
-msgstr ""
-
-#: wp-admin/install.php:363
-msgid "Admin Setup"
-msgstr ""
-
-#: wp-admin/install.php:365
-msgid "Give your site a great title and fill out your administrator account details. Take note of your username and password – you will need these again in a moment."
-msgstr ""
-
-#: wp-admin/install.php:396
-msgid "Please provide a valid username."
-msgstr ""
-
-#: wp-admin/install.php:399
-msgid "The username you provided has invalid characters."
-msgstr ""
-
-#: wp-admin/install.php:403
-msgid "Your passwords do not match. Please try again."
-msgstr ""
-
-#: wp-admin/install.php:407
-msgid "You must provide an email address."
-msgstr ""
-
-#: wp-admin/install.php:411
-msgid "Sorry, that is not a valid email address. Email addresses look like <code>username@example.com</code>."
-msgstr ""
-
-#: wp-admin/install.php:420
-msgid "Success!"
-msgstr ""
-
-#. translators: link to Open Collective donation page
-#: wp-admin/install.php:426
-msgid "ClassicPress has been installed. Consider making a donation to support <a href=\"%s\">ClassicPress</a>, please. Thank you, and enjoy!"
-msgstr ""
-
-#: wp-admin/link-add.php:13
-msgid "Sorry, you are not allowed to add links to this site."
-msgstr ""
-
-#: wp-admin/link-add.php:17
-msgid "Add New Link"
-msgstr ""
-
-#. translators: %s: URL to Widgets screen.
-#: wp-admin/link-manager.php:61
-msgid "You can add links here to be displayed on your site, usually using <a href=\"%s\">Widgets</a>. By default, links to several sites in the ClassicPress community are included as examples."
-msgstr ""
-
-#: wp-admin/link-manager.php:64
-msgid "Links may be separated into Link Categories; these are different than the categories used on your posts."
-msgstr ""
-
-#: wp-admin/link-manager.php:65
-msgid "You can customize the display of this screen using the Screen Options tab and/or the dropdown filters above the links table."
-msgstr ""
-
-#: wp-admin/link-manager.php:71
-msgid "Deleting Links"
-msgstr ""
-
-#: wp-admin/link-manager.php:73
-msgid "If you delete a link, it will be removed permanently, as Links do not have a Trash function yet."
-msgstr ""
-
-#: wp-admin/link-manager.php:79
-msgid "<a href=\"https://codex.wordpress.org/Links_Screen\">Documentation on Managing Links</a>"
-msgstr ""
-
-#: wp-admin/link-manager.php:85
-msgid "Links list"
-msgstr ""
-
-#. translators: %s: Number of links.
-#: wp-admin/link-manager.php:125
-msgid "%s link deleted."
-msgid_plural "%s links deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/link-manager.php:133
-msgid "Search Links"
-msgstr ""
-
-#: wp-admin/link-parse-opml.php:77
-#: wp-admin/link-parse-opml.php:78
-#: wp-includes/atomlib.php:151
-#: wp-includes/feed.php:582
-#: wp-includes/IXR/class-IXR-message.php:48
-msgid "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension."
-msgstr ""
-
-#. translators: 1: Error message, 2: Line number.
-#: wp-admin/link-parse-opml.php:89
-#: wp-includes/atomlib.php:175
-msgid "XML Error: %1$s at line %2$s"
-msgstr ""
-
-#: wp-admin/link.php:112
-msgid "Edit Link"
-msgstr ""
-
-#: wp-admin/link.php:118
-msgid "Link not found."
-msgstr ""
-
-#: wp-admin/maint/repair.php:20
-msgid "ClassicPress &rsaquo; Database Repair"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/maint/repair.php:32
-msgid "Allow automatic database repair"
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/maint/repair.php:38
-msgid "To allow use of this page to automatically repair database problems, please add the following line to your %s file. Once this line is added to your config, reload this page."
-msgstr ""
-
-#. translators: This string should only be translated if wp-config-sample.php is localized. You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
-#: wp-admin/maint/repair.php:51
-#: wp-includes/class-wp-recovery-mode-cookie-service.php:219
-#: wp-includes/pluggable.php:2447
-msgid "put your unique phrase here"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/maint/repair.php:81
-msgid "Check secret keys"
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: Secret key service URL.
-#: wp-admin/maint/repair.php:85
-msgid "While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href=\"%2$s\">ClassicPress.net secret key service</a>."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/maint/repair.php:91
-msgid "Database repair results"
-msgstr ""
-
-#. translators: %s: Table name.
-#: wp-admin/maint/repair.php:116
-msgid "The %s table is okay."
-msgstr ""
-
-#. translators: 1: Table name, 2: Error message.
-#: wp-admin/maint/repair.php:119
-msgid "The %1$s table is not okay. It is reporting the following error: %2$s. ClassicPress will attempt to repair this table&hellip;"
-msgstr ""
-
-#. translators: %s: Table name.
-#: wp-admin/maint/repair.php:126
-msgid "Successfully repaired the %s table."
-msgstr ""
-
-#. translators: 1: Table name, 2: Error message.
-#: wp-admin/maint/repair.php:129
-msgid "Failed to repair the %1$s table. Error: %2$s"
-msgstr ""
-
-#. translators: %s: Table name.
-#: wp-admin/maint/repair.php:141
-msgid "The %s table is already optimized."
-msgstr ""
-
-#. translators: %s: Table name.
-#: wp-admin/maint/repair.php:148
-msgid "Successfully optimized the %s table."
-msgstr ""
-
-#. translators: 1: Table name. 2: Error message.
-#: wp-admin/maint/repair.php:151
-msgid "Failed to optimize the %1$s table. Error: %2$s"
-msgstr ""
-
-#. translators: %s: URL to "Fixing WordPress" forum.
-#: wp-admin/maint/repair.php:161
-msgid "Some database problems could not be repaired. Please copy-and-paste the following list of errors to the <a href=\"%s\">ClassicPress support forums</a> to get additional assistance."
-msgstr ""
-
-#: wp-admin/maint/repair.php:162
-msgid "https://wordpress.org/support/forum/how-to-and-troubleshooting"
-msgstr ""
-
-#: wp-admin/maint/repair.php:170
-msgid "Repairs complete. Please remove the following line from wp-config.php to prevent this page from being used by unauthorized users."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/maint/repair.php:176
-msgid "ClassicPress database repair"
-msgstr ""
-
-#: wp-admin/maint/repair.php:180
-msgid "One or more database tables are unavailable. To allow ClassicPress to attempt to repair these tables, press the &#8220;Repair Database&#8221; button. Repairing can take a while, so please be patient."
-msgstr ""
-
-#: wp-admin/maint/repair.php:182
-msgid "ClassicPress can automatically look for some common database problems and repair them. Repairing can take a while, so please be patient."
-msgstr ""
-
-#: wp-admin/maint/repair.php:185
-msgid "Repair Database"
-msgstr ""
-
-#: wp-admin/maint/repair.php:186
-msgid "ClassicPress can also attempt to optimize the database. This improves performance in some situations. Repairing and optimizing the database can take a long time and the database will be locked while optimizing."
-msgstr ""
-
-#: wp-admin/maint/repair.php:187
-msgid "Repair and Optimize Database"
-msgstr ""
-
-#: wp-admin/media-new.php:43
-msgid "Upload New Media"
-msgstr ""
-
-#: wp-admin/media-new.php:51
-msgid "You can upload media files here without creating a post first. This allows you to upload files to use with posts and pages later and/or to get a web link for a particular file that you can share. There are three options for uploading files:"
-msgstr ""
-
-#: wp-admin/media-new.php:53
-msgid "<strong>Drag and drop</strong> your files into the area below. Multiple files are allowed."
-msgstr ""
-
-#: wp-admin/media-new.php:54
-msgid "Clicking <strong>Select Files</strong> opens a navigation window showing you files in your operating system. Selecting <strong>Open</strong> after clicking on the file you want activates a progress bar on the uploader screen."
-msgstr ""
-
-#: wp-admin/media-new.php:55
-msgid "Revert to the <strong>Browser Uploader</strong> by clicking the link below the drag and drop box."
-msgstr ""
-
-#: wp-admin/media-new.php:61
-msgid "<a href=\"https://wordpress.org/documentation/article/media-add-new-screen/\">Documentation on Uploading Media Files</a>"
-msgstr ""
-
-#: wp-admin/media-upload.php:39
-#: wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php:190
-msgid "Invalid item ID."
-msgstr ""
-
-#: wp-admin/media.php:23
-#: wp-admin/media.php:62
-msgid "Sorry, you are not allowed to edit this attachment."
-msgstr ""
-
-#: wp-admin/media.php:49
-#: wp-includes/post.php:79
-msgid "Edit Media"
-msgstr ""
-
-#: wp-admin/media.php:68
-msgid "You attempted to edit an attachment that does not exist. Perhaps it was deleted?"
-msgstr ""
-
-#: wp-admin/media.php:71
-msgid "You attempted to edit an item that is not an attachment. Please go back and try again."
-msgstr ""
-
-#: wp-admin/media.php:74
-msgid "You cannot edit this attachment because it is in the Trash. Please move it out of the Trash and try again."
-msgstr ""
-
-#. translators: Add new file.
-#: wp-admin/media.php:130
-#: wp-admin/menu.php:69
-#: wp-admin/upload.php:175
-#: wp-admin/upload.php:373
-#: wp-includes/post.php:78
-msgctxt "file"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/menu-header.php:296
-#: wp-admin/js/common.js:1989
-msgid "Collapse Main menu"
-msgstr ""
-
-#: wp-admin/menu-header.php:298
-msgid "Collapse menu"
-msgstr ""
-
-#: wp-admin/menu-header.php:304
-msgid "Main menu"
-msgstr ""
-
-#: wp-admin/menu-header.php:305
-msgid "Skip to main content"
-msgstr ""
-
-#: wp-admin/menu-header.php:306
-#: wp-includes/class-wp-admin-bar.php:467
-msgid "Skip to toolbar"
-msgstr ""
-
-#: wp-admin/menu.php:26
-#: wp-admin/network/menu.php:13
-#: wp-includes/post-template.php:1457
-msgid "Home"
-msgstr ""
-
-#: wp-admin/menu.php:29
-#: wp-admin/my-sites.php:38
-#: wp-includes/admin-bar.php:479
-msgid "My Sites"
-msgstr ""
-
-#. translators: %s: Number of pending updates.
-#. translators: %s: Number of available updates.
-#: wp-admin/menu.php:49
-#: wp-admin/network/menu.php:30
-msgid "Updates %s"
-msgstr ""
-
-#: wp-admin/menu.php:67
-msgid "Library"
-msgstr ""
-
-#: wp-admin/menu.php:81
-msgctxt "admin menu"
-msgid "All Links"
-msgstr ""
-
-#: wp-admin/menu.php:84
-#: wp-includes/taxonomy.php:142
-msgid "Link Categories"
-msgstr ""
-
-#. translators: %s: Number of comments.
-#: wp-admin/menu.php:98
-msgid "Comments %s"
-msgstr ""
-
-#: wp-admin/menu.php:109
-msgid "All Comments"
-msgstr ""
-
-#: wp-admin/menu.php:188
-msgid "Appearance"
-msgstr ""
-
-#. translators: %s: Number of available theme updates.
-#: wp-admin/menu.php:203
-#: wp-admin/network/menu.php:63
-msgid "Themes %s"
-msgstr ""
-
-#: wp-admin/menu.php:210
-#: wp-admin/nav-menus.php:32
-#: wp-admin/nav-menus.php:700
-#: wp-includes/admin-bar.php:1005
-#: wp-includes/class-wp-customize-nav-menus.php:673
-#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:113
-msgid "Menus"
-msgstr ""
-
-#: wp-admin/menu.php:240
-msgctxt "theme editor"
-msgid "Editor"
-msgstr ""
-
-#. translators: %s: Number of available plugin updates.
-#: wp-admin/menu.php:256
-#: wp-admin/network/menu.php:88
-msgid "Plugins %s"
-msgstr ""
-
-#: wp-admin/menu.php:258
-#: wp-admin/network/menu.php:105
-msgid "Installed Plugins"
-msgstr ""
-
-#. translators: Add new plugin.
-#: wp-admin/menu.php:262
-#: wp-admin/plugins.php:729
-msgctxt "plugin"
-msgid "Upload"
-msgstr ""
-
-#: wp-admin/menu.php:263
-#: wp-admin/network/menu.php:106
-#: wp-admin/plugins.php:728
-msgctxt "plugin"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/menu.php:264
-#: wp-admin/network/menu.php:107
-msgid "Plugin File Editor"
-msgstr ""
-
-#: wp-admin/menu.php:272
-#: wp-admin/menu.php:284
-#: wp-admin/menu.php:287
-#: wp-admin/user-edit.php:40
-#: wp-admin/user/menu.php:14
-msgid "Profile"
-msgstr ""
-
-#: wp-admin/menu.php:277
-#: wp-admin/network/menu.php:56
-msgid "All Users"
-msgstr ""
-
-#: wp-admin/menu.php:279
-#: wp-admin/menu.php:281
-#: wp-admin/network/menu.php:57
-#: wp-admin/network/users.php:288
-#: wp-admin/user-edit.php:241
-#: wp-admin/users.php:628
-msgctxt "user"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/menu.php:289
-#: wp-admin/menu.php:291
-#: wp-admin/network/site-users.php:351
-#: wp-admin/network/site-users.php:378
-#: wp-admin/network/user-new.php:100
-#: wp-admin/network/user-new.php:106
-#: wp-admin/user-new.php:255
-#: wp-admin/user-new.php:377
-#: wp-admin/user-new.php:504
-#: wp-admin/user-new.php:656
-msgid "Add New User"
-msgstr ""
-
-#: wp-admin/menu.php:320
-#: wp-admin/tools.php:43
-msgid "Tools"
-msgstr ""
-
-#: wp-admin/menu.php:321
-msgid "Available Tools"
-msgstr ""
-
-#. translators: %s: Number of critical Site Health checks.
-#: wp-admin/menu.php:325
-msgid "Site Health %s"
-msgstr ""
-
-#: wp-admin/menu.php:329
-#: wp-admin/ms-delete-site.php:39
-msgid "Delete Site"
-msgstr ""
-
-#: wp-admin/menu.php:332
-#: wp-admin/network.php:53
-#: wp-admin/network/menu.php:112
-msgid "Network Setup"
-msgstr ""
-
-#: wp-admin/menu.php:336
-msgctxt "settings screen"
-msgid "General"
-msgstr ""
-
-#: wp-admin/menu.php:337
-msgid "Writing"
-msgstr ""
-
-#: wp-admin/menu.php:338
-msgid "Reading"
-msgstr ""
-
-#: wp-admin/menu.php:341
-msgid "Permalinks"
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:13
-#: wp-admin/my-sites.php:13
-#: wp-admin/network/admin.php:17
-msgid "Multisite support is not enabled."
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:17
-msgid "Sorry, you are not allowed to delete this site."
-msgstr ""
-
-#. translators: %s: Network title.
-#: wp-admin/ms-delete-site.php:26
-msgid "Thank you for using %s, your site has been deleted. Happy trails to you until we meet again."
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:31
-msgid "Sorry, the link you clicked is stale. Please select another option."
-msgstr ""
-
-#. translators: Do not translate USERNAME, URL_DELETE, SITENAME, SITEURL: those are placeholders.
-#: wp-admin/ms-delete-site.php:58
-msgid ""
-"Hello ###USERNAME###,\n"
-"\n"
-"You recently clicked the 'Delete Site' link on your site and filled in a\n"
-"form on that page.\n"
-"\n"
-"If you really want to delete your site, click the link below. You will not\n"
-"be asked to confirm again so only click this link if you are absolutely certain:\n"
-"###URL_DELETE###\n"
-"\n"
-"If you delete your site, please consider opening a new site here some time in\n"
-"the future! (But remember that your current site and username are gone forever.)\n"
-"\n"
-"Thank you for using the site,\n"
-"All at ###SITENAME###\n"
-"###SITEURL###"
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/ms-delete-site.php:93
-msgid "[%s] Delete My Site"
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:104
-msgid "Thank you. Please check your email for a link to confirm your action. Your site will not be deleted until this link is clicked."
-msgstr ""
-
-#. translators: %s: Network title.
-#: wp-admin/ms-delete-site.php:113
-msgid "If you do not want to use your %s site any more, you can delete it using the form below. When you click <strong>Delete My Site Permanently</strong> you will be sent an email with a link in it. Click on this link to delete your site."
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:118
-msgid "Remember, once deleted your site cannot be restored."
-msgstr ""
-
-#. translators: %s: Site address.
-#: wp-admin/ms-delete-site.php:127
-msgid "I'm sure I want to permanently delete my site, and I am aware I can never get it back or use %s again."
-msgstr ""
-
-#: wp-admin/ms-delete-site.php:132
-msgid "Delete My Site Permanently"
-msgstr ""
-
-#: wp-admin/my-sites.php:33
-msgid "The primary site you chose does not exist."
-msgstr ""
-
-#: wp-admin/my-sites.php:46
-msgid "This screen shows an individual user all of their sites in this network, and also allows that user to set a primary site. They can use the links under each site to visit either the front end or the dashboard for that site."
-msgstr ""
-
-#: wp-admin/my-sites.php:52
-msgid "<a href=\"https://codex.wordpress.org/Dashboard_My_Sites_Screen\">Documentation on My Sites</a>"
-msgstr ""
-
-#: wp-admin/my-sites.php:59
-#: wp-admin/network/settings.php:141
-#: wp-admin/network/sites.php:352
-#: wp-admin/options-head.php:15
-#: wp-admin/options.php:349
-msgid "Settings saved."
-msgstr ""
-
-#: wp-admin/my-sites.php:73
-#: wp-admin/network/menu.php:53
-#: wp-admin/network/sites.php:370
-msgctxt "site"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/my-sites.php:78
-msgid "You must be a member of at least one site to use this page."
-msgstr ""
-
-#: wp-admin/my-sites.php:113
-msgid "Global Settings"
-msgstr ""
-
-#: wp-admin/nav-menus.php:19
-msgid "Your theme does not support navigation menus or widgets."
-msgstr ""
-
-#: wp-admin/nav-menus.php:26
-#: wp-admin/themes.php:15
-#: wp-admin/widgets.php:18
-#: wp-includes/class-wp-customize-manager.php:571
-msgid "Sorry, you are not allowed to edit theme options on this site."
-msgstr ""
-
-#: wp-admin/nav-menus.php:284
-msgid "The menu item has been successfully deleted."
-msgstr ""
-
-#: wp-admin/nav-menus.php:307
-msgid "The menu has been successfully deleted."
-msgstr ""
-
-#: wp-admin/nav-menus.php:329
-msgid "Selected menus have been successfully deleted."
-msgstr ""
-
-#: wp-admin/nav-menus.php:403
-#: wp-admin/nav-menus.php:425
-msgid "Please enter a valid menu name."
-msgstr ""
-
-#: wp-admin/nav-menus.php:471
-msgid "Menu locations updated."
-msgstr ""
-
-#: wp-admin/nav-menus.php:502
-#: wp-includes/class-wp-customize-nav-menus.php:554
-msgid "Move up one"
-msgstr ""
-
-#: wp-admin/nav-menus.php:503
-#: wp-includes/class-wp-customize-nav-menus.php:555
-msgid "Move down one"
-msgstr ""
-
-#: wp-admin/nav-menus.php:504
-#: wp-includes/class-wp-customize-nav-menus.php:556
-msgid "Move to the top"
-msgstr ""
-
-#. translators: %s: Previous item name.
-#: wp-admin/nav-menus.php:506
-#: wp-includes/class-wp-customize-nav-menus.php:558
-msgid "Move under %s"
-msgstr ""
-
-#. translators: %s: Previous item name.
-#: wp-admin/nav-menus.php:508
-#: wp-includes/class-wp-customize-nav-menus.php:560
-msgid "Move out from under %s"
-msgstr ""
-
-#. translators: %s: Previous item name.
-#: wp-admin/nav-menus.php:510
-#: wp-includes/class-wp-customize-nav-menus.php:562
-msgid "Under %s"
-msgstr ""
-
-#. translators: %s: Previous item name.
-#: wp-admin/nav-menus.php:512
-#: wp-includes/class-wp-customize-nav-menus.php:564
-msgid "Out from under %s"
-msgstr ""
-
-#. translators: 1: Item name, 2: Item position, 3: Total number of items.
-#: wp-admin/nav-menus.php:514
-#: wp-includes/class-wp-customize-nav-menus.php:566
-msgid "%1$s. Menu item %2$d of %3$d."
-msgstr ""
-
-#. translators: 1: Item name, 2: Item position, 3: Parent item name.
-#: wp-admin/nav-menus.php:516
-#: wp-includes/class-wp-customize-nav-menus.php:568
-msgid "%1$s. Sub item number %2$d under %3$s."
-msgstr ""
-
-#. translators: %s: Item name.
-#: wp-admin/nav-menus.php:518
-msgid "item %s"
-msgstr ""
-
-#. translators: %s: Item name.
-#: wp-admin/nav-menus.php:520
-msgid "Deleted menu item: %s."
-msgstr ""
-
-#: wp-admin/nav-menus.php:521
-#: wp-includes/class-wp-customize-nav-menus.php:515
-msgid "Menu item added"
-msgstr ""
-
-#: wp-admin/nav-menus.php:522
-msgid "Menu item removed"
-msgstr ""
-
-#: wp-admin/nav-menus.php:523
-#: wp-includes/class-wp-customize-nav-menus.php:519
-msgid "Menu item moved up"
-msgstr ""
-
-#: wp-admin/nav-menus.php:524
-#: wp-includes/class-wp-customize-nav-menus.php:520
-msgid "Menu item moved down"
-msgstr ""
-
-#: wp-admin/nav-menus.php:525
-msgid "Menu item moved to the top"
-msgstr ""
-
-#: wp-admin/nav-menus.php:526
-#: wp-includes/class-wp-customize-nav-menus.php:521
-msgid "Menu item moved out of submenu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:527
-#: wp-includes/class-wp-customize-nav-menus.php:522
-msgid "Menu item is now a sub-item"
-msgstr ""
-
-#: wp-admin/nav-menus.php:528
-msgid "menu position"
-msgstr ""
-
-#: wp-admin/nav-menus.php:529
-msgid "moved to"
-msgstr ""
-
-#. translators: %s: URL to Widgets screen.
-#: wp-admin/nav-menus.php:622
-msgid "Your theme does not natively support menus, but you can use them in sidebars by adding a &#8220;Navigation Menu&#8221; widget on the <a href=\"%s\">Widgets</a> screen."
-msgstr ""
-
-#: wp-admin/nav-menus.php:628
-msgid "This screen is used for managing your navigation menus."
-msgstr ""
-
-#. translators: 1: URL to Widgets screen, 2 and 3: The names of the default themes.
-#: wp-admin/nav-menus.php:631
-msgid "Menus can be displayed in locations defined by your theme, even used in sidebars by adding a &#8220;Navigation Menu&#8221; widget on the <a href=\"%1$s\">Widgets</a> screen. If your theme does not support the navigation menus feature (the default themes, %2$s and %3$s, do), you can learn about adding this support by following the documentation link to the side."
-msgstr ""
-
-#: wp-admin/nav-menus.php:636
-#: wp-admin/themes.php:133
-msgid "From this screen you can:"
-msgstr ""
-
-#: wp-admin/nav-menus.php:637
-msgid "Create, edit, and delete menus"
-msgstr ""
-
-#: wp-admin/nav-menus.php:638
-msgid "Add, organize, and modify individual menu items"
-msgstr ""
-
-#: wp-admin/nav-menus.php:648
-msgid "The menu management box at the top of the screen is used to control which menu is opened in the editor below."
-msgstr ""
-
-#: wp-admin/nav-menus.php:649
-msgid "To edit an existing menu, <strong>choose a menu from the dropdown and click Select</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:650
-msgid "If you have not yet created any menus, <strong>click the &#8217;create a new menu&#8217; link</strong> to get started"
-msgstr ""
-
-#: wp-admin/nav-menus.php:651
-msgid "You can assign theme locations to individual menus by <strong>selecting the desired settings</strong> at the bottom of the menu editor. To assign menus to all theme locations at once, <strong>visit the Manage Locations tab</strong> at the top of the screen."
-msgstr ""
-
-#: wp-admin/nav-menus.php:656
-msgid "Menu Management"
-msgstr ""
-
-#: wp-admin/nav-menus.php:661
-msgid "Each navigation menu may contain a mix of links to pages, categories, custom URLs or other content types. Menu links are added by selecting items from the expanding boxes in the left-hand column below."
-msgstr ""
-
-#: wp-admin/nav-menus.php:662
-msgid "<strong>Clicking the arrow to the right of any menu item</strong> in the editor will reveal a standard group of settings. Additional settings such as link target, CSS classes, link relationships, and link descriptions can be enabled and disabled via the Screen Options tab."
-msgstr ""
-
-#: wp-admin/nav-menus.php:663
-msgid "Add one or several items at once by <strong>selecting the checkbox next to each item and clicking Add to Menu</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:664
-msgid "To add a custom link, <strong>expand the Custom Links section, enter a URL and link text, and click Add to Menu</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:665
-msgid "To reorganize menu items, <strong>drag and drop items with your mouse or use your keyboard</strong>. Drag or move a menu item a little to the right to make it a submenu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:666
-msgid "Delete a menu item by <strong>expanding it and clicking the Remove link</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:671
-msgid "Editing Menus"
-msgstr ""
-
-#: wp-admin/nav-menus.php:676
-msgid "This screen is used for globally assigning menus to locations defined by your theme."
-msgstr ""
-
-#: wp-admin/nav-menus.php:677
-msgid "To assign menus to one or more theme locations, <strong>select a menu from each location&#8217;s dropdown</strong>. When you are finished, <strong>click Save Changes</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:678
-msgid "To edit a menu currently assigned to a theme location, <strong>click the adjacent &#8217;Edit&#8217; link</strong>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:679
-msgid "To add a new menu instead of assigning an existing one, <strong>click the &#8217;Use new menu&#8217; link</strong>. Your new menu will be automatically assigned to that theme location"
-msgstr ""
-
-#: wp-admin/nav-menus.php:692
-msgid "<a href=\"https://wordpress.org/documentation/article/appearance-menus-screen/\">Documentation on Menus</a>"
-msgstr ""
-
-#: wp-admin/nav-menus.php:715
-#: wp-admin/widgets-form.php:393
-msgid "Manage with Live Preview"
-msgstr ""
-
-#: wp-admin/nav-menus.php:731
-msgid "Edit Menus"
-msgstr ""
-
-#: wp-admin/nav-menus.php:742
-msgid "Manage Locations"
-msgstr ""
-
-#: wp-admin/nav-menus.php:755
-msgid "Your theme supports one menu. Select which menu you would like to use."
-msgstr ""
-
-#. translators: %s: Number of menus.
-#: wp-admin/nav-menus.php:759
-msgid "Your theme supports %s menu. Select which menu appears in each location."
-msgid_plural "Your theme supports %s menus. Select which menu appears in each location."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/nav-menus.php:773
-msgid "Theme Location"
-msgstr ""
-
-#: wp-admin/nav-menus.php:774
-msgid "Assigned Menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:783
-msgid "Select a Menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:814
-msgctxt "menu"
-msgid "Edit"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/nav-menus.php:817
-#: wp-includes/customize/class-wp-customize-nav-menu-location-control.php:86
-msgid "Edit selected menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:838
-msgctxt "menu"
-msgid "Use new menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:864
-msgid "Create your first menu below."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/nav-menus.php:868
-msgid "Fill in the Menu Name and click the Create Menu button to create your first menu."
-msgstr ""
-
-#. translators: %s: URL to create a new menu.
-#: wp-admin/nav-menus.php:877
-msgid "Edit your menu below, or <a href=\"%s\">create a new menu</a>. Do not forget to save your changes!"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/nav-menus.php:892
-#: wp-admin/nav-menus.php:962
-msgid "Click the Save Menu button to save your changes."
-msgstr ""
-
-#: wp-admin/nav-menus.php:899
-msgid "Select a menu to edit:"
-msgstr ""
-
-#. translators: %s: URL to create a new menu.
-#: wp-admin/nav-menus.php:947
-msgid "or <a href=\"%s\">create a new menu</a>. Do not forget to save your changes!"
-msgstr ""
-
-#: wp-admin/nav-menus.php:986
-msgid "Add menu items"
-msgstr ""
-
-#: wp-admin/nav-menus.php:994
-msgid "Menu structure"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1017
-#: wp-includes/class-wp-customize-nav-menus.php:513
-msgid "Menu Name"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1020
-#: wp-admin/nav-menus.php:1157
-#: wp-includes/customize/class-wp-customize-new-menu-control.php:59
-msgid "Create Menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1020
-#: wp-admin/nav-menus.php:1157
-msgid "Save Menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1035
-msgid "Edit your default menu by adding or removing items. Drag the items into the order you prefer. Click Create Menu to save your changes."
-msgstr ""
-
-#: wp-admin/nav-menus.php:1037
-msgid "Drag the items into the order you prefer. Click the arrow on the left of the item to reveal additional configuration options."
-msgstr ""
-
-#: wp-admin/nav-menus.php:1048
-#: wp-admin/nav-menus.php:1083
-msgid "Bulk Select"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1064
-msgid "Give your menu a name, then click Create Menu."
-msgstr ""
-
-#: wp-admin/nav-menus.php:1085
-msgid "Remove Selected Items"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1087
-msgid "List of menu items selected for deletion:"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1094
-#: wp-admin/network/settings.php:501
-msgid "Menu Settings"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1110
-msgid "Auto add pages"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1112
-#: wp-includes/customize/class-wp-customize-nav-menu-auto-add-control.php:46
-msgid "Automatically add new top-level pages to this menu"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1119
-msgid "Display location"
-msgstr ""
-
-#. translators: %s: Menu name.
-#: wp-admin/nav-menus.php:1139
-msgctxt "menu location"
-msgid "(Currently set to: %s)"
-msgstr ""
-
-#: wp-admin/nav-menus.php:1182
-#: wp-includes/class-wp-customize-nav-menus.php:1108
-msgid "Delete Menu"
-msgstr ""
-
-#: wp-admin/network.php:19
-#: wp-admin/options-discussion.php:12
-#: wp-admin/options-general.php:16
-#: wp-admin/options-media.php:13
-#: wp-admin/options-permalink.php:13
-#: wp-admin/options-reading.php:13
-#: wp-admin/options-writing.php:13
-#: wp-admin/options.php:51
-msgid "Sorry, you are not allowed to manage options for this site."
-msgstr ""
-
-#: wp-admin/network.php:29
-msgid "The Network creation panel is not for ClassicPress MU networks."
-msgstr ""
-
-#. translators: 1: WP_ALLOW_MULTISITE, 2: wp-config.php
-#: wp-admin/network.php:44
-msgid "You must define the %1$s constant as true in your %2$s file to allow creation of a Network."
-msgstr ""
-
-#: wp-admin/network.php:57
-msgid "Create a Network of ClassicPress Sites"
-msgstr ""
-
-#: wp-admin/network.php:61
-msgid "This screen allows you to configure a network as having subdomains (<code>site1.example.com</code>) or subdirectories (<code>example.com/site1</code>). Subdomains require wildcard subdomains to be enabled in Apache and DNS records, if your host allows it."
-msgstr ""
-
-#: wp-admin/network.php:62
-msgid "Choose subdomains or subdirectories; this can only be switched afterwards by reconfiguring your installation. Fill out the network details, and click Install. If this does not work, you may have to add a wildcard DNS record (for subdomains) or change to another setting in Permalinks (for subdirectories)."
-msgstr ""
-
-#: wp-admin/network.php:63
-msgid "The next screen for Network Setup will give you individually-generated lines of code to add to your wp-config.php and .htaccess files. Make sure the settings of your FTP client make files starting with a dot visible, so that you can find .htaccess; you may have to create this file if it really is not there. Make backup copies of those two files."
-msgstr ""
-
-#: wp-admin/network.php:64
-msgid "Add the designated lines of code to wp-config.php (just before <code>/*...stop editing...*/</code>) and <code>.htaccess</code> (replacing the existing ClassicPress rules)."
-msgstr ""
-
-#: wp-admin/network.php:65
-msgid "Once you add this code and refresh your browser, multisite should be enabled. This screen, now in the Network Admin navigation menu, will keep an archive of the added code. You can toggle between Network Admin and Site Admin by clicking on the Network Admin or an individual site name under the My Sites dropdown in the Toolbar."
-msgstr ""
-
-#: wp-admin/network.php:66
-msgid "The choice of subdirectory sites is disabled if this setup is more than a month old because of permalink problems with &#8220;/blog/&#8221; from the main site. This disabling will be addressed in a future version."
-msgstr ""
-
-#: wp-admin/network.php:68
-#: wp-admin/network.php:81
-msgid "<a href=\"https://wordpress.org/documentation/article/create-a-network/\">Documentation on Creating a Network</a>"
-msgstr ""
-
-#: wp-admin/network.php:69
-#: wp-admin/network.php:82
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-network-screen/\">Documentation on the Network Screen</a>"
-msgstr ""
-
-#: wp-admin/network.php:74
-msgid "Network"
-msgstr ""
-
-#: wp-admin/network/index.php:24
-msgid "Welcome to your Network Admin. This area of the Administration Screens is used for managing all aspects of your Multisite Network."
-msgstr ""
-
-#: wp-admin/network/index.php:25
-msgid "From here you can:"
-msgstr ""
-
-#: wp-admin/network/index.php:26
-msgid "Add and manage sites or users"
-msgstr ""
-
-#: wp-admin/network/index.php:27
-msgid "Install and activate themes or plugins"
-msgstr ""
-
-#: wp-admin/network/index.php:28
-msgid "Update your network"
-msgstr ""
-
-#: wp-admin/network/index.php:29
-msgid "Modify global network settings"
-msgstr ""
-
-#: wp-admin/network/index.php:39
-msgid "The Right Now widget on this screen provides current user and site counts on your network."
-msgstr ""
-
-#: wp-admin/network/index.php:40
-msgid "To add a new user, <strong>click Create a New User</strong>."
-msgstr ""
-
-#: wp-admin/network/index.php:41
-msgid "To add a new site, <strong>click Create a New Site</strong>."
-msgstr ""
-
-#: wp-admin/network/index.php:42
-msgid "To search for a user or site, use the search boxes."
-msgstr ""
-
-#: wp-admin/network/index.php:43
-msgid "To search for a user, <strong>enter an email address or username</strong>. Use a wildcard to search for a partial username, such as user&#42;."
-msgstr ""
-
-#: wp-admin/network/index.php:44
-msgid "To search for a site, <strong>enter the path or domain</strong>."
-msgstr ""
-
-#: wp-admin/network/index.php:49
-msgid "Quick Tasks"
-msgstr ""
-
-#: wp-admin/network/index.php:56
-msgid "<a href=\"https://wordpress.org/documentation/article/network-admin/\">Documentation on the Network Admin</a>"
-msgstr ""
-
-#: wp-admin/network/menu.php:41
-msgid "Updates"
-msgstr ""
-
-#: wp-admin/network/menu.php:46
-#: wp-admin/network/upgrade.php:16
-#: wp-admin/network/upgrade.php:43
-#: wp-admin/network/upgrade.php:145
-msgid "Upgrade Network"
-msgstr ""
-
-#: wp-admin/network/menu.php:52
-msgid "All Sites"
-msgstr ""
-
-#: wp-admin/network/menu.php:80
-msgid "Installed Themes"
-msgstr ""
-
-#: wp-admin/network/menu.php:81
-#: wp-admin/network/themes.php:352
-#: wp-admin/themes.php:255
-msgctxt "theme"
-msgid "Add New"
-msgstr ""
-
-#: wp-admin/network/menu.php:82
-msgid "Theme File Editor"
-msgstr ""
-
-#: wp-admin/network/menu.php:103
-#: wp-admin/network/settings.php:497
-#: wp-admin/plugins.php:601
-#: wp-admin/update-core.php:303
-#: wp-admin/update-core.php:322
-#: wp-includes/admin-bar.php:548
-msgid "Plugins"
-msgstr ""
-
-#: wp-admin/network/menu.php:111
-#: wp-admin/network/settings.php:21
-msgid "Network Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:51
-msgid "This screen sets and changes options for the network as a whole. The first site is the main site in the network and network options are pulled from that original site&#8217;s options."
-msgstr ""
-
-#: wp-admin/network/settings.php:52
-msgid "Operational settings has fields for the network&#8217;s name and admin email."
-msgstr ""
-
-#: wp-admin/network/settings.php:53
-msgid "Registration settings can disable/enable public signups. If you let others sign up for a site, install spam plugins. Spaces, not commas, should separate names banned as sites for this network."
-msgstr ""
-
-#: wp-admin/network/settings.php:54
-msgid "New site settings are defaults applied when a new site is created in the network. These include welcome email for when a new site or user account is registered, and what&#8127;s put in the first post, page, comment, comment author, and comment URL."
-msgstr ""
-
-#: wp-admin/network/settings.php:55
-msgid "Upload settings control the size of the uploaded files and the amount of available upload space for each site. You can change the default value for specific sites when you edit a particular site. Allowed file types are also listed (space separated only)."
-msgstr ""
-
-#: wp-admin/network/settings.php:56
-#: wp-admin/options-general.php:39
-msgid "You can set the language, and the translation files will be automatically downloaded and installed (available if your filesystem is writable)."
-msgstr ""
-
-#: wp-admin/network/settings.php:57
-msgid "Menu setting enables/disables the plugin menus from appearing for non super admins, so that only super admins, not site admins, have access to activate plugins."
-msgstr ""
-
-#: wp-admin/network/settings.php:58
-msgid "Super admins can no longer be added on the Options screen. You must now go to the list of existing users on Network Admin > Users and click on Username or the Edit action link below that name. This goes to an Edit User page where you can check a box to grant super admin privileges."
-msgstr ""
-
-#: wp-admin/network/settings.php:64
-msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-settings-screen/\">Documentation on Network Settings</a>"
-msgstr ""
-
-#: wp-admin/network/settings.php:150
-msgid "Operational Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:164
-#: wp-admin/options-general.php:238
-msgid "This address is used for admin purposes. If you change this, an email will be sent to your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>"
-msgstr ""
-
-#. translators: %s: New network admin email.
-#: wp-admin/network/settings.php:175
-msgid "There is a pending change of the network admin email to %s."
-msgstr ""
-
-#: wp-admin/network/settings.php:190
-msgid "Registration Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:193
-msgid "Allow new registrations"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/settings.php:205
-msgid "New registrations settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:208
-msgid "Registration is disabled"
-msgstr ""
-
-#: wp-admin/network/settings.php:209
-msgid "User accounts may be registered"
-msgstr ""
-
-#: wp-admin/network/settings.php:210
-msgid "Logged in users may register new sites"
-msgstr ""
-
-#: wp-admin/network/settings.php:211
-msgid "Both sites and user accounts can be registered"
-msgstr ""
-
-#. translators: 1: NOBLOGREDIRECT, 2: wp-config.php
-#: wp-admin/network/settings.php:217
-msgid "If registration is disabled, please set %1$s in %2$s to a URL you will redirect visitors to if they visit a non-existent site."
-msgstr ""
-
-#: wp-admin/network/settings.php:229
-msgid "Registration notification"
-msgstr ""
-
-#: wp-admin/network/settings.php:236
-msgid "Send the network admin an email notification every time someone registers a site or user account"
-msgstr ""
-
-#: wp-admin/network/settings.php:241
-msgid "Add New Users"
-msgstr ""
-
-#: wp-admin/network/settings.php:243
-msgid "Allow site administrators to add new users to their site via the \"Users &rarr; Add New\" page"
-msgstr ""
-
-#: wp-admin/network/settings.php:248
-msgid "Banned Names"
-msgstr ""
-
-#: wp-admin/network/settings.php:261
-msgid "Users are not allowed to register these sites. Separate names by spaces."
-msgstr ""
-
-#: wp-admin/network/settings.php:267
-msgid "Limited Email Registrations"
-msgstr ""
-
-#: wp-admin/network/settings.php:286
-msgid "If you want to limit site registrations to certain domains. One domain per line."
-msgstr ""
-
-#: wp-admin/network/settings.php:292
-msgid "Banned Email Domains"
-msgstr ""
-
-#: wp-admin/network/settings.php:306
-msgid "If you want to ban domains from site registrations. One domain per line."
-msgstr ""
-
-#: wp-admin/network/settings.php:312
-msgid "New Site Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:316
-msgid "Welcome Email"
-msgstr ""
-
-#: wp-admin/network/settings.php:321
-msgid "The welcome email sent to new site owners."
-msgstr ""
-
-#: wp-admin/network/settings.php:326
-msgid "Welcome User Email"
-msgstr ""
-
-#: wp-admin/network/settings.php:331
-msgid "The welcome email sent to new users."
-msgstr ""
-
-#: wp-admin/network/settings.php:336
-#: wp-includes/deprecated.php:2691
-msgid "First Post"
-msgstr ""
-
-#: wp-admin/network/settings.php:341
-msgid "The first post on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:346
-msgid "First Page"
-msgstr ""
-
-#: wp-admin/network/settings.php:351
-msgid "The first page on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:356
-msgid "First Comment"
-msgstr ""
-
-#: wp-admin/network/settings.php:361
-msgid "The first comment on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:366
-msgid "First Comment Author"
-msgstr ""
-
-#: wp-admin/network/settings.php:370
-msgid "The author of the first comment on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:375
-msgid "First Comment Email"
-msgstr ""
-
-#: wp-admin/network/settings.php:379
-msgid "The email address of the first comment author on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:384
-msgid "First Comment URL"
-msgstr ""
-
-#: wp-admin/network/settings.php:388
-msgid "The URL for the first comment on a new site."
-msgstr ""
-
-#: wp-admin/network/settings.php:393
-msgid "Upload Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:396
-msgid "Site upload space"
-msgstr ""
-
-#. translators: %s: Number of megabytes to limit uploads to.
-#: wp-admin/network/settings.php:402
-msgid "Limit total size of files uploaded to %s MB"
-msgstr ""
-
-#: wp-admin/network/settings.php:417
-msgid "Upload file types"
-msgstr ""
-
-#: wp-admin/network/settings.php:421
-msgid "Allowed file types. Separate types by spaces."
-msgstr ""
-
-#: wp-admin/network/settings.php:427
-msgid "Max upload file size"
-msgstr ""
-
-#. translators: %s: File size in kilobytes.
-#: wp-admin/network/settings.php:432
-msgid "%s KB"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/settings.php:439
-msgid "Size in kilobytes"
-msgstr ""
-
-#: wp-admin/network/settings.php:451
-msgid "Language Settings"
-msgstr ""
-
-#: wp-admin/network/settings.php:454
-msgid "Default Language"
-msgstr ""
-
-#: wp-admin/network/settings.php:504
-msgid "Enable administration menus"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/settings.php:509
-msgid "Enable menus"
-msgstr ""
-
-#: wp-admin/network/site-info.php:14
-#: wp-admin/network/site-settings.php:14
-#: wp-admin/network/site-users.php:14
-msgid "Sorry, you are not allowed to edit this site."
-msgstr ""
-
-#: wp-admin/network/site-info.php:23
-#: wp-admin/network/site-settings.php:23
-#: wp-admin/network/site-themes.php:46
-#: wp-admin/network/site-users.php:41
-msgid "Invalid site ID."
-msgstr ""
-
-#: wp-admin/network/site-info.php:28
-#: wp-admin/network/site-settings.php:28
-#: wp-admin/network/site-themes.php:53
-#: wp-admin/network/site-users.php:46
-msgid "The requested site does not exist."
-msgstr ""
-
-#: wp-admin/network/site-info.php:126
-msgid "Site info updated."
-msgstr ""
-
-#. translators: %s: Site title.
-#: wp-admin/network/site-info.php:132
-#: wp-admin/network/site-settings.php:84
-#: wp-admin/network/site-themes.php:171
-#: wp-admin/network/site-users.php:200
-msgid "Edit Site: %s"
-msgstr ""
-
-#: wp-admin/network/site-info.php:168
-#: wp-admin/network/site-info.php:176
-#: wp-admin/network/site-new.php:204
-#: wp-admin/options-general.php:217
-#: wp-includes/class-wp-xmlrpc-server.php:537
-msgid "Site Address (URL)"
-msgstr ""
-
-#: wp-admin/network/site-info.php:190
-msgctxt "site"
-msgid "Public"
-msgstr ""
-
-#: wp-admin/network/site-info.php:199
-msgid "Attributes"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/site-info.php:205
-msgid "Set site attributes"
-msgstr ""
-
-#: wp-admin/network/site-new.php:17
-msgid "Sorry, you are not allowed to add sites to this network."
-msgstr ""
-
-#: wp-admin/network/site-new.php:25
-msgid "This screen is for Super Admins to add new sites to the network. This is not affected by the registration settings."
-msgstr ""
-
-#: wp-admin/network/site-new.php:26
-msgid "If the admin email for the new site does not exist in the database, a new user will also be created."
-msgstr ""
-
-#: wp-admin/network/site-new.php:40
-msgid "Cannot create an empty site."
-msgstr ""
-
-#. translators: %s: Reserved names list.
-#: wp-admin/network/site-new.php:59
-msgid "The following words are reserved for use by ClassicPress functions and cannot be used as site names: %s"
-msgstr ""
-
-#: wp-admin/network/site-new.php:87
-msgid "Missing or invalid site address."
-msgstr ""
-
-#: wp-admin/network/site-new.php:91
-msgid "Missing email address."
-msgstr ""
-
-#: wp-admin/network/site-new.php:96
-#: wp-includes/rest-api.php:2163
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:731
-#: wp-includes/user.php:4564
-msgid "Invalid email address."
-msgstr ""
-
-#: wp-admin/network/site-new.php:121
-msgid "The domain or path entered conflicts with an existing username."
-msgstr ""
-
-#: wp-admin/network/site-new.php:126
-msgid "There was an error creating the user."
-msgstr ""
-
-#. translators: 1: Dashboard URL, 2: Network admin edit URL.
-#: wp-admin/network/site-new.php:170
-msgid "Site added. <a href=\"%1$s\">Visit Dashboard</a> or <a href=\"%2$s\">Edit Site</a>"
-msgstr ""
-
-#: wp-admin/network/site-new.php:178
-#: wp-admin/network/site-new.php:188
-msgid "Add New Site"
-msgstr ""
-
-#: wp-admin/network/site-new.php:219
-msgid "Only lowercase letters (a-z), numbers, and hyphens are allowed."
-msgstr ""
-
-#: wp-admin/network/site-new.php:288
-msgid "Admin Email"
-msgstr ""
-
-#: wp-admin/network/site-new.php:297
-msgid "A new user will be created if the above email address is not in the database."
-msgstr ""
-
-#: wp-admin/network/site-new.php:297
-msgid "The username and a link to set the password will be mailed to this email address."
-msgstr ""
-
-#: wp-admin/network/site-new.php:309
-msgid "Add Site"
-msgstr ""
-
-#: wp-admin/network/site-settings.php:78
-msgid "Site options updated."
-msgstr ""
-
-#: wp-admin/network/site-themes.php:14
-msgid "Sorry, you are not allowed to manage themes for this site."
-msgstr ""
-
-#: wp-admin/network/site-themes.php:22
-msgid "Filter site themes list"
-msgstr ""
-
-#: wp-admin/network/site-themes.php:23
-msgid "Site themes list navigation"
-msgstr ""
-
-#: wp-admin/network/site-themes.php:24
-msgid "Site themes list"
-msgstr ""
-
-#: wp-admin/network/site-themes.php:193
-#: wp-admin/network/themes.php:373
-msgid "Theme enabled."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/network/site-themes.php:196
-#: wp-admin/network/themes.php:376
-msgid "%s theme enabled."
-msgid_plural "%s themes enabled."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/network/site-themes.php:202
-#: wp-admin/network/themes.php:382
-msgid "Theme disabled."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/network/site-themes.php:205
-#: wp-admin/network/themes.php:385
-msgid "%s theme disabled."
-msgid_plural "%s themes disabled."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/network/site-themes.php:209
-#: wp-admin/network/themes.php:416
-msgid "No theme selected."
-msgstr ""
-
-#: wp-admin/network/site-themes.php:213
-msgid "Network enabled themes are not shown on this screen."
-msgstr ""
-
-#: wp-admin/network/site-themes.php:216
-#: wp-admin/network/themes.php:424
-#: wp-admin/themes.php:233
-msgid "Search Installed Themes"
-msgstr ""
-
-#: wp-admin/network/site-users.php:25
-msgid "Filter site users list"
-msgstr ""
-
-#: wp-admin/network/site-users.php:26
-msgid "Site users list navigation"
-msgstr ""
-
-#: wp-admin/network/site-users.php:27
-msgid "Site users list"
-msgstr ""
-
-#: wp-admin/network/site-users.php:120
-#: wp-admin/users.php:420
-#: wp-admin/users.php:452
-msgid "Sorry, you are not allowed to remove users."
-msgstr ""
-
-#: wp-admin/network/site-users.php:159
-#: wp-admin/users.php:158
-msgid "One of the selected users is not a member of this site."
-msgstr ""
-
-#: wp-admin/network/site-users.php:238
-#: wp-admin/network/user-new.php:91
-#: wp-admin/network/users.php:274
-#: wp-admin/user-new.php:368
-msgid "User added."
-msgstr ""
-
-#: wp-admin/network/site-users.php:241
-msgid "User is already a member of this site."
-msgstr ""
-
-#: wp-admin/network/site-users.php:244
-msgid "User could not be added to this site."
-msgstr ""
-
-#: wp-admin/network/site-users.php:247
-msgid "Enter the username of an existing user."
-msgstr ""
-
-#: wp-admin/network/site-users.php:250
-#: wp-admin/users.php:577
-msgid "Changed roles."
-msgstr ""
-
-#: wp-admin/network/site-users.php:253
-msgid "Select a user to change role."
-msgstr ""
-
-#: wp-admin/network/site-users.php:256
-#: wp-admin/users.php:588
-msgid "User removed from this site."
-msgstr ""
-
-#: wp-admin/network/site-users.php:259
-msgid "Select a user to remove."
-msgstr ""
-
-#: wp-admin/network/site-users.php:262
-msgid "User created."
-msgstr ""
-
-#: wp-admin/network/site-users.php:265
-msgid "Enter the username and email."
-msgstr ""
-
-#: wp-admin/network/site-users.php:268
-msgid "Duplicated username or email address."
-msgstr ""
-
-#: wp-admin/network/site-users.php:316
-#: wp-admin/user-new.php:379
-#: wp-admin/user-new.php:418
-#: wp-admin/user-new.php:497
-msgid "Add Existing User"
-msgstr ""
-
-#: wp-admin/network/site-users.php:337
-#: wp-admin/network/user-new.php:146
-msgid "Add User"
-msgstr ""
-
-#: wp-admin/network/site-users.php:374
-#: wp-admin/network/user-new.php:134
-msgid "A password reset link will be sent to the user via email."
-msgstr ""
-
-#: wp-admin/network/sites.php:31
-msgid "Add New takes you to the Add New Site screen. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page."
-msgstr ""
-
-#: wp-admin/network/sites.php:32
-msgid "This is the main table of all sites on this network. Switch between list and excerpt views by using the icons above the right side of the table."
-msgstr ""
-
-#: wp-admin/network/sites.php:33
-msgid "Hovering over each site reveals seven options (three for the primary site):"
-msgstr ""
-
-#: wp-admin/network/sites.php:34
-msgid "An Edit link to a separate Edit Site screen."
-msgstr ""
-
-#: wp-admin/network/sites.php:35
-msgid "Dashboard leads to the Dashboard for that site."
-msgstr ""
-
-#: wp-admin/network/sites.php:36
-msgid "Deactivate, Archive, and Spam which lead to confirmation screens. These actions can be reversed later."
-msgstr ""
-
-#: wp-admin/network/sites.php:37
-msgid "Delete which is a permanent action after the confirmation screens."
-msgstr ""
-
-#: wp-admin/network/sites.php:38
-msgid "Visit to go to the front-end site live."
-msgstr ""
-
-#: wp-admin/network/sites.php:39
-msgid "The site ID is used internally, and is not shown on the front end of the site or to users/viewers."
-msgstr ""
-
-#: wp-admin/network/sites.php:40
-msgid "Clicking on bold headings can re-sort this table."
-msgstr ""
-
-#: wp-admin/network/sites.php:52
-msgid "Sites list navigation"
-msgstr ""
-
-#: wp-admin/network/sites.php:53
-msgid "Sites list"
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:66
-msgid "You are about to activate the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:68
-msgid "You are about to deactivate the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:70
-msgid "You are about to unarchive the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:72
-msgid "You are about to archive the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:74
-msgid "You are about to unspam the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:76
-msgid "You are about to mark the site %s as spam."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:78
-msgid "You are about to delete the site %s."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:80
-msgid "You are about to mark the site %s as mature."
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:82
-msgid "You are about to mark the site %s as not mature."
-msgstr ""
-
-#: wp-admin/network/sites.php:90
-msgid "The requested action is not valid."
-msgstr ""
-
-#: wp-admin/network/sites.php:106
-#: wp-admin/network/sites.php:224
-msgid "Sorry, you are not allowed to change the current site."
-msgstr ""
-
-#: wp-admin/network/sites.php:115
-#: wp-admin/network/sites.php:191
-msgid "Confirm your action"
-msgstr ""
-
-#: wp-admin/network/sites.php:122
-#: wp-admin/network/sites.php:209
-msgid "Confirm"
-msgstr ""
-
-#. translators: %s: Site URL.
-#: wp-admin/network/sites.php:168
-msgid "Sorry, you are not allowed to delete the site %s."
-msgstr ""
-
-#: wp-admin/network/sites.php:196
-msgid "You are about to delete the following sites:"
-msgstr ""
-
-#: wp-admin/network/sites.php:309
-msgid "Sites removed from spam."
-msgstr ""
-
-#: wp-admin/network/sites.php:312
-msgid "Sites marked as spam."
-msgstr ""
-
-#: wp-admin/network/sites.php:315
-msgid "Sites deleted."
-msgstr ""
-
-#: wp-admin/network/sites.php:318
-msgid "Site deleted."
-msgstr ""
-
-#: wp-admin/network/sites.php:321
-msgid "Sorry, you are not allowed to delete that site."
-msgstr ""
-
-#: wp-admin/network/sites.php:324
-msgid "Site archived."
-msgstr ""
-
-#: wp-admin/network/sites.php:327
-msgid "Site unarchived."
-msgstr ""
-
-#: wp-admin/network/sites.php:330
-msgid "Site activated."
-msgstr ""
-
-#: wp-admin/network/sites.php:333
-msgid "Site deactivated."
-msgstr ""
-
-#: wp-admin/network/sites.php:336
-msgid "Site removed from spam."
-msgstr ""
-
-#: wp-admin/network/sites.php:339
-msgid "Site marked as spam."
-msgstr ""
-
-#: wp-admin/network/themes.php:14
-msgid "Sorry, you are not allowed to manage network themes."
-msgstr ""
-
-#: wp-admin/network/themes.php:85
-#: wp-admin/update-core.php:510
-#: wp-admin/update-core.php:641
-#: wp-admin/update-core.php:1040
-#: wp-admin/update-core.php:1045
-msgid "Update Themes"
-msgstr ""
-
-#: wp-admin/network/themes.php:102
-msgid "Sorry, you are not allowed to delete themes for this site."
-msgstr ""
-
-#: wp-admin/network/themes.php:137
-msgid "Delete Theme"
-msgstr ""
-
-#: wp-admin/network/themes.php:138
-msgid "This theme may be active on other sites in the network."
-msgstr ""
-
-#: wp-admin/network/themes.php:139
-msgid "You are about to remove the following theme:"
-msgstr ""
-
-#: wp-admin/network/themes.php:141
-msgid "Delete Themes"
-msgstr ""
-
-#: wp-admin/network/themes.php:142
-msgid "These themes may be active on other sites in the network."
-msgstr ""
-
-#: wp-admin/network/themes.php:143
-msgid "You are about to remove the following themes:"
-msgstr ""
-
-#. translators: 1: Theme name, 2: Theme author.
-#: wp-admin/network/themes.php:150
-msgctxt "theme"
-msgid "%1$s by %2$s"
-msgstr ""
-
-#: wp-admin/network/themes.php:158
-#: wp-includes/class-wp-customize-manager.php:4934
-msgid "Are you sure you want to delete this theme?"
-msgstr ""
-
-#: wp-admin/network/themes.php:160
-msgid "Are you sure you want to delete these themes?"
-msgstr ""
-
-#: wp-admin/network/themes.php:174
-msgid "Yes, delete this theme"
-msgstr ""
-
-#: wp-admin/network/themes.php:176
-msgid "Yes, delete these themes"
-msgstr ""
-
-#: wp-admin/network/themes.php:183
-msgid "No, return me to the theme list"
-msgstr ""
-
-#: wp-admin/network/themes.php:226
-msgid "Sorry, you are not allowed to change themes automatic update settings."
-msgstr ""
-
-#: wp-admin/network/themes.php:300
-msgid "This screen enables and disables the inclusion of themes available to choose in the Appearance menu for each site. It does not activate or deactivate which theme a site is currently using."
-msgstr ""
-
-#: wp-admin/network/themes.php:301
-msgid "If the network admin disables a theme that is in use, it can still remain selected on that site. If another theme is chosen, the disabled theme will not appear in the site&#8217;s Appearance > Themes screen."
-msgstr ""
-
-#: wp-admin/network/themes.php:302
-msgid "Themes can be enabled on a site by site basis by the network admin on the Edit Site screen (which has a Themes tab); get there via the Edit action link on the All Sites screen. Only network admins are able to install or edit themes."
-msgstr ""
-
-#: wp-admin/network/themes.php:314
-#: wp-admin/themes.php:191
-msgid "Auto-updates can be enabled or disabled for each individual theme. Themes with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system."
-msgstr ""
-
-#: wp-admin/network/themes.php:315
-#: wp-admin/plugins.php:578
-#: wp-admin/themes.php:192
-msgid "Please note: Third-party themes and plugins, or custom code, may override ClassicPress scheduling."
-msgstr ""
-
-#: wp-admin/network/themes.php:319
-#: wp-admin/plugins.php:582
-#: wp-admin/themes.php:202
-msgid "<a href=\"https://wordpress.org/documentation/article/plugins-themes-auto-updates/\">Documentation on Auto-updates</a>"
-msgstr ""
-
-#: wp-admin/network/themes.php:324
-msgid "<a href=\"https://codex.wordpress.org/Network_Admin_Themes_Screen\">Documentation on Network Themes</a>"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/themes.php:331
-#: wp-admin/theme-install.php:184
-msgid "Filter themes list"
-msgstr ""
-
-#: wp-admin/network/themes.php:332
-msgid "Themes list navigation"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/network/themes.php:333
-#: wp-admin/theme-install.php:239
-msgid "Themes list"
-msgstr ""
-
-#: wp-admin/network/themes.php:391
-#: wp-admin/themes.php:278
-msgid "Theme deleted."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/network/themes.php:394
-msgid "%s theme deleted."
-msgid_plural "%s themes deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/network/themes.php:400
-#: wp-admin/themes.php:294
-msgid "Theme will be auto-updated."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/network/themes.php:403
-msgid "%s theme will be auto-updated."
-msgid_plural "%s themes will be auto-updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/network/themes.php:409
-#: wp-admin/themes.php:298
-msgid "Theme will no longer be auto-updated."
-msgstr ""
-
-#. translators: %s: Number of themes.
-#: wp-admin/network/themes.php:412
-msgid "%s theme will no longer be auto-updated."
-msgid_plural "%s themes will no longer be auto-updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/network/themes.php:418
-msgid "You cannot delete a theme while it is active on the main site."
-msgstr ""
-
-#: wp-admin/network/themes.php:431
-#: wp-admin/themes.php:593
-msgid "The following themes are installed but incomplete."
-msgstr ""
-
-#: wp-admin/network/upgrade.php:24
-msgid "Only use this screen once you have updated to a new version of ClassicPress through Updates/Available Updates (via the Network Administration navigation menu or the Toolbar). Clicking the Upgrade Network button will step through each site in the network, five at a time, and make sure any database updates are applied."
-msgstr ""
-
-#: wp-admin/network/upgrade.php:25
-msgid "If a version update to core has not happened, clicking this button will not affect anything."
-msgstr ""
-
-#: wp-admin/network/upgrade.php:26
-msgid "If this process fails for any reason, users logging in to their sites will force the same update."
-msgstr ""
-
-#: wp-admin/network/upgrade.php:32
-msgid "<a href=\"https://wordpress.org/documentation/article/network-admin-updates-screen/\">Documentation on Upgrade Network</a>"
-msgstr ""
-
-#: wp-admin/network/upgrade.php:74
-msgid "All done!"
-msgstr ""
-
-#. translators: 1: Site URL, 2: Server error message.
-#: wp-admin/network/upgrade.php:99
-msgid "Warning! Problem updating %1$s. Your server may not be able to connect to sites running on it. Error message: %2$s"
-msgstr ""
-
-#: wp-admin/network/upgrade.php:125
-msgid "If your browser does not start loading the next page automatically, click this link:"
-msgstr ""
-
-#: wp-admin/network/upgrade.php:125
-msgid "Next Sites"
-msgstr ""
-
-#: wp-admin/network/upgrade.php:140
-#: wp-admin/upgrade.php:140
-msgid "Database Update Required"
-msgstr ""
-
-#: wp-admin/network/upgrade.php:141
-msgid "ClassicPress has been updated! Next and final step is to individually upgrade the sites in your network."
-msgstr ""
-
-#: wp-admin/network/upgrade.php:144
-#: wp-admin/upgrade.php:142
-msgid "The database update process may take a little while, so please be patient."
-msgstr ""
-
-#: wp-admin/network/user-new.php:14
-#: wp-admin/user-new.php:16
-#: wp-admin/user-new.php:56
-msgid "Sorry, you are not allowed to add users to this network."
-msgstr ""
-
-#: wp-admin/network/user-new.php:22
-msgid "Add User will set up a new user account on the network and send that person an email with username and password."
-msgstr ""
-
-#: wp-admin/network/user-new.php:23
-msgid "Users who are signed up to the network without a site are added as subscribers to the main or primary dashboard site, giving them profile pages to manage their accounts. These users will only see Dashboard and My Sites in the main navigation until a site is created for them."
-msgstr ""
-
-#: wp-admin/network/user-new.php:29
-#: wp-admin/network/users.php:242
-msgid "<a href=\"https://codex.wordpress.org/Network_Admin_Users_Screen\">Documentation on Network Users</a>"
-msgstr ""
-
-#: wp-admin/network/user-new.php:41
-msgid "Cannot create an empty user."
-msgstr ""
-
-#: wp-admin/network/user-new.php:55
-msgid "Cannot add user."
-msgstr ""
-
-#: wp-admin/network/user-new.php:94
-#: wp-admin/user-new.php:345
-#: wp-admin/users.php:560
-msgid "Edit user"
-msgstr ""
-
-#. translators: %s: User login.
-#: wp-admin/network/users.php:87
-msgid "Warning! User cannot be modified. The user %s is a network administrator."
-msgstr ""
-
-#: wp-admin/network/users.php:231
-msgid "This table shows all users across the network and the sites to which they are assigned."
-msgstr ""
-
-#: wp-admin/network/users.php:232
-msgid "Hover over any user on the list to make the edit links appear. The Edit link on the left will take you to their Edit User profile page; the Edit link on the right by any site name goes to an Edit Site screen for that site."
-msgstr ""
-
-#: wp-admin/network/users.php:233
-msgid "You can also go to the user&#8217;s profile page by clicking on the individual username."
-msgstr ""
-
-#: wp-admin/network/users.php:234
-msgid "You can sort the table by clicking on any of the table headings and switch between list and excerpt views by using the icons above the users list."
-msgstr ""
-
-#: wp-admin/network/users.php:235
-msgid "The bulk action will permanently delete selected users, or mark/unmark those selected as spam. Spam users will have posts removed and will be unable to sign up again with the same email addresses."
-msgstr ""
-
-#: wp-admin/network/users.php:236
-msgid "You can make an existing user an additional super admin by going to the Edit User profile page and checking the box to grant that privilege."
-msgstr ""
-
-#: wp-admin/network/users.php:248
-#: wp-admin/users.php:89
-msgid "Filter users list"
-msgstr ""
-
-#: wp-admin/network/users.php:249
-#: wp-admin/users.php:90
-msgid "Users list navigation"
-msgstr ""
-
-#: wp-admin/network/users.php:250
-#: wp-admin/users.php:91
-msgid "Users list"
-msgstr ""
-
-#: wp-admin/network/users.php:262
-#: wp-admin/users.php:539
-msgid "User deleted."
-msgstr ""
-
-#: wp-admin/network/users.php:265
-msgid "Users marked as spam."
-msgstr ""
-
-#: wp-admin/network/users.php:268
-msgid "Users removed from spam."
-msgstr ""
-
-#: wp-admin/network/users.php:271
-msgid "Users deleted."
-msgstr ""
-
-#: wp-admin/options-discussion.php:25
-msgid "This screen provides many options for controlling the management and display of comments and links to your posts/pages. So many, in fact, they will not all fit here! :) Use the documentation links to get information on what each discussion setting does."
-msgstr ""
-
-#: wp-admin/options-discussion.php:26
-#: wp-admin/options-general.php:41
-#: wp-admin/options-media.php:29
-#: wp-admin/options-permalink.php:26
-#: wp-admin/options-permalink.php:46
-#: wp-admin/options-permalink.php:55
-#: wp-admin/options-reading.php:37
-#: wp-admin/options-writing.php:25
-msgid "You must click the Save Changes button at the bottom of the screen for new settings to take effect."
-msgstr ""
-
-#: wp-admin/options-discussion.php:32
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-discussion-screen/\">Documentation on Discussion Settings</a>"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:47
-#: wp-admin/options-discussion.php:51
-msgid "Default post settings"
-msgstr ""
-
-#: wp-admin/options-discussion.php:56
-msgid "Attempt to notify any blogs linked to from the post"
-msgstr ""
-
-#: wp-admin/options-discussion.php:60
-msgid "Allow link notifications from other blogs (pingbacks and trackbacks) on new posts"
-msgstr ""
-
-#: wp-admin/options-discussion.php:64
-msgid "Allow people to submit comments on new posts"
-msgstr ""
-
-#: wp-admin/options-discussion.php:66
-msgid "Individual posts may override these settings. Changes here will only be applied to new posts."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:70
-#: wp-admin/options-discussion.php:74
-msgid "Other comment settings"
-msgstr ""
-
-#: wp-admin/options-discussion.php:77
-msgid "Comment author must fill out name and email"
-msgstr ""
-
-#: wp-admin/options-discussion.php:81
-msgid "Users must be registered and logged in to comment"
-msgstr ""
-
-#: wp-admin/options-discussion.php:84
-msgid "(Signup has been disabled. Only members of this site can comment.)"
-msgstr ""
-
-#. translators: %s: Number of days.
-#: wp-admin/options-discussion.php:95
-msgid "Automatically close comments on posts older than %s days"
-msgstr ""
-
-#: wp-admin/options-discussion.php:104
-msgid "Show comments cookies opt-in checkbox, allowing comment author cookies to be set"
-msgstr ""
-
-#. translators: %s: Number of levels.
-#: wp-admin/options-discussion.php:131
-msgid "Enable threaded (nested) comments %s levels deep"
-msgstr ""
-
-#: wp-admin/options-discussion.php:143
-msgid "last"
-msgstr ""
-
-#: wp-admin/options-discussion.php:147
-msgid "first"
-msgstr ""
-
-#. translators: 1: Form field control for number of top level comments per page, 2: Form field control for the 'first' or 'last' page.
-#: wp-admin/options-discussion.php:150
-msgid "Break comments into pages with %1$s top level comments per page and the %2$s page displayed by default"
-msgstr ""
-
-#: wp-admin/options-discussion.php:164
-msgid "older"
-msgstr ""
-
-#: wp-admin/options-discussion.php:168
-msgid "newer"
-msgstr ""
-
-#. translators: %s: Form field control for 'older' or 'newer' comments.
-#: wp-admin/options-discussion.php:171
-msgid "Comments should be displayed with the %s comments at the top of each page"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:178
-#: wp-admin/options-discussion.php:182
-msgid "Email me whenever"
-msgstr ""
-
-#: wp-admin/options-discussion.php:187
-msgid "Anyone posts a comment"
-msgstr ""
-
-#: wp-admin/options-discussion.php:191
-msgid "A comment is held for moderation"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:195
-#: wp-admin/options-discussion.php:199
-msgid "Before a comment appears"
-msgstr ""
-
-#: wp-admin/options-discussion.php:204
-msgid "Comment must be manually approved"
-msgstr ""
-
-#: wp-admin/options-discussion.php:206
-msgid "Comment author must have a previously approved comment"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:210
-#: wp-admin/options-discussion.php:214
-msgid "Comment Moderation"
-msgstr ""
-
-#. translators: %s: Number of links.
-#: wp-admin/options-discussion.php:221
-msgid "Hold a comment in the queue if it contains %s or more links. (A common characteristic of comment spam is a large number of hyperlinks.)"
-msgstr ""
-
-#: wp-admin/options-discussion.php:227
-msgid "When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be held in the <a href=\"edit-comments.php?comment_status=moderated\">moderation queue</a>. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;ClassicPress&#8221;."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:234
-#: wp-admin/options-discussion.php:238
-msgid "Disallowed Comment Keys"
-msgstr ""
-
-#: wp-admin/options-discussion.php:241
-msgid "When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be put in the Trash. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;ClassicPress&#8221;."
-msgstr ""
-
-#: wp-admin/options-discussion.php:250
-msgid "Avatars"
-msgstr ""
-
-#: wp-admin/options-discussion.php:252
-msgid "An avatar is an image that can be associated with a user across multiple websites. In this area, you can choose to display avatars of users who interact with the site."
-msgstr ""
-
-#: wp-admin/options-discussion.php:266
-msgid "Avatar Display"
-msgstr ""
-
-#: wp-admin/options-discussion.php:270
-msgid "Show Avatars"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:275
-#: wp-admin/options-discussion.php:279
-msgid "Maximum Rating"
-msgstr ""
-
-#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
-#: wp-admin/options-discussion.php:286
-msgid "G &#8212; Suitable for all audiences"
-msgstr ""
-
-#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
-#: wp-admin/options-discussion.php:288
-msgid "PG &#8212; Possibly offensive, usually for audiences 13 and above"
-msgstr ""
-
-#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
-#: wp-admin/options-discussion.php:290
-msgid "R &#8212; Intended for adult audiences above 17"
-msgstr ""
-
-#. translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system
-#: wp-admin/options-discussion.php:292
-msgid "X &#8212; Even more mature than above"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-discussion.php:303
-#: wp-admin/options-discussion.php:307
-msgid "Default Avatar"
-msgstr ""
-
-#: wp-admin/options-discussion.php:312
-msgid "For users without a custom avatar of their own, you can either display a generic logo or a generated one based on their email address."
-msgstr ""
-
-#: wp-admin/options-discussion.php:317
-msgid "Mystery Person"
-msgstr ""
-
-#: wp-admin/options-discussion.php:318
-msgid "Blank"
-msgstr ""
-
-#: wp-admin/options-discussion.php:319
-msgid "Gravatar Logo"
-msgstr ""
-
-#: wp-admin/options-discussion.php:320
-msgid "Identicon (Generated)"
-msgstr ""
-
-#: wp-admin/options-discussion.php:321
-msgid "Wavatar (Generated)"
-msgstr ""
-
-#: wp-admin/options-discussion.php:322
-msgid "MonsterID (Generated)"
-msgstr ""
-
-#: wp-admin/options-discussion.php:323
-msgid "Retro (Generated)"
-msgstr ""
-
-#: wp-admin/options-discussion.php:324
-msgid "RoboHash (Generated)"
-msgstr ""
-
-#: wp-admin/options-general.php:20
-msgid "General Settings"
-msgstr ""
-
-#. translators: Date and time format for exact current time, mainly about timezones, see https://www.php.net/manual/datetime.format.php
-#: wp-admin/options-general.php:23
-msgctxt "timezone date format"
-msgid "Y-m-d H:i:s"
-msgstr ""
-
-#: wp-admin/options-general.php:31
-msgid "The fields on this screen determine some of the basics of your site setup."
-msgstr ""
-
-#: wp-admin/options-general.php:32
-msgid "Most themes show the site title at the top of every page, in the title bar of the browser, and as the identifying name for syndicated feeds. Many themes also show the tagline."
-msgstr ""
-
-#: wp-admin/options-general.php:35
-msgid "The ClassicPress URL and the site URL can be the same (example.com) or different; for example, having the ClassicPress core files (example.com/classicpress) in a subdirectory instead of the root directory."
-msgstr ""
-
-#: wp-admin/options-general.php:36
-msgid "If you want site visitors to be able to register themselves, as opposed to by the site administrator, check the membership box. A default user role can be set for all new users, whether self-registered or registered by the site admin."
-msgstr ""
-
-#: wp-admin/options-general.php:40
-msgid "UTC means Coordinated Universal Time."
-msgstr ""
-
-#: wp-admin/options-general.php:53
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-general-screen/\">Documentation on General Settings</a>"
-msgstr ""
-
-#. translators: Site tagline.
-#: wp-admin/options-general.php:75
-msgid "Just another ClassicPress site"
-msgstr ""
-
-#. translators: %s: Network title.
-#: wp-admin/options-general.php:78
-msgid "Just another %s site"
-msgstr ""
-
-#: wp-admin/options-general.php:82
-#: wp-includes/class-wp-customize-manager.php:5151
-msgid "Tagline"
-msgstr ""
-
-#: wp-admin/options-general.php:84
-msgid "In a few words, explain what this site is about."
-msgstr ""
-
-#. translators: %s: The selected image filename.
-#: wp-admin/options-general.php:119
-#: wp-admin/js/site-icon.js:161
-msgid "App icon preview: The current image has no alternative text. The file name is: %s"
-msgstr ""
-
-#. translators: %s: The selected image filename.
-#: wp-admin/options-general.php:125
-#: wp-admin/js/site-icon.js:168
-msgid "Browser icon preview: The current image has no alternative text. The file name is: %s"
-msgstr ""
-
-#. translators: %s: The selected image alt text.
-#: wp-admin/options-general.php:132
-#: wp-admin/js/site-icon.js:150
-msgid "App icon preview: Current image: %s"
-msgstr ""
-
-#. translators: %s: The selected image alt text.
-#: wp-admin/options-general.php:138
-#: wp-admin/js/site-icon.js:155
-msgid "Browser icon preview: Current image: %s"
-msgstr ""
-
-#: wp-admin/options-general.php:165
-#: wp-admin/options-general.php:174
-msgid "Choose a Site Icon"
-msgstr ""
-
-#: wp-admin/options-general.php:166
-#: wp-admin/options-general.php:172
-msgid "Change Site Icon"
-msgstr ""
-
-#: wp-admin/options-general.php:167
-msgid "Set as Site Icon"
-msgstr ""
-
-#: wp-admin/options-general.php:182
-msgid "Remove Site Icon"
-msgstr ""
-
-#. translators: %s: Site Icon size in pixels.
-#: wp-admin/options-general.php:189
-#: wp-includes/class-wp-customize-manager.php:5195
-msgid "The Site Icon is what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. It should be square and at least %s pixels."
-msgstr ""
-
-#: wp-admin/options-general.php:212
-#: wp-includes/class-wp-xmlrpc-server.php:532
-msgid "ClassicPress Address (URL)"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/options-general.php:224
-msgid "Enter the same address here unless you <a href=\"%s\">want your site home page to be different from your ClassicPress installation directory</a>."
-msgstr ""
-
-#: wp-admin/options-general.php:225
-msgid "https://wordpress.org/documentation/article/giving-wordpress-its-own-directory/"
-msgstr ""
-
-#: wp-admin/options-general.php:236
-msgid "Administration Email Address"
-msgstr ""
-
-#. translators: %s: New admin email.
-#: wp-admin/options-general.php:248
-msgid "There is a pending change of the admin email to %s."
-msgstr ""
-
-#: wp-admin/options-general.php:285
-#: wp-admin/options-general.php:288
-msgid "Custom Login Image"
-msgstr ""
-
-#: wp-admin/options-general.php:290
-msgid "If you choose an image here and enable this option, then that image will be shown at the top of the login page instead of the ClassicPress logo."
-msgstr ""
-
-#: wp-admin/options-general.php:292
-#: wp-admin/options-general.php:644
-#: wp-includes/classicpress/class-cp-debug-compat.php:86
-#: wp-includes/classicpress/class-cp-debug-compat.php:122
-msgid "Learn more."
-msgstr ""
-
-#: wp-admin/options-general.php:297
-msgid "No custom image: use the <strong>ClassicPress logo</strong>"
-msgstr ""
-
-#: wp-admin/options-general.php:307
-msgid "Use my custom image as a <strong>logo</strong>"
-msgstr ""
-
-#: wp-admin/options-general.php:317
-msgid "Use my custom image as a <strong>banner</strong>"
-msgstr ""
-
-#: wp-admin/options-general.php:323
-msgid "Clear Image"
-msgstr ""
-
-#: wp-admin/options-general.php:327
-msgid "Changing the custom login image requires JavaScript to be enabled."
-msgstr ""
-
-#: wp-admin/options-general.php:345
-msgid "Anyone can register"
-msgstr ""
-
-#: wp-admin/options-general.php:350
-msgid "New User Default Role"
-msgstr ""
-
-#. translators: 1: WPLANG, 2: wp-config.php
-#: wp-admin/options-general.php:392
-msgid "The %1$s constant in your %2$s file is no longer needed."
-msgstr ""
-
-#. translators: %s: UTC abbreviation
-#: wp-admin/options-general.php:436
-msgid "Choose either a city in the same timezone as you or a %s (Coordinated Universal Time) time offset."
-msgstr ""
-
-#. translators: %s: UTC time.
-#: wp-admin/options-general.php:447
-msgid "Universal time is %s."
-msgstr ""
-
-#. translators: %s: Local time.
-#: wp-admin/options-general.php:457
-msgid "Local time is %s."
-msgstr ""
-
-#: wp-admin/options-general.php:473
-msgid "This timezone is currently in daylight saving time."
-msgstr ""
-
-#: wp-admin/options-general.php:475
-msgid "This timezone is currently in standard time."
-msgstr ""
-
-#. translators: %s: Date and time.
-#: wp-admin/options-general.php:488
-msgid "Daylight saving time begins on: %s."
-msgstr ""
-
-#. translators: %s: Date and time.
-#: wp-admin/options-general.php:490
-msgid "Standard time begins on: %s."
-msgstr ""
-
-#: wp-admin/options-general.php:496
-msgid "This timezone does not observe daylight saving time."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:507
-#: wp-admin/options-general.php:512
-#: wp-includes/class-wp-xmlrpc-server.php:599
-msgid "Date Format"
-msgstr ""
-
-#: wp-admin/options-general.php:539
-#: wp-admin/options-general.php:587
-msgid "Custom:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:541
-msgid "enter a custom date format in the following field"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:545
-msgid "Custom date format:"
-msgstr ""
-
-#: wp-admin/options-general.php:549
-#: wp-admin/options-general.php:597
-msgid "Preview:"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:556
-#: wp-admin/options-general.php:561
-#: wp-includes/class-wp-xmlrpc-server.php:604
-msgid "Time Format"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:589
-msgid "enter a custom time format in the following field"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-general.php:593
-msgid "Custom time format:"
-msgstr ""
-
-#: wp-admin/options-general.php:600
-msgid "<a href=\"https://wordpress.org/documentation/article/customize-date-and-time-format/\">Documentation on date and time formatting</a>."
-msgstr ""
-
-#: wp-admin/options-general.php:606
-msgid "Week Starts On"
-msgstr ""
-
-#: wp-admin/options-general.php:624
-msgid "Blocks Compatibility"
-msgstr ""
-
-#: wp-admin/options-general.php:630
-msgctxt "Block Compatibility"
-msgid "Off"
-msgstr ""
-
-#: wp-admin/options-general.php:631
-msgctxt "Block Compatibility"
-msgid "On"
-msgstr ""
-
-#: wp-admin/options-general.php:632
-msgctxt "Block Compatibility"
-msgid "Troubleshooting"
-msgstr ""
-
-#: wp-admin/options-general.php:642
-msgid "ClassicPress is incompatible with the block editor. When blocks compatibility is turned on (default), it allows more plugins and themes to work but block-related features will not work. "
-msgstr ""
-
-#: wp-admin/options-media.php:17
-msgid "Media Settings"
-msgstr ""
-
-#: wp-admin/options-media.php:20
-msgid "You can set maximum sizes for images inserted into your written content; you can also insert an image as Full Size."
-msgstr ""
-
-#: wp-admin/options-media.php:26
-msgid "Uploading Files allows you to choose the folder and path for storing your uploaded files."
-msgstr ""
-
-#: wp-admin/options-media.php:41
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-media-screen/\">Documentation on Media Settings</a>"
-msgstr ""
-
-#: wp-admin/options-media.php:55
-msgid "Image sizes"
-msgstr ""
-
-#: wp-admin/options-media.php:56
-msgid "The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-media.php:60
-#: wp-admin/options-media.php:64
-msgid "Thumbnail size"
-msgstr ""
-
-#: wp-admin/options-media.php:67
-#: wp-includes/class-wp-editor.php:1330
-#: wp-includes/media-template.php:1193
-#: wp-includes/widgets/class-wp-widget-media-image.php:78
-msgid "Width"
-msgstr ""
-
-#: wp-admin/options-media.php:70
-#: wp-includes/class-wp-editor.php:1329
-#: wp-includes/media-template.php:1198
-#: wp-includes/widgets/class-wp-widget-media-image.php:84
-msgid "Height"
-msgstr ""
-
-#: wp-admin/options-media.php:74
-msgid "Crop thumbnail to exact dimensions (normally thumbnails are proportional)"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-media.php:79
-#: wp-admin/options-media.php:83
-msgid "Medium size"
-msgstr ""
-
-#: wp-admin/options-media.php:86
-#: wp-admin/options-media.php:102
-msgid "Max Width"
-msgstr ""
-
-#: wp-admin/options-media.php:89
-#: wp-admin/options-media.php:105
-msgid "Max Height"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-media.php:95
-#: wp-admin/options-media.php:99
-msgid "Large size"
-msgstr ""
-
-#: wp-admin/options-media.php:119
-msgid "Embeds"
-msgstr ""
-
-#: wp-admin/options-media.php:126
-msgid "Uploading Files"
-msgstr ""
-
-#: wp-admin/options-media.php:138
-msgid "Store uploads in this folder"
-msgstr ""
-
-#. translators: %s: wp-content/uploads
-#: wp-admin/options-media.php:143
-msgid "Default is %s"
-msgstr ""
-
-#: wp-admin/options-media.php:150
-msgid "Full URL path to files"
-msgstr ""
-
-#: wp-admin/options-media.php:152
-msgid "Configuring this is optional. By default, it should be blank."
-msgstr ""
-
-#: wp-admin/options-media.php:163
-msgid "Organize my uploads into month- and year-based folders"
-msgstr ""
-
-#: wp-admin/options-permalink.php:17
-#: wp-admin/options-permalink.php:33
-msgid "Permalink Settings"
-msgstr ""
-
-#: wp-admin/options-permalink.php:24
-msgid "Permalinks are the permanent URLs to your individual pages and blog posts, as well as your category and tag archives. A permalink is the web address used to link to your content. The URL to each post should be permanent, and never change &#8212; hence the name permalink."
-msgstr ""
-
-#: wp-admin/options-permalink.php:25
-msgid "This screen allows you to choose your permalink structure. You can choose from common settings or create custom URL structures."
-msgstr ""
-
-#: wp-admin/options-permalink.php:34
-msgid "Permalinks can contain useful information, such as the post date, title, or other elements. You can choose from any of the suggested permalink formats, or you can craft your own if you select Custom Structure."
-msgstr ""
-
-#. translators: %s: Percent sign (%).
-#: wp-admin/options-permalink.php:37
-msgid "If you pick an option other than Plain, your general URL path with structure tags (terms surrounded by %s) will also appear in the custom structure field and your path can be further modified there."
-msgstr ""
-
-#. translators: 1: %category%, 2: %tag%
-#: wp-admin/options-permalink.php:42
-msgid "When you assign multiple categories or tags to a post, only one can show up in the permalink: the lowest numbered category. This applies if your custom structure includes %1$s or %2$s."
-msgstr ""
-
-#: wp-admin/options-permalink.php:53
-msgid "Custom Structures"
-msgstr ""
-
-#: wp-admin/options-permalink.php:54
-msgid "The Optional fields let you customize the &#8220;category&#8221; and &#8220;tag&#8221; base names that will appear in archive URLs. For example, the page listing all posts in the &#8220;Uncategorized&#8221; category could be <code>/topics/uncategorized</code> instead of <code>/category/uncategorized</code>."
-msgstr ""
-
-#: wp-admin/options-permalink.php:60
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-permalinks-screen/\">Documentation on Permalinks Settings</a>"
-msgstr ""
-
-#: wp-admin/options-permalink.php:61
-msgid "<a href=\"https://wordpress.org/documentation/article/customize-permalinks/\">Documentation on Using Permalinks</a>"
-msgstr ""
-
-#: wp-admin/options-permalink.php:64
-msgid "<a href=\"https://wordpress.org/documentation/article/nginx/\">Documentation on Nginx configuration</a>."
-msgstr ""
-
-#: wp-admin/options-permalink.php:176
-msgid "Permalink structure updated."
-msgstr ""
-
-#. translators: %s: web.config
-#. translators: %s: .htaccess
-#: wp-admin/options-permalink.php:183
-#: wp-admin/options-permalink.php:196
-msgid "You should update your %s file now."
-msgstr ""
-
-#. translators: %s: web.config
-#: wp-admin/options-permalink.php:189
-msgid "Permalink structure updated. Remove write access on %s file now!"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/options-permalink.php:226
-msgid "ClassicPress offers you the ability to create a custom URL structure for your permalinks and archives. Custom URL structures can improve the aesthetics, usability, and forward-compatibility of your links. A <a href=\"%s\">number of tags are available</a>, and here are some examples to get you started."
-msgstr ""
-
-#: wp-admin/options-permalink.php:227
-msgid "https://wordpress.org/support/article/using-permalinks/"
-msgstr ""
-
-#: wp-admin/options-permalink.php:246
-msgid "Plain"
-msgstr ""
-
-#: wp-admin/options-permalink.php:252
-msgid "Day and name"
-msgstr ""
-
-#: wp-admin/options-permalink.php:254
-#: wp-admin/options-permalink.php:260
-#: wp-admin/options-permalink.php:272
-msgctxt "sample permalink structure"
-msgid "sample-post"
-msgstr ""
-
-#: wp-admin/options-permalink.php:258
-msgid "Month and name"
-msgstr ""
-
-#: wp-admin/options-permalink.php:264
-msgid "Numeric"
-msgstr ""
-
-#: wp-admin/options-permalink.php:265
-#: wp-admin/options-permalink.php:266
-msgctxt "sample permalink base"
-msgid "archives"
-msgstr ""
-
-#: wp-admin/options-permalink.php:270
-msgid "Post name"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:280
-msgid "%s (The year of the post, four digits, for example 2004.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:282
-msgid "%s (Month of the year, for example 05.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:284
-msgid "%s (Day of the month, for example 28.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:286
-msgid "%s (Hour of the day, for example 15.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:288
-msgid "%s (Minute of the hour, for example 43.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:290
-msgid "%s (Second of the minute, for example 33.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:292
-msgid "%s (The unique ID of the post, for example 423.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:294
-msgid "%s (The sanitized post title (slug).)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:296
-msgid "%s (Category slug. Nested sub-categories appear as nested directories in the URL.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:298
-msgid "%s (A sanitized version of the author name.)"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:311
-msgid "%s added to permalink structure"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:313
-msgid "%s removed from permalink structure"
-msgstr ""
-
-#. translators: %s: Permalink structure tag.
-#: wp-admin/options-permalink.php:315
-msgid "%s (already used in permalink structure)"
-msgstr ""
-
-#: wp-admin/options-permalink.php:317
-msgid "Common Settings"
-msgstr ""
-
-#. translators: %s: %postname%
-#: wp-admin/options-permalink.php:322
-msgid "Select the permalink structure for your website. Including the %s tag makes links easy to understand, and can help your posts rank higher in search engines."
-msgstr ""
-
-#: wp-admin/options-permalink.php:365
-msgid "Custom Structure"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-permalink.php:370
-msgid "Customize permalink structure by selecting available tags"
-msgstr ""
-
-#: wp-admin/options-permalink.php:386
-msgid "Available tags:"
-msgstr ""
-
-#: wp-admin/options-permalink.php:412
-msgid "Optional"
-msgstr ""
-
-#. translators: %s: Placeholder that must come at the start of the URL.
-#: wp-admin/options-permalink.php:417
-msgid "If you like, you may enter custom structures for your category and tag URLs here. For example, using <code>topics</code> as your category base would make your category links like <code>%s/topics/uncategorized/</code>. If you leave these blank the defaults will be used."
-msgstr ""
-
-#. translators: Prefix for category permalinks.
-#: wp-admin/options-permalink.php:427
-msgid "Category base"
-msgstr ""
-
-#: wp-admin/options-permalink.php:439
-msgid "Tag base"
-msgstr ""
-
-#. translators: 1: web.config, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A, 5: Element code.
-#: wp-admin/options-permalink.php:466
-msgid "<strong>Error:</strong> Your %1$s file is not <a href=\"%2$s\">writable</a>, so updating it automatically was not possible. This is the URL rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file."
-msgstr ""
-
-#: wp-admin/options-permalink.php:468
-#: wp-admin/options-permalink.php:500
-#: wp-admin/options-permalink.php:536
-msgid "https://wordpress.org/support/article/changing-file-permissions/"
-msgstr ""
-
-#: wp-admin/options-permalink.php:478
-#: wp-admin/options-permalink.php:510
-#: wp-admin/options-permalink.php:545
-msgid "Rewrite rules:"
-msgstr ""
-
-#. translators: %s: web.config
-#: wp-admin/options-permalink.php:489
-msgid "If you temporarily make your %s file writable to generate rewrite rules automatically, do not forget to revert the permissions after the rule has been saved."
-msgstr ""
-
-#. translators: 1: Documentation URL, 2: web.config, 3: Ctrl + A, 4: ⌘ + A
-#: wp-admin/options-permalink.php:499
-msgid "<strong>Error:</strong> The root directory of your site is not <a href=\"%1$s\">writable</a>, so creating a file automatically was not possible. This is the URL rewrite rule you should have in your %2$s file. Create a new file called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file."
-msgstr ""
-
-#. translators: %s: web.config
-#: wp-admin/options-permalink.php:521
-msgid "If you temporarily make your site&#8217;s root directory writable to generate the %s file automatically, do not forget to revert the permissions after the file has been created."
-msgstr ""
-
-#. translators: 1: .htaccess, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A
-#: wp-admin/options-permalink.php:534
-msgid "<strong>Error:</strong> Your %1$s file is not <a href=\"%2$s\">writable</a>, so updating it automatically was not possible. These are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all."
-msgstr ""
-
-#: wp-admin/options-privacy.php:13
-#: wp-admin/privacy-policy-guide.php:13
-msgid "Sorry, you are not allowed to manage privacy options on this site."
-msgstr ""
-
-#: wp-admin/options-privacy.php:40
-msgid "The Privacy screen lets you either build a new privacy-policy page or choose one you already have to show."
-msgstr ""
-
-#: wp-admin/options-privacy.php:41
-msgid "This screen includes suggestions to help you write your own privacy policy. However, it is your responsibility to use these resources correctly, to provide the information required by your privacy policy, and to keep this information current and accurate."
-msgstr ""
-
-#: wp-admin/options-privacy.php:47
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-privacy-screen/\">Documentation on Privacy Settings</a>"
-msgstr ""
-
-#: wp-admin/options-privacy.php:57
-#: wp-admin/privacy.php:25
-msgid "Privacy Policy page updated successfully."
-msgstr ""
-
-#. translators: %s: URL to Customizer -> Menus.
-#: wp-admin/options-privacy.php:74
-msgid "Privacy Policy page setting updated successfully. Remember to <a href=\"%s\">update your menus</a>!"
-msgstr ""
-
-#: wp-admin/options-privacy.php:102
-#: wp-admin/privacy.php:75
-msgid "Unable to create a Privacy Policy page."
-msgstr ""
-
-#: wp-admin/options-privacy.php:126
-#: wp-admin/privacy.php:99
-msgid "The currently selected Privacy Policy page does not exist. Please create or select a new page."
-msgstr ""
-
-#. translators: %s: URL to Pages Trash.
-#: wp-admin/options-privacy.php:136
-msgid "The currently selected Privacy Policy page is in the Trash. Please create or select a new Privacy Policy page or <a href=\"%s\">restore the current page</a>."
-msgstr ""
-
-#. translators: Tab heading for Site Health Status page.
-#: wp-admin/options-privacy.php:165
-#: wp-admin/privacy-policy-guide.php:48
-msgctxt "Privacy Settings"
-msgid "Settings"
-msgstr ""
-
-#. translators: Tab heading for Site Health Status page.
-#: wp-admin/options-privacy.php:172
-#: wp-admin/privacy-policy-guide.php:55
-msgctxt "Privacy Settings"
-msgid "Policy Guide"
-msgstr ""
-
-#: wp-admin/options-privacy.php:181
-#: wp-admin/privacy-policy-guide.php:64
-msgid "The Privacy Settings require JavaScript."
-msgstr ""
-
-#: wp-admin/options-privacy.php:185
-#: wp-admin/privacy.php:120
-msgid "Privacy Settings"
-msgstr ""
-
-#: wp-admin/options-privacy.php:187
-msgid "As a website owner, you may need to follow national or international privacy laws. For example, you may need to create and display a privacy policy."
-msgstr ""
-
-#: wp-admin/options-privacy.php:188
-#: wp-admin/privacy.php:131
-msgid "If you already have a Privacy Policy page, please select it below. If not, please create one."
-msgstr ""
-
-#: wp-admin/options-privacy.php:191
-msgid "The new page will include help and suggestions for your privacy policy."
-msgstr ""
-
-#: wp-admin/options-privacy.php:192
-msgid "However, it is your responsibility to use those resources correctly, to provide the information that your privacy policy requires, and to keep that information current and accurate."
-msgstr ""
-
-#: wp-admin/options-privacy.php:195
-msgid "After your Privacy Policy page is set, you should edit it."
-msgstr ""
-
-#: wp-admin/options-privacy.php:196
-msgid "You should also review your privacy policy from time to time, especially after installing or updating any themes or plugins. There may be changes or new suggested information for you to consider adding to your policy."
-msgstr ""
-
-#. translators: 1: URL to edit Privacy Policy page, 2: URL to view Privacy Policy page.
-#. translators: 1: URL to edit page, 2: URL to view page
-#: wp-admin/options-privacy.php:215
-#: wp-admin/privacy.php:160
-msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">view</a> your Privacy Policy page content."
-msgstr ""
-
-#. translators: 1: URL to edit Privacy Policy page, 2: URL to preview Privacy Policy page.
-#. translators: 1: URL to edit page, 2: URL to preview page
-#: wp-admin/options-privacy.php:222
-#: wp-admin/privacy.php:163
-msgid "<a href=\"%1$s\">Edit</a> or <a href=\"%2$s\">preview</a> your Privacy Policy page content."
-msgstr ""
-
-#. translators: 1: Privacy Policy guide URL, 2: Additional link attributes, 3: Accessibility text.
-#: wp-admin/options-privacy.php:233
-msgid "Need help putting together your new Privacy Policy page? <a href=\"%1$s\" %2$s>Check out our privacy policy guide%3$s</a> for recommendations on what content to include, along with policies suggested by your plugins and theme."
-msgstr ""
-
-#: wp-admin/options-privacy.php:259
-msgid "Create a new Privacy Policy page"
-msgstr ""
-
-#: wp-admin/options-privacy.php:261
-#: wp-admin/privacy.php:241
-msgid "There are no pages."
-msgstr ""
-
-#: wp-admin/options-privacy.php:271
-msgid "Create"
-msgstr ""
-
-#: wp-admin/options-privacy.php:282
-#: wp-admin/privacy.php:190
-msgid "Change your Privacy Policy page"
-msgstr ""
-
-#: wp-admin/options-privacy.php:284
-#: wp-admin/privacy.php:192
-msgid "Select a Privacy Policy page"
-msgstr ""
-
-#: wp-admin/options-privacy.php:305
-#: wp-admin/privacy.php:229
-msgid "Use This Page"
-msgstr ""
-
-#: wp-admin/options-reading.php:17
-msgid "Reading Settings"
-msgstr ""
-
-#: wp-admin/options-reading.php:26
-msgid "This screen contains the settings that affect the display of your content."
-msgstr ""
-
-#. translators: %s: URL to create a new page.
-#: wp-admin/options-reading.php:29
-msgid "You can choose what&#8217;s displayed on the homepage of your site. It can be posts in reverse chronological order (classic blog), or a fixed/static page. To set a static homepage, you first need to create two <a href=\"%s\">Pages</a>. One will become the homepage, and the other will be where your posts are displayed."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/options-reading.php:34
-msgid "You can also control the display of your content in RSS feeds, including the maximum number of posts to display and whether to show full text or an excerpt. <a href=\"%s\">Learn more about feeds</a>."
-msgstr ""
-
-#: wp-admin/options-reading.php:35
-#: wp-admin/options-reading.php:184
-msgid "https://wordpress.org/documentation/article/wordpress-feeds/"
-msgstr ""
-
-#: wp-admin/options-reading.php:45
-msgid "You can choose whether or not your site will be crawled by robots, ping services, and spiders. If you want those services to ignore your site, click the checkbox next to &#8220;Discourage search engines from indexing this site&#8221; and click the Save Changes button at the bottom of the screen."
-msgstr ""
-
-#: wp-admin/options-reading.php:46
-msgid "Note that even when set to discourage search engines, your site is still visible on the web and not all search engines adhere to this directive."
-msgstr ""
-
-#: wp-admin/options-reading.php:47
-msgid "When this setting is in effect, a reminder is shown in the At a Glance box of the Dashboard that says, &#8220;Search engines discouraged&#8221;, to remind you that you have directed search engines to not crawl your site."
-msgstr ""
-
-#: wp-admin/options-reading.php:53
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-reading-screen/\">Documentation on Reading Settings</a>"
-msgstr ""
-
-#: wp-admin/options-reading.php:68
-msgid "Encoding for pages and feeds"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-reading.php:87
-#: wp-admin/options-reading.php:92
-#: wp-includes/class-wp-customize-manager.php:5640
-msgid "Your homepage displays"
-msgstr ""
-
-#: wp-admin/options-reading.php:97
-#: wp-includes/class-wp-customize-manager.php:5644
-msgid "Your latest posts"
-msgstr ""
-
-#. translators: %s: URL to Pages screen.
-#: wp-admin/options-reading.php:105
-msgid "A <a href=\"%s\">static page</a> (select below)"
-msgstr ""
-
-#. translators: %s: Select field to choose the front page.
-#: wp-admin/options-reading.php:116
-msgid "Homepage: %s"
-msgstr ""
-
-#. translators: %s: Select field to choose the page for posts.
-#: wp-admin/options-reading.php:133
-msgid "Posts page: %s"
-msgstr ""
-
-#: wp-admin/options-reading.php:148
-msgid "<strong>Warning:</strong> these pages should not be the same!"
-msgstr ""
-
-#: wp-admin/options-reading.php:151
-msgid "<strong>Warning:</strong> these pages should not be the same as your Privacy Policy page!"
-msgstr ""
-
-#: wp-admin/options-reading.php:157
-msgid "Blog pages show at most"
-msgstr ""
-
-#: wp-admin/options-reading.php:159
-msgid "posts"
-msgstr ""
-
-#: wp-admin/options-reading.php:163
-msgid "Syndication feeds show the most recent"
-msgstr ""
-
-#: wp-admin/options-reading.php:164
-msgid "items"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-reading.php:167
-#: wp-admin/options-reading.php:172
-msgid "For each post in a feed, include"
-msgstr ""
-
-#: wp-admin/options-reading.php:176
-msgid "Full text"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/options-reading.php:183
-msgid "Your theme determines how content is displayed in browsers. <a href=\"%s\">Learn more about feeds</a>."
-msgstr ""
-
-#: wp-admin/options-writing.php:17
-msgid "Writing Settings"
-msgstr ""
-
-#: wp-admin/options-writing.php:24
-msgid "You can submit content in several different ways; this screen holds the settings for all of them. The top section controls the editor within the dashboard, while the rest control external publishing methods. For more information on any of these methods, use the documentation links."
-msgstr ""
-
-#: wp-admin/options-writing.php:34
-msgid "Post Via Email"
-msgstr ""
-
-#: wp-admin/options-writing.php:35
-msgid "Post via email settings allow you to send your ClassicPress installation an email with the content of your post. You must set up a secret email account with POP3 access to use this, and any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret."
-msgstr ""
-
-#: wp-admin/options-writing.php:45
-#: wp-admin/options-writing.php:207
-msgid "Update Services"
-msgstr ""
-
-#: wp-admin/options-writing.php:46
-msgid "If desired, ClassicPress will automatically alert various services of your new posts."
-msgstr ""
-
-#: wp-admin/options-writing.php:53
-msgid "<a href=\"https://wordpress.org/documentation/article/settings-writing-screen/\">Documentation on Writing Settings</a>"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/options-writing.php:69
-#: wp-admin/options-writing.php:73
-msgid "Formatting"
-msgstr ""
-
-#: wp-admin/options-writing.php:78
-msgid "Convert emoticons like <code>:-)</code> and <code>:-P</code> to graphics on display"
-msgstr ""
-
-#: wp-admin/options-writing.php:79
-msgid "ClassicPress should correct invalidly nested XHTML automatically"
-msgstr ""
-
-#: wp-admin/options-writing.php:84
-msgid "Default Post Category"
-msgstr ""
-
-#: wp-admin/options-writing.php:104
-msgid "Default Post Format"
-msgstr ""
-
-#: wp-admin/options-writing.php:118
-msgid "Default Link Category"
-msgstr ""
-
-#: wp-admin/options-writing.php:146
-msgid "Post via email"
-msgstr ""
-
-#. translators: 1, 2, 3: Examples of random email addresses.
-#: wp-admin/options-writing.php:151
-msgid "To post to ClassicPress by email, you must set up a secret email account with POP3 access. Any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret. Here are three random strings you could use: %1$s, %2$s, %3$s."
-msgstr ""
-
-#: wp-admin/options-writing.php:161
-msgid "Mail Server"
-msgstr ""
-
-#: wp-admin/options-writing.php:163
-msgid "Port"
-msgstr ""
-
-#: wp-admin/options-writing.php:168
-msgid "Login Name"
-msgstr ""
-
-#: wp-admin/options-writing.php:178
-msgid "Default Mail Category"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/options-writing.php:215
-msgid "When you publish a new post, ClassicPress automatically notifies the following site update services. For more about this, see the <a href=\"%s\">Update Services</a> documentation article. Separate multiple service URLs with line breaks."
-msgstr ""
-
-#: wp-admin/options-writing.php:216
-#: wp-admin/options-writing.php:230
-msgid "https://wordpress.org/documentation/article/update-services/"
-msgstr ""
-
-#. translators: 1: Documentation URL, 2: URL to Reading Settings screen.
-#: wp-admin/options-writing.php:229
-msgid "ClassicPress is not notifying any <a href=\"%1$s\">Update Services</a> because of your site&#8217;s <a href=\"%2$s\">visibility settings</a>."
-msgstr ""
-
-#: wp-admin/options.php:227
-#: wp-includes/comment.php:1330
-msgid "Please consider writing more inclusive code."
-msgstr ""
-
-#. translators: %s: The options page name.
-#: wp-admin/options.php:252
-msgid "<strong>Error:</strong> The %s options page is not in the allowed options list."
-msgstr ""
-
-#: wp-admin/options.php:260
-msgid "Sorry, you are not allowed to modify unregistered settings for this site."
-msgstr ""
-
-#. translators: %s: The option/setting.
-#: wp-admin/options.php:311
-msgid "The %s setting is unregistered. Unregistered settings are deprecated. See https://developer.wordpress.org/plugins/settings/settings-api/"
-msgstr ""
-
-#: wp-admin/options.php:340
-msgid "Settings save failed."
-msgstr ""
-
-#: wp-admin/options.php:363
-msgid "All Settings"
-msgstr ""
-
-#: wp-admin/options.php:366
-msgid "This page allows direct access to your site settings. You can break things here. Please be cautious!"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:22
-msgid "Edit Plugins"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:127
-msgid "You can use the plugin file editor to make changes to any of your plugins&#8217; individual PHP files. Be aware that if you make changes, plugins updates will overwrite your customizations."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:128
-msgid "Choose a plugin to edit from the dropdown menu and click the Select button. Click once on any file name to load it in the editor, and make your changes. Do not forget to save your changes (Update File) when you are finished."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:129
-msgid "The documentation menu below the editor lists the PHP functions recognized in the plugin file. Clicking Look Up takes you to a web page about that particular function."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:130
-#: wp-admin/theme-editor.php:33
-#: wp-includes/class-wp-customize-manager.php:5698
-#: wp-includes/widgets/class-wp-widget-custom-html.php:323
-msgid "When using a keyboard to navigate:"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:132
-#: wp-admin/theme-editor.php:35
-#: wp-includes/class-wp-customize-manager.php:5700
-#: wp-includes/widgets/class-wp-widget-custom-html.php:325
-msgid "In the editing area, the Tab key enters a tab character."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:133
-#: wp-admin/theme-editor.php:36
-#: wp-includes/class-wp-customize-manager.php:5701
-#: wp-includes/widgets/class-wp-widget-custom-html.php:326
-msgid "To move away from this area, press the Esc key followed by the Tab key."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:134
-#: wp-admin/theme-editor.php:37
-#: wp-includes/class-wp-customize-manager.php:5702
-#: wp-includes/widgets/class-wp-widget-custom-html.php:327
-msgid "Screen reader users: when in forms mode, you may need to press the Esc key twice."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:136
-msgid "If you want to make changes but do not want them to be overwritten when the plugin is updated, you may be ready to think about writing your own plugin. For information on how to edit plugins, write your own from scratch, or just better understand their anatomy, check out the links below."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:137
-#: wp-admin/theme-editor.php:46
-msgid "Any edits to files from this screen will be reflected on all sites in the network."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:143
-msgid "<a href=\"https://wordpress.org/documentation/article/plugins-editor-screen/\">Documentation on Editing Plugins</a>"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:144
-msgid "<a href=\"https://developer.wordpress.org/plugins/\">Documentation on Writing Plugins</a>"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:170
-#: wp-admin/theme-editor.php:169
-msgid "Function Name&hellip;"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:191
-#: wp-admin/theme-editor.php:198
-msgid "There was an error while trying to update the file. You may need to fix something and try updating again."
-msgstr ""
-
-#. translators: %s: Plugin file name.
-#: wp-admin/plugin-editor.php:203
-msgid "Editing %s (active)"
-msgstr ""
-
-#. translators: %s: Plugin file name.
-#: wp-admin/plugin-editor.php:206
-msgid "Browsing %s (active)"
-msgstr ""
-
-#. translators: %s: Plugin file name.
-#: wp-admin/plugin-editor.php:211
-msgid "Editing %s (inactive)"
-msgstr ""
-
-#. translators: %s: Plugin file name.
-#: wp-admin/plugin-editor.php:214
-msgid "Browsing %s (inactive)"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:222
-msgid "Select plugin to edit:"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:245
-msgid "Plugin Files"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:266
-#: wp-admin/theme-editor.php:290
-msgid "Selected file content:"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:275
-#: wp-admin/theme-editor.php:299
-msgid "Documentation:"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:277
-#: wp-admin/theme-editor.php:301
-msgid "Look Up"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:285
-msgid "<strong>Warning:</strong> Making changes to active plugins is not recommended."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:290
-#: wp-admin/theme-editor.php:320
-msgid "Update File"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:330
-#: wp-admin/theme-editor.php:364
-msgid "Heads up!"
-msgstr ""
-
-#: wp-admin/plugin-editor.php:331
-msgid "You appear to be making direct edits to your plugin in the ClassicPress dashboard. Editing plugins directly is not recommended as it may introduce incompatibilities that break your site and your changes may be lost in future updates."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:332
-msgid "If you absolutely have to make direct edits to this plugin, use a file manager to create a copy with a new name and hang on to the original. That way, you can re-enable a functional version if something goes wrong."
-msgstr ""
-
-#: wp-admin/plugin-editor.php:336
-#: wp-admin/theme-editor.php:385
-msgid "I understand"
-msgstr ""
-
-#: wp-admin/plugin-install.php:51
-msgid "Add Plugins"
-msgstr ""
-
-#. translators: %s: https://wordpress.org/plugins
-#: wp-admin/plugin-install.php:97
-msgid "Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the <a href=\"%s\">ClassicPress Plugin Directory</a> are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!"
-msgstr ""
-
-#: wp-admin/plugin-install.php:100
-msgid "You can find new plugins to install by searching or browsing the directory right here in your own Plugins section."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/plugin-install.php:100
-#: wp-admin/plugins.php:546
-#: wp-admin/theme-install.php:113
-#: wp-admin/themes.php:138
-#: wp-includes/class-wp-customize-nav-menus.php:1178
-#: wp-includes/class-wp-customize-widgets.php:866
-#: wp-includes/customize/class-wp-customize-themes-section.php:138
-#: wp-includes/customize/class-wp-customize-themes-section.php:163
-msgid "The search results will be updated as you type."
-msgstr ""
-
-#: wp-admin/plugin-install.php:107
-msgid "Adding Plugins"
-msgstr ""
-
-#: wp-admin/plugin-install.php:109
-msgid "If you know what you are looking for, Search is your best bet. The Search screen has options to search the ClassicPress Plugin Directory for a particular Term, Author, or Tag. You can also search the directory by selecting popular tags. Tags in larger type mean more plugins have been labeled with that tag."
-msgstr ""
-
-#: wp-admin/plugin-install.php:110
-msgid "If you just want to get an idea of what&#8217;s available, you can browse Featured and Popular plugins by using the links above the plugins list. These sections rotate regularly."
-msgstr ""
-
-#: wp-admin/plugin-install.php:111
-msgid "You can also browse a user&#8217;s favorite plugins, by using the Favorites link above the plugins list and entering their WordPress.org username."
-msgstr ""
-
-#: wp-admin/plugin-install.php:112
-msgid "If you want to install a plugin that you&#8217;ve downloaded elsewhere, click the Upload Plugin button above the plugins list. You will be prompted to upload the .zip package, and once uploaded, you can activate the new plugin."
-msgstr ""
-
-#: wp-admin/plugin-install.php:118
-msgid "<a href=\"https://wordpress.org/documentation/article/plugins-add-new-screen/\">Documentation on Installing Plugins</a>"
-msgstr ""
-
-#: wp-admin/plugin-install.php:124
-#: wp-admin/plugins.php:594
-msgid "Filter plugins list"
-msgstr ""
-
-#: wp-admin/plugin-install.php:125
-#: wp-admin/plugins.php:595
-msgid "Plugins list navigation"
-msgstr ""
-
-#: wp-admin/plugin-install.php:126
-#: wp-admin/plugins.php:596
-msgid "Plugins list"
-msgstr ""
-
-#: wp-admin/plugin-install.php:148
-msgid "Browse Plugins"
-msgstr ""
-
-#: wp-admin/plugins.php:48
-#: wp-admin/plugins.php:176
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:708
-msgid "Sorry, you are not allowed to activate this plugin."
-msgstr ""
-
-#: wp-admin/plugins.php:92
-msgid "Sorry, you are not allowed to activate plugins for this site."
-msgstr ""
-
-#: wp-admin/plugins.php:157
-#: wp-admin/update-core.php:330
-#: wp-admin/update-core.php:467
-#: wp-admin/update-core.php:999
-#: wp-admin/update-core.php:1004
-msgid "Update Plugins"
-msgstr ""
-
-#: wp-admin/plugins.php:199
-#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:716
-msgid "Sorry, you are not allowed to deactivate this plugin."
-msgstr ""
-
-#: wp-admin/plugins.php:226
-msgid "Sorry, you are not allowed to deactivate plugins for this site."
-msgstr ""
-
-#: wp-admin/plugins.php:341
-msgid "Delete Plugin"
-msgstr ""
-
-#: wp-admin/plugins.php:343
-msgid "This plugin may be active on other sites in the network."
-msgstr ""
-
-#: wp-admin/plugins.php:345
-msgid "You are about to remove the following plugin:"
-msgstr ""
-
-#: wp-admin/plugins.php:347
-msgid "Delete Plugins"
-msgstr ""
-
-#: wp-admin/plugins.php:349
-msgid "These plugins may be active on other sites in the network."
-msgstr ""
-
-#: wp-admin/plugins.php:351
-msgid "You are about to remove the following plugins:"
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Plugin author.
-#: wp-admin/plugins.php:361
-msgid "%1$s by %2$s (will also <strong>delete its data</strong>)"
-msgstr ""
-
-#. translators: 1: Plugin name, 2: Plugin author.
-#: wp-admin/plugins.php:365
-msgctxt "plugin"
-msgid "%1$s by %2$s"
-msgstr ""
-
-#: wp-admin/plugins.php:375
-msgid "Are you sure you want to delete these files and data?"
-msgstr ""
-
-#: wp-admin/plugins.php:377
-msgid "Are you sure you want to delete these files?"
-msgstr ""
-
-#: wp-admin/plugins.php:393
-msgid "Yes, delete these files and data"
-msgstr ""
-
-#: wp-admin/plugins.php:393
-msgid "Yes, delete these files"
-msgstr ""
-
-#: wp-admin/plugins.php:401
-msgid "No, return me to the plugin list"
-msgstr ""
-
-#: wp-admin/plugins.php:432
-msgid "Sorry, you are not allowed to resume this plugin."
-msgstr ""
-
-#: wp-admin/plugins.php:450
-msgid "Sorry, you are not allowed to manage plugins automatic updates."
-msgstr ""
-
-#: wp-admin/plugins.php:454
-msgid "Please connect to your network admin to manage plugins automatic updates."
-msgstr ""
-
-#: wp-admin/plugins.php:545
-msgid "Plugins extend and expand the functionality of ClassicPress. Once a plugin is installed, you may activate it or deactivate it here."
-msgstr ""
-
-#: wp-admin/plugins.php:546
-msgid "The search for installed plugins will search for terms in their name, description, or author."
-msgstr ""
-
-#. translators: %s: WordPress Plugin Directory URL.
-#: wp-admin/plugins.php:549
-msgid "If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href=\"%s\">ClassicPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!"
-msgstr ""
-
-#: wp-admin/plugins.php:557
-msgid "Troubleshooting"
-msgstr ""
-
-#: wp-admin/plugins.php:559
-msgid "Most of the time, plugins play nicely with the core of ClassicPress and with other plugins. Sometimes, though, a plugin&#8217;s code will get in the way of another plugin, causing compatibility issues. If your site starts doing strange things, this may be the problem. Try deactivating all your plugins and re-activating them in various combinations until you isolate which one(s) caused the issue."
-msgstr ""
-
-#. translators: %s: WP_PLUGIN_DIR constant value.
-#: wp-admin/plugins.php:562
-msgid "If something goes wrong with a plugin and you cannot use ClassicPress, delete or rename that file in the %s directory and it will be automatically deactivated."
-msgstr ""
-
-#: wp-admin/plugins.php:576
-msgid "Auto-updates can be enabled or disabled for each individual plugin. Plugins with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system."
-msgstr ""
-
-#: wp-admin/plugins.php:577
-msgid "Auto-updates are only available for plugins recognized by WordPress.org or ClassicPress.net, or that include a compatible update system."
-msgstr ""
-
-#: wp-admin/plugins.php:587
-msgid "<a href=\"https://wordpress.org/documentation/article/manage-plugins/\">Documentation on Managing Plugins</a>"
-msgstr ""
-
-#. translators: 1: Plugin file, 2: Error message.
-#: wp-admin/plugins.php:612
-msgid "The plugin %1$s has been deactivated due to an error: %2$s"
-msgstr ""
-
-#. translators: %d: Number of characters.
-#: wp-admin/plugins.php:627
-msgid "The plugin generated %d character of <strong>unexpected output</strong> during activation."
-msgid_plural "The plugin generated %d characters of <strong>unexpected output</strong> during activation."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/plugins.php:634
-msgid "If you notice &#8220;headers already sent&#8221; messages, problems with syndication feeds or other issues, try deactivating or removing this plugin."
-msgstr ""
-
-#: wp-admin/plugins.php:636
-msgid "Plugin could not be resumed because it triggered a <strong>fatal error</strong>."
-msgstr ""
-
-#: wp-admin/plugins.php:638
-msgid "Plugin could not be activated because it triggered a <strong>fatal error</strong>."
-msgstr ""
-
-#. translators: %s: Error message.
-#: wp-admin/plugins.php:677
-msgid "Plugin could not be deleted due to an error: %s"
-msgstr ""
-
-#: wp-admin/plugins.php:688
-msgid "The selected plugin has been deleted."
-msgstr ""
-
-#: wp-admin/plugins.php:690
-msgid "The selected plugins have been deleted."
-msgstr ""
-
-#: wp-admin/plugins.php:697
-msgid "Plugin activated."
-msgstr ""
-
-#: wp-admin/plugins.php:699
-msgid "Selected plugins activated."
-msgstr ""
-
-#: wp-admin/plugins.php:701
-msgid "Plugin deactivated."
-msgstr ""
-
-#: wp-admin/plugins.php:703
-msgid "Selected plugins deactivated."
-msgstr ""
-
-#: wp-admin/plugins.php:705
-msgid "All selected plugins are up to date."
-msgstr ""
-
-#: wp-admin/plugins.php:707
-msgid "Plugin resumed."
-msgstr ""
-
-#: wp-admin/plugins.php:709
-msgid "Plugin will be auto-updated."
-msgstr ""
-
-#: wp-admin/plugins.php:711
-msgid "Plugin will no longer be auto-updated."
-msgstr ""
-
-#: wp-admin/plugins.php:713
-msgid "Selected plugins will be auto-updated."
-msgstr ""
-
-#: wp-admin/plugins.php:715
-msgid "Selected plugins will no longer be auto-updated."
-msgstr ""
-
-#: wp-admin/plugins.php:765
-msgid "Search Installed Plugins"
-msgstr ""
-
-#: wp-admin/post.php:47
-msgid "A post type mismatch has been detected."
-msgstr ""
-
-#: wp-admin/post.php:82
-msgid "Unable to submit this form, please refresh and try again."
-msgstr ""
-
-#: wp-admin/post.php:143
-msgid "You cannot edit this item because it is in the Trash. Please restore it and try again."
-msgstr ""
-
-#: wp-admin/post.php:245
-msgid "The item you are trying to move to the Trash no longer exists."
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/post.php:260
-msgid "You cannot move this item to the Trash. %s is currently editing."
-msgstr ""
-
-#: wp-admin/post.php:282
-msgid "The item you are trying to restore from the Trash no longer exists."
-msgstr ""
-
-#: wp-admin/post.php:311
-msgid "This item has already been deleted."
-msgstr ""
-
-#: wp-admin/press-this.php:44
-msgid "Activate Press This"
-msgstr ""
-
-#. translators: %s: URL to Press This bookmarklet on the main site.
-#: wp-admin/press-this.php:68
-msgid "Press This is not installed. Please install Press This from <a href=\"%s\">the main site</a>."
-msgstr ""
-
-#: wp-admin/press-this.php:74
-#: wp-includes/deprecated.php:3950
-#: wp-includes/deprecated.php:3967
-msgid "The Press This plugin is required."
-msgstr ""
-
-#: wp-admin/press-this.php:75
-#: wp-admin/press-this.php:81
-msgid "Installation Required"
-msgstr ""
-
-#: wp-admin/press-this.php:80
-msgid "Press This is not available. Please contact your site administrator."
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:21
-#: wp-admin/privacy-policy-guide.php:68
-#: wp-admin/privacy-policy-guide.php:77
-msgid "Privacy Policy Guide"
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:69
-msgid "Introduction"
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:70
-msgid "This text template will help you to create your web site&#8217;s privacy policy."
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:71
-msgid "The template contains a suggestion of sections you most likely will need. Under each section heading you will find a short summary of what information you should provide, which will help you to get started. Some sections include suggested policy content, others will have to be completed with information from your theme and plugins."
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:72
-msgid "Please edit your privacy policy content, making sure to delete the summaries, and adding any information from your theme and plugins. Once you publish your policy page, remember to add it to your navigation menu."
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:73
-msgid "It is your responsibility to write a comprehensive privacy policy, to make sure it reflects all national and international legal requirements on privacy, and to keep your policy current and accurate."
-msgstr ""
-
-#: wp-admin/privacy-policy-guide.php:89
-msgid "Policies"
-msgstr ""
-
-#: wp-admin/privacy.php:13
-msgid "Sorry, you are not allowed to manage privacy on this site."
-msgstr ""
-
-#. translators: %s: URL to Customizer -> Menus
-#: wp-admin/privacy.php:42
-msgid "Privacy Policy page updated successfully. Remember to <a href=\"%s\">update your menus</a>!"
-msgstr ""
-
-#. translators: URL to Pages Trash
-#: wp-admin/privacy.php:109
-msgid "The currently selected Privacy Policy page is in the trash. Please create or select a new Privacy Policy page or <a href=\"%s\">restore the current page</a>."
-msgstr ""
-
-#: wp-admin/privacy.php:128
-msgid "Privacy Policy page"
-msgstr ""
-
-#: wp-admin/privacy.php:130
-msgid "As a website owner, you may need to follow national or international privacy laws. For example, you may need to create and display a Privacy Policy."
-msgstr ""
-
-#: wp-admin/privacy.php:134
-msgid "The new page will include help and suggestions for your Privacy Policy."
-msgstr ""
-
-#: wp-admin/privacy.php:135
-msgid "However, it is your responsibility to use those resources correctly, to provide the information that your Privacy Policy requires, and to keep that information current and accurate."
-msgstr ""
-
-#: wp-admin/privacy.php:138
-msgid "After your Privacy Policy page is set, we suggest that you edit it."
-msgstr ""
-
-#: wp-admin/privacy.php:139
-msgid "We would also suggest reviewing your Privacy Policy from time to time, especially after installing or updating any themes or plugins. There may be changes or new suggested information for you to consider adding to your policy."
-msgstr ""
-
-#: wp-admin/privacy.php:173
-msgid "Need help putting together your new Privacy Policy page? <a href=\"%1$s\" %2$s>Check out our guide%3$s</a> for recommendations on what content to include, along with policies suggested by your plugins and theme."
-msgstr ""
-
-#: wp-admin/privacy.php:213
-msgid "Select an existing page:"
-msgstr ""
-
-#: wp-admin/privacy.php:239
-msgid "Or:"
-msgstr ""
-
-#: wp-admin/privacy.php:248
-msgid "Create New Page"
-msgstr ""
-
-#. translators: %s: Post title.
-#: wp-admin/revision.php:109
-msgid "Compare Revisions of &#8220;%s&#8221;"
-msgstr ""
-
-#: wp-admin/revision.php:110
-msgid "&larr; Go to editor"
-msgstr ""
-
-#: wp-admin/revision.php:141
-msgid "This screen is used for managing your content revisions."
-msgstr ""
-
-#: wp-admin/revision.php:142
-msgid "Revisions are saved copies of your post or page, which are periodically created as you update your content. The red text on the left shows the content that was removed. The green text on the right shows the content that was added."
-msgstr ""
-
-#: wp-admin/revision.php:143
-msgid "From this screen you can review, compare, and restore revisions:"
-msgstr ""
-
-#: wp-admin/revision.php:144
-msgid "To navigate between revisions, <strong>drag the slider handle left or right</strong> or <strong>use the Previous or Next buttons</strong>."
-msgstr ""
-
-#: wp-admin/revision.php:145
-msgid "Compare two different revisions by <strong>selecting the &#8220;Compare any two revisions&#8221; box</strong> to the side."
-msgstr ""
-
-#: wp-admin/revision.php:146
-msgid "To restore a revision, <strong>click Restore This Revision</strong>."
-msgstr ""
-
-#: wp-admin/revision.php:157
-msgid "<a href=\"https://wordpress.org/documentation/article/revisions/\">Revisions Management</a>"
-msgstr ""
-
-#: wp-admin/revision.php:179
-msgid "Revision by "
-msgstr ""
-
-#: wp-admin/revision.php:181
-msgid "Autosave by "
-msgstr ""
-
-#: wp-admin/revision.php:183
-msgid "Current Revision by "
-msgstr ""
-
-#: wp-admin/revision.php:209
-msgid "Earlier Revision"
-msgstr ""
-
-#: wp-admin/revision.php:214
-msgid "Later Revision"
-msgstr ""
-
-#. translators: %s: wp-config-sample.php
-#: wp-admin/setup-config.php:52
-msgid "Sorry, I need a %s file to work from. Please re-upload this file to your ClassicPress installation."
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: install.php
-#: wp-admin/setup-config.php:63
-msgid "The file %1$s already exists. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href=\"%2$s\">installing now</a>."
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: install.php
-#: wp-admin/setup-config.php:76
-msgid "The file %1$s already exists one level above your ClassicPress installation. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href=\"%2$s\">installing now</a>."
-msgstr ""
-
-#: wp-admin/setup-config.php:111
-msgid "ClassicPress &rsaquo; Setup Configuration File"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/setup-config.php:163
-msgid "Before getting started"
-msgstr ""
-
-#: wp-admin/setup-config.php:166
-msgid "Welcome to ClassicPress. Before getting started, you will need to know the following items."
-msgstr ""
-
-#: wp-admin/setup-config.php:170
-msgid "Database password"
-msgstr ""
-
-#: wp-admin/setup-config.php:172
-msgid "Table prefix (if you want to run more than one ClassicPress in a single database)"
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/setup-config.php:178
-msgid "This information is being used to create a %s file."
-msgstr ""
-
-#. translators: 1: wp-config-sample.php, 2: wp-config.php
-#: wp-admin/setup-config.php:186
-msgid "If for any reason this automatic file creation does not work, do not worry. All this does is fill in the database information to a configuration file. You may also simply open %1$s in a text editor, fill in your information, and save it as %2$s."
-msgstr ""
-
-#. translators: 1: Documentation URL, 2: wp-config.php
-#: wp-admin/setup-config.php:195
-#: wp-load.php:93
-msgid "Need more help? <a href=\"%1$s\">Read the support article on %2$s</a>."
-msgstr ""
-
-#: wp-admin/setup-config.php:196
-#: wp-load.php:94
-msgid "https://wordpress.org/documentation/article/editing-wp-config-php/"
-msgstr ""
-
-#: wp-admin/setup-config.php:201
-msgid "In all likelihood, these items were supplied to you by your web host. If you do not have this information, then you will need to contact them before you can continue. If you are ready&hellip;"
-msgstr ""
-
-#: wp-admin/setup-config.php:203
-msgid "Let&#8217;s go!"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/setup-config.php:218
-msgid "Set up your database connection"
-msgstr ""
-
-#: wp-admin/setup-config.php:222
-msgid "Below you should enter your database connection details. If you are not sure about these, contact your host."
-msgstr ""
-
-#: wp-admin/setup-config.php:225
-msgid "Database Name"
-msgstr ""
-
-#: wp-admin/setup-config.php:227
-msgid "The name of the database you want to use with ClassicPress."
-msgstr ""
-
-#: wp-admin/setup-config.php:231
-msgctxt "example username"
-msgid "username"
-msgstr ""
-
-#: wp-admin/setup-config.php:232
-msgid "Your database username."
-msgstr ""
-
-#: wp-admin/setup-config.php:236
-msgctxt "example password"
-msgid "password"
-msgstr ""
-
-#: wp-admin/setup-config.php:237
-msgid "Your database password."
-msgstr ""
-
-#: wp-admin/setup-config.php:240
-msgid "Database Host"
-msgstr ""
-
-#. translators: %s: localhost
-#: wp-admin/setup-config.php:245
-msgid "You should be able to get this info from your web host, if %s does not work."
-msgstr ""
-
-#: wp-admin/setup-config.php:250
-msgid "Table Prefix"
-msgstr ""
-
-#: wp-admin/setup-config.php:252
-msgid "If you want to run multiple ClassicPress installations in a single database, change this."
-msgstr ""
-
-#: wp-admin/setup-config.php:260
-msgid "Submit"
-msgstr ""
-
-#: wp-admin/setup-config.php:291
-msgid "<strong>Error:</strong> \"Table Prefix\" must not be empty."
-msgstr ""
-
-#: wp-admin/setup-config.php:296
-msgid "<strong>Error:</strong> \"Table Prefix\" can only contain numbers, letters, and underscores."
-msgstr ""
-
-#: wp-admin/setup-config.php:330
-msgid "<strong>Error:</strong> \"Table Prefix\" is invalid."
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/setup-config.php:410
-#: wp-admin/setup-config.php:479
-msgid "Unable to write to %s file."
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/setup-config.php:416
-msgid "You can create the %s file manually and paste the following text into it."
-msgstr ""
-
-#. translators: %s: wp-config.php
-#: wp-admin/setup-config.php:428
-msgid "Configuration rules for %s:"
-msgstr ""
-
-#: wp-admin/setup-config.php:432
-msgid "After you&#8217;ve done that, click &#8220;Run the installation&#8221;."
-msgstr ""
-
-#: wp-admin/setup-config.php:433
-#: wp-admin/setup-config.php:498
-msgid "Run the installation"
-msgstr ""
-
-#. translators: 1: wp-config.php, 2: Documentation URL.
-#: wp-admin/setup-config.php:472
-msgid "You need to make the file %1$s writable before you can save your changes. See <a href=\"%2$s\">Changing File Permissions</a> for more information."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/setup-config.php:493
-msgid "Successful database connection"
-msgstr ""
-
-#: wp-admin/setup-config.php:496
-msgid "All right, sparky! You&#8217;ve made it through this part of the installation. ClassicPress can now communicate with your database. If you are ready, time now to&hellip;"
-msgstr ""
-
-#: wp-admin/site-health-info.php:24
-#: wp-admin/site-health.php:218
-msgid "The Site Health check requires JavaScript."
-msgstr ""
-
-#: wp-admin/site-health-info.php:37
-msgid "Site Health Info"
-msgstr ""
-
-#. translators: %s: URL to Site Health Status page.
-#: wp-admin/site-health-info.php:43
-msgid "This page can show you every detail about the configuration of your ClassicPress website. For any improvements that could be made, see the <a href=\"%s\">Site Health Status</a> page."
-msgstr ""
-
-#: wp-admin/site-health-info.php:47
-msgid "If you want to export a handy list of all the information on this page, you can use the button below to copy it to the clipboard. You can then paste it in a text file and save it to your device, or paste it in an email exchange with a support engineer or theme/plugin developer for example."
-msgstr ""
-
-#: wp-admin/site-health-info.php:53
-msgid "Copy site info to clipboard"
-msgstr ""
-
-#. translators: Tab heading for Site Health Status page.
-#: wp-admin/site-health.php:16
-msgctxt "Site Health"
-msgid "Status"
-msgstr ""
-
-#. translators: Tab heading for Site Health Info page.
-#: wp-admin/site-health.php:18
-msgctxt "Site Health"
-msgid "Info"
-msgstr ""
-
-#. translators: %s: The currently displayed tab.
-#: wp-admin/site-health.php:43
-msgid "Site Health - %s"
-msgstr ""
-
-#: wp-admin/site-health.php:48
-msgid "Sorry, you are not allowed to access site health information."
-msgstr ""
-
-#: wp-admin/site-health.php:62
-msgid "Sorry, you are not allowed to update this site to HTTPS."
-msgstr ""
-
-#: wp-admin/site-health.php:66
-msgid "It looks like HTTPS is not supported for your website at this point."
-msgstr ""
-
-#: wp-admin/site-health.php:82
-msgid "This screen allows you to obtain a health diagnosis of your site, and displays an overall rating of the status of your installation."
-msgstr ""
-
-#: wp-admin/site-health.php:83
-msgid "In the Status tab, you can see critical information about your ClassicPress configuration, along with anything else that requires your attention."
-msgstr ""
-
-#: wp-admin/site-health.php:84
-msgid "In the Info tab, you will find all the details about the configuration of your ClassicPress site, server, and database. There is also an export feature that allows you to copy all of the information about your site to the clipboard, to help solve problems on your site when obtaining support."
-msgstr ""
-
-#: wp-admin/site-health.php:90
-msgid "<a href=\"https://wordpress.org/documentation/article/site-health-screen/\">Documentation on Site Health tool</a>"
-msgstr ""
-
-#: wp-admin/site-health.php:101
-msgid "Site Health"
-msgstr ""
-
-#: wp-admin/site-health.php:109
-msgid "Site URLs switched to HTTPS."
-msgstr ""
-
-#: wp-admin/site-health.php:113
-msgid "Site URLs could not be switched to HTTPS."
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/site-health.php:166
-msgid "Toggle extra menu items"
-msgstr ""
-
-#: wp-admin/site-health.php:228
-msgid "Great job!"
-msgstr ""
-
-#: wp-admin/site-health.php:232
-msgid "Everything is running smoothly here."
-msgstr ""
-
-#: wp-admin/site-health.php:241
-msgid "The site health check shows information about your ClassicPress configuration and items that may need your attention."
-msgstr ""
-
-#. translators: %s: Number of critical issues found.
-#: wp-admin/site-health.php:247
-#: wp-admin/js/site-health.js:150
-msgid "%s critical issue"
-msgid_plural "%s critical issues"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/site-health.php:251
-msgid "Critical issues are items that may have a high impact on your sites performance or security, and resolving these issues should be prioritized."
-msgstr ""
-
-#. translators: %s: Number of recommended improvements.
-#: wp-admin/site-health.php:260
-#: wp-admin/js/site-health.js:155
-msgid "%s recommended improvement"
-msgid_plural "%s recommended improvements"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/site-health.php:264
-msgid "Recommended items are considered beneficial to your site, although not as important to prioritize as a critical issue, they may include improvements to things such as; Performance, user experience, and more."
-msgstr ""
-
-#: wp-admin/site-health.php:272
-msgid "Passed tests"
-msgstr ""
-
-#. translators: %s: Number of items with no issues.
-#: wp-admin/site-health.php:281
-#: wp-admin/js/site-health.js:160
-msgid "%s item with no issues detected"
-msgid_plural "%s items with no issues detected"
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/theme-editor.php:22
-msgid "Edit Themes"
-msgstr ""
-
-#: wp-admin/theme-editor.php:30
-msgid "You can use the theme file editor to edit the individual CSS and PHP files which make up your theme."
-msgstr ""
-
-#: wp-admin/theme-editor.php:31
-msgid "Begin by choosing a theme to edit from the dropdown menu and clicking the Select button. A list then appears of the theme&#8217;s template files. Clicking once on any file name causes the file to appear in the large Editor box."
-msgstr ""
-
-#: wp-admin/theme-editor.php:32
-msgid "For PHP files, you can use the documentation dropdown to select from functions recognized in that file. Look Up takes you to a web page with reference material about that particular function."
-msgstr ""
-
-#: wp-admin/theme-editor.php:39
-msgid "After typing in your edits, click Update File."
-msgstr ""
-
-#: wp-admin/theme-editor.php:40
-msgid "<strong>Advice:</strong> Think very carefully about your site crashing if you are live-editing the theme currently in use."
-msgstr ""
-
-#. translators: %s: Link to documentation on child themes.
-#: wp-admin/theme-editor.php:43
-msgid "Upgrading to a newer version of the same theme will override changes made here. To avoid this, consider creating a <a href=\"%s\">child theme</a> instead."
-msgstr ""
-
-#: wp-admin/theme-editor.php:52
-msgid "<a href=\"https://developer.wordpress.org/themes/\">Documentation on Theme Development</a>"
-msgstr ""
-
-#: wp-admin/theme-editor.php:53
-msgid "<a href=\"https://wordpress.org/documentation/article/appearance-theme-file-editor-screen/\">Documentation on Editing Themes</a>"
-msgstr ""
-
-#: wp-admin/theme-editor.php:54
-msgid "<a href=\"https://wordpress.org/documentation/article/editing-files/\">Documentation on Editing Files</a>"
-msgstr ""
-
-#: wp-admin/theme-editor.php:55
-msgid "<a href=\"https://developer.wordpress.org/themes/basics/template-tags/\">Documentation on Template Tags</a>"
-msgstr ""
-
-#: wp-admin/theme-editor.php:205
-msgid "Did you know?"
-msgstr ""
-
-#. translators: %s: Link to Custom CSS section in the Customizer.
-#: wp-admin/theme-editor.php:210
-msgid "There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href=\"%s\">built-in CSS editor</a>."
-msgstr ""
-
-#: wp-admin/theme-editor.php:231
-msgid "Select theme to edit:"
-msgstr ""
-
-#: wp-admin/theme-editor.php:252
-msgid "This theme is broken."
-msgstr ""
-
-#: wp-admin/theme-editor.php:257
-msgid "Theme Files"
-msgstr ""
-
-#. translators: %s: Link to edit parent theme.
-#: wp-admin/theme-editor.php:264
-msgid "This child theme inherits templates from a parent theme, %s."
-msgstr ""
-
-#: wp-admin/theme-editor.php:313
-msgid "This is a file in your current parent theme."
-msgstr ""
-
-#: wp-admin/theme-editor.php:367
-msgid "You appear to be making direct edits to your theme in the ClassicPress dashboard. It is not recommended! Editing your theme directly could break your site and your changes may be lost in future updates."
-msgstr ""
-
-#. translators: %s: Link to documentation on child themes.
-#: wp-admin/theme-editor.php:375
-msgid "If you need to tweak more than your theme&#8217;s CSS, you might want to try <a href=\"%s\">making a child theme</a>."
-msgstr ""
-
-#: wp-admin/theme-editor.php:381
-msgid "If you decide to go ahead with direct edits anyway, use a file manager to create a copy with a new name and hang on to the original. That way, you can re-enable a functional version if something goes wrong."
-msgstr ""
-
-#: wp-admin/theme-install.php:25
-msgid "Add Themes"
-msgstr ""
-
-#: wp-admin/theme-install.php:57
-#: wp-admin/themes.php:232
-msgid "Add New Theme"
-msgstr ""
-
-#: wp-admin/theme-install.php:58
-msgid "Search Themes"
-msgstr ""
-
-#: wp-admin/theme-install.php:59
-msgid "Search themes..."
-msgstr ""
-
-#: wp-admin/theme-install.php:60
-#: wp-admin/theme-install.php:165
-#: wp-admin/theme-install.php:167
-#: wp-admin/update.php:340
-msgid "Upload Theme"
-msgstr ""
-
-#. translators: %s: Support forums URL.
-#: wp-admin/theme-install.php:64
-msgid "An unexpected error occurred. Something may be wrong with WordPress.org, ClassicPress.net, or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
-msgstr ""
-
-#. translators: %d: Number of themes.
-#: wp-admin/theme-install.php:69
-#: wp-admin/themes.php:236
-msgid "Number of Themes found: %d"
-msgstr ""
-
-#: wp-admin/theme-install.php:70
-#: wp-admin/theme-install.php:245
-#: wp-admin/themes.php:237
-#: wp-admin/themes.php:583
-#: wp-includes/customize/class-wp-customize-themes-section.php:97
-msgid "No themes found. Try a different search."
-msgstr ""
-
-#: wp-admin/theme-install.php:72
-msgid "Expand Sidebar"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/theme-install.php:74
-msgid "Select one or more Theme features to filter by"
-msgstr ""
-
-#. translators: %s: Theme Directory URL.
-#: wp-admin/theme-install.php:110
-msgid "You can find additional themes for your site by using the Theme Browser/Installer on this screen, which will display themes from the <a href=\"%s\">ClassicPress Theme Directory</a>. These themes are designed and developed by third parties, are available free of charge, and are compatible with the license WordPress uses."
-msgstr ""
-
-#: wp-admin/theme-install.php:113
-msgid "You can Search for themes by keyword, author, or tag, or can get more specific and search by criteria listed in the feature filter."
-msgstr ""
-
-#: wp-admin/theme-install.php:114
-msgid "Alternately, you can browse the themes that are Popular or Latest. When you find a theme you like, you can preview it or install it."
-msgstr ""
-
-#. translators: %s: /wp-content/themes
-#: wp-admin/theme-install.php:117
-msgid "You can Upload a theme manually if you have already downloaded its ZIP archive onto your computer (make sure it is from a trusted and original source). You can also do it the old-fashioned way and copy a downloaded theme&#8217;s folder via FTP into your %s directory."
-msgstr ""
-
-#: wp-admin/theme-install.php:130
-msgid "Once you have generated a list of themes, you can preview and install any of them. Click on the thumbnail of the theme you are interested in previewing. It will open up in a full-screen Preview page to give you a better idea of how that theme will look."
-msgstr ""
-
-#: wp-admin/theme-install.php:131
-msgid "To install the theme so you can preview it with your site&#8217;s content and customize its theme options, click the \"Install\" button at the top of the left-hand pane. The theme files will be downloaded to your website automatically. When this is complete, the theme is now available for activation, which you can do by clicking the \"Activate\" link, or by navigating to your Manage Themes screen and clicking the \"Live Preview\" link under any installed theme&#8217;s thumbnail image."
-msgstr ""
-
-#: wp-admin/theme-install.php:136
-msgid "Previewing and Installing"
-msgstr ""
-
-#: wp-admin/theme-install.php:143
-msgid "<a href=\"https://wordpress.org/documentation/article/appearance-themes-screen/#install-themes\">Documentation on Adding New Themes</a>"
-msgstr ""
-
-#: wp-admin/theme-install.php:144
-msgid "<a href=\"https://wordpress.org/documentation/article/block-themes/\">Documentation on Block Themes</a>"
-msgstr ""
-
-#: wp-admin/theme-install.php:174
-msgid "The Theme Installer screen requires JavaScript."
-msgstr ""
-
-#: wp-admin/theme-install.php:194
-msgctxt "themes"
-msgid "Popular"
-msgstr ""
-
-#: wp-admin/theme-install.php:204
-#: wp-admin/theme-install.php:226
-msgid "Apply Filters"
-msgstr ""
-
-#: wp-admin/theme-install.php:205
-#: wp-admin/theme-install.php:227
-msgid "Clear current filters"
-msgstr ""
-
-#: wp-admin/theme-install.php:205
-#: wp-admin/theme-install.php:227
-#: wp-includes/media-template.php:799
-#: wp-admin/js/color-picker.js:154
-msgid "Clear"
-msgstr ""
-
-#: wp-admin/theme-install.php:230
-msgid "Filtering by:"
-msgstr ""
-
-#: wp-admin/theme-install.php:232
-msgid "Edit Filters"
-msgstr ""
-
-#: wp-admin/theme-install.php:348
-msgctxt "theme"
-msgid "Details &amp; Preview"
-msgstr ""
-
-#: wp-admin/theme-install.php:370
-#: wp-admin/theme-install.php:445
-msgctxt "theme"
-msgid "Activated"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/theme-install.php:383
-#: wp-admin/themes.php:567
-#: wp-admin/themes.php:927
-#: wp-admin/themes.php:1157
-msgctxt "theme"
-msgid "Cannot Activate %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/theme-install.php:405
-msgctxt "theme"
-msgid "Cannot Install %s"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/theme-install.php:427
-msgid "Previous theme"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/theme-install.php:433
-msgid "Next theme"
-msgstr ""
-
-#: wp-admin/theme-install.php:484
-msgid "This theme has not been rated yet."
-msgstr ""
-
-#: wp-admin/themes.php:43
-msgid "Sorry, you are not allowed to resume this theme."
-msgstr ""
-
-#: wp-admin/themes.php:86
-msgid "Sorry, you are not allowed to enable themes automatic updates."
-msgstr ""
-
-#: wp-admin/themes.php:106
-msgid "Sorry, you are not allowed to disable themes automatic updates."
-msgstr ""
-
-#: wp-admin/themes.php:132
-msgid "This screen is used for managing your installed themes. Aside from the default theme(s) included with your WordPress installation, themes are designed and developed by third parties."
-msgstr ""
-
-#: wp-admin/themes.php:134
-msgid "Hover or tap to see Activate and Live Preview buttons"
-msgstr ""
-
-#: wp-admin/themes.php:135
-msgid "Click on the theme to see the theme name, version, author, description, tags, and the Delete link"
-msgstr ""
-
-#: wp-admin/themes.php:136
-msgid "Click Customize for the active theme or Live Preview for any other theme to see a live preview"
-msgstr ""
-
-#: wp-admin/themes.php:137
-msgid "The active theme is displayed highlighted as the first theme."
-msgstr ""
-
-#: wp-admin/themes.php:138
-msgid "The search for installed themes will search for terms in their name, description, author, or tag."
-msgstr ""
-
-#: wp-admin/themes.php:152
-msgid "Installing themes on Multisite can only be done from the Network Admin section."
-msgstr ""
-
-#. translators: %s: https://wordpress.org/themes
-#: wp-admin/themes.php:156
-msgid "If you would like to see more themes to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional themes from the <a href=\"%s\">ClassicPress Theme Directory</a>. Themes in the WordPress Theme Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!"
-msgstr ""
-
-#: wp-admin/themes.php:164
-msgid "Adding Themes"
-msgstr ""
-
-#: wp-admin/themes.php:173
-msgid "Tap or hover on any theme then click the Live Preview button to see a live preview of that theme and change theme options in a separate, full-screen view. You can also find a Live Preview button at the bottom of the theme details screen. Any installed theme can be previewed and customized in this way."
-msgstr ""
-
-#: wp-admin/themes.php:174
-msgid "The theme being previewed is fully interactive &mdash; navigate to different pages to see how the theme handles posts, archives, and other page templates. The settings may differ depending on what theme features the theme being previewed supports. To accept the new settings and activate the theme all in one step, click the Activate &amp; Publish button above the menu."
-msgstr ""
-
-#: wp-admin/themes.php:175
-msgid "When previewing on smaller monitors, you can use the collapse icon at the bottom of the left-hand pane. This will hide the pane, giving you more room to preview your site in the new theme. To bring the pane back, click on the collapse icon again."
-msgstr ""
-
-#: wp-admin/themes.php:180
-msgid "Previewing and Customizing"
-msgstr ""
-
-#: wp-admin/themes.php:207
-msgid "<a href=\"https://wordpress.org/documentation/article/work-with-themes/\">Documentation on Using Themes</a>"
-msgstr ""
-
-#: wp-admin/themes.php:208
-msgid "<a href=\"https://wordpress.org/documentation/article/appearance-themes-screen/\">Documentation on Managing Themes</a>"
-msgstr ""
-
-#: wp-admin/themes.php:228
-msgid ""
-"Are you sure you want to delete this theme?\n"
-"\n"
-"Click 'Cancel' to go back, 'OK' to confirm the delete."
-msgstr ""
-
-#: wp-admin/themes.php:234
-msgid "Search installed themes..."
-msgstr ""
-
-#: wp-admin/themes.php:251
-#: wp-includes/formatting.php:3996
-#: wp-includes/general-template.php:4561
-msgid "&hellip;"
-msgstr ""
-
-#: wp-admin/themes.php:264
-msgid "The active theme is broken. Reverting to the default theme."
-msgstr ""
-
-#: wp-admin/themes.php:269
-msgid "Settings saved and theme activated."
-msgstr ""
-
-#: wp-admin/themes.php:269
-#: wp-admin/themes.php:273
-msgid "Visit site"
-msgstr ""
-
-#: wp-admin/themes.php:273
-msgid "New theme activated."
-msgstr ""
-
-#: wp-admin/themes.php:282
-msgid "You cannot delete a theme while it has an active child theme."
-msgstr ""
-
-#: wp-admin/themes.php:286
-msgid "Theme resumed."
-msgstr ""
-
-#: wp-admin/themes.php:290
-msgid "Theme could not be resumed because it triggered a <strong>fatal error</strong>."
-msgstr ""
-
-#: wp-admin/themes.php:401
-#: wp-admin/themes.php:752
-msgid "New version available. <button class=\"button-link\" type=\"button\">Update now</button>"
-msgstr ""
-
-#: wp-admin/themes.php:403
-#: wp-admin/themes.php:754
-#: wp-includes/customize/class-wp-customize-theme-control.php:98
-msgid "New version available."
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/themes.php:523
-#: wp-admin/themes.php:882
-msgctxt "theme"
-msgid "View Theme Details for %s"
-msgstr ""
-
-#: wp-admin/themes.php:525
-#: wp-admin/themes.php:581
-#: wp-admin/themes.php:884
-#: wp-includes/customize/class-wp-customize-theme-control.php:83
-#: wp-includes/customize/class-wp-customize-themes-section.php:78
-msgid "Theme Details"
-msgstr ""
-
-#: wp-admin/themes.php:536
-#: wp-admin/themes.php:895
-msgctxt "theme"
-msgid "Active:"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/themes.php:547
-#: wp-admin/themes.php:906
-msgctxt "theme"
-msgid "Customize %s"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/themes.php:560
-#: wp-admin/themes.php:920
-msgctxt "theme"
-msgid "Live Preview %s"
-msgstr ""
-
-#: wp-admin/themes.php:592
-msgid "Broken Themes"
-msgstr ""
-
-#: wp-admin/themes.php:602
-msgctxt "theme name"
-msgid "Name"
-msgstr ""
-
-#: wp-admin/themes.php:669
-msgid "Install Parent Theme"
-msgstr ""
-
-#: wp-admin/tools.php:49
-msgid "Categories have hierarchy, meaning that you can nest sub-categories. Tags do not have hierarchy and cannot be nested. Sometimes people start out using one on their posts, then later realize that the other would work better for their content."
-msgstr ""
-
-#: wp-admin/tools.php:50
-msgid "The Categories and Tags Converter link on this screen will take you to the Import screen, where that Converter is one of the plugins you can install. Once that plugin is installed, the Activate Plugin &amp; Run Importer link will take you to a screen where you can choose to convert tags into categories or vice versa."
-msgstr ""
-
-#: wp-admin/tools.php:56
-msgid "<a href=\"https://wordpress.org/documentation/article/tools-screen/\">Documentation on Tools</a>"
-msgstr ""
-
-#. translators: %s: URL to Import screen.
-#: wp-admin/tools.php:78
-msgid "If you want to convert your categories to tags (or vice versa), use the <a href=\"%s\">Categories and Tags Converter</a> available from the Import screen."
-msgstr ""
-
-#: wp-admin/update-core.php:23
-#: wp-admin/update-core.php:945
-#: wp-admin/update-core.php:981
-#: wp-admin/update-core.php:1022
-#: wp-admin/update-core.php:1063
-msgid "Sorry, you are not allowed to update this site."
-msgstr ""
-
-#. translators: %s: ClassicPress version.
-#: wp-admin/update-core.php:71
-msgid "Update to latest %s nightly"
-msgstr ""
-
-#: wp-admin/update-core.php:78
-msgid "You are using a development version of ClassicPress. You can update to the latest nightly build automatically:"
-msgstr ""
-
-#: wp-admin/update-core.php:81
-msgid "If you need to re-install version %s, you can do so here:"
-msgstr ""
-
-#: wp-admin/update-core.php:82
-msgid "Re-install Now"
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number
-#: wp-admin/update-core.php:94
-msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s."
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number
-#: wp-admin/update-core.php:97
-msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s."
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number
-#: wp-admin/update-core.php:100
-msgid "You cannot update because <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s."
-msgstr ""
-
-#. translators: 1: ClassicPress version number, 2: ClassicPress version number including locale if necessary
-#: wp-admin/update-core.php:102
-msgid "You can update to <a href=\"https://www.classicpress.net/version/%1$s\">ClassicPress %2$s</a> automatically:"
-msgstr ""
-
-#: wp-admin/update-core.php:130
-msgid "Hide this update"
-msgstr ""
-
-#: wp-admin/update-core.php:132
-msgid "Bring back this update"
-msgstr ""
-
-#: wp-admin/update-core.php:138
-msgid "This localized version contains both the translation and various other localization fixes."
-msgstr ""
-
-#. translators: %s: WordPress version.
-#: wp-admin/update-core.php:143
-msgid "You are about to install ClassicPress %s <strong>in English (US)</strong>. There is a chance this update will break your translation. You may prefer to wait for the localized version to be released."
-msgstr ""
-
-#: wp-admin/update-core.php:165
-#: wp-admin/update-core.php:184
-msgid "Show hidden updates"
-msgstr ""
-
-#: wp-admin/update-core.php:166
-msgid "Hide hidden updates"
-msgstr ""
-
-#: wp-admin/update-core.php:213
-msgid "You are running a development version of ClassicPress."
-msgstr ""
-
-#: wp-admin/update-core.php:216
-msgid "Development versions of ClassicPress do not receive automatic updates."
-msgstr ""
-
-#: wp-admin/update-core.php:220
-msgid "Unable to determine whether a ClassicPress update is available."
-msgstr ""
-
-#: wp-admin/update-core.php:223
-msgid "You may be running a customized build of ClassicPress, or your server may be having internet connectivity problems."
-msgstr ""
-
-#: wp-admin/update-core.php:228
-msgid "You have the latest version of ClassicPress."
-msgstr ""
-
-#: wp-admin/update-core.php:243
-msgid "Future security updates will be applied automatically."
-msgstr ""
-
-#: wp-admin/update-core.php:250
-msgid "<strong>Important:</strong> before updating, please <a href=\"%1$s\">back up your database and files</a>. For help with updates, visit the <a href=\"%2$s\">Updating ClassicPress</a> documentation page."
-msgstr ""
-
-#: wp-admin/update-core.php:257
-msgid "An updated version of ClassicPress is available."
-msgstr ""
-
-#: wp-admin/update-core.php:266
-msgid "BETA TESTERS:"
-msgstr ""
-
-#: wp-admin/update-core.php:266
-msgid "This site is set up to install updates of future beta versions automatically."
-msgstr ""
-
-#: wp-admin/update-core.php:281
-msgid "While your site is being updated, it will be in maintenance mode. As soon as your updates are complete, this mode will be deactivated."
-msgstr ""
-
-#. translators: 1: URL to About screen, 2: WordPress version.
-#: wp-admin/update-core.php:285
-msgid "<a href=\"%1$s\">Learn more about ClassicPress %2$s</a>."
-msgstr ""
-
-#: wp-admin/update-core.php:304
-msgid "Your plugins are all up to date."
-msgstr ""
-
-#: wp-admin/update-core.php:327
-msgid "The following plugins have new versions available. Check the ones you want to update and then click &#8220;Update Plugins&#8221;."
-msgstr ""
-
-#: wp-admin/update-core.php:362
-#: wp-admin/update-core.php:375
-msgid "Expected compatibility with ClassicPress %1$s: 100%%."
-msgstr ""
-
-#: wp-admin/update-core.php:363
-#: wp-admin/update-core.php:367
-#: wp-admin/update-core.php:370
-#: wp-admin/update-core.php:376
-#: wp-admin/update-core.php:380
-#: wp-admin/update-core.php:383
-msgid "More info."
-msgstr ""
-
-#: wp-admin/update-core.php:366
-msgid "Expected Compatibility with ClassicPress %1$s: %2$d%% (%3$d \"works\" votes out of %4$d total)."
-msgstr ""
-
-#: wp-admin/update-core.php:369
-#: wp-admin/update-core.php:382
-msgid "Expected compatibility with ClassicPress %1$s: Unknown."
-msgstr ""
-
-#: wp-admin/update-core.php:379
-msgid "Expected compatibility with ClassicPress %1$s: %2$d%% (%3$d \"works\" votes out of %4$d total)."
-msgstr ""
-
-#: wp-admin/update-core.php:391
-msgid "This update doesn&#8217;t work with your version of PHP."
-msgstr ""
-
-#: wp-admin/update-core.php:394
-msgid "<a href=\"%s\">Learn more about updating PHP.</a>"
-msgstr ""
-
-#. translators: %s: Plugin version.
-#: wp-admin/update-core.php:419
-msgid "View version %s details."
-msgstr ""
-
-#. translators: 1: Plugin version, 2: New version.
-#. translators: 1: Theme version, 2: New version.
-#: wp-admin/update-core.php:442
-#: wp-admin/update-core.php:616
-msgid "You have version %1$s installed. Update to %2$s."
-msgstr ""
-
-#: wp-admin/update-core.php:481
-msgid "Your themes are all up to date."
-msgstr ""
-
-#: wp-admin/update-core.php:498
-msgid "The following themes have new versions available. Check the ones you want to update and then click &#8220;Update Themes&#8221;."
-msgstr ""
-
-#. translators: %s: Link to documentation on child themes.
-#: wp-admin/update-core.php:503
-msgid "<strong>Please Note:</strong> Any customizations you have made to theme files will be lost. Please consider using <a href=\"%s\">child themes</a> for modifications."
-msgstr ""
-
-#: wp-admin/update-core.php:537
-msgid "This update does not work with your versions of ClassicPress and PHP."
-msgstr ""
-
-#: wp-admin/update-core.php:571
-msgid "This update does not work with your version of ClassicPress."
-msgstr ""
-
-#: wp-admin/update-core.php:580
-msgid "This update does not work with your version of PHP."
-msgstr ""
-
-#: wp-admin/update-core.php:655
-#: wp-admin/update-core.php:663
-msgid "Translations"
-msgstr ""
-
-#: wp-admin/update-core.php:665
-msgid "New translations are available."
-msgstr ""
-
-#: wp-admin/update-core.php:706
-msgid "Update ClassicPress"
-msgstr ""
-
-#: wp-admin/update-core.php:754
-msgid "It's possible that an update started, but the server encountered a temporary issue and could not continue."
-msgstr ""
-
-#: wp-admin/update-core.php:759
-msgid "Or, you may have clicked the update button multiple times."
-msgstr ""
-
-#: wp-admin/update-core.php:764
-msgid "Please wait <strong>15 minutes</strong> and try again."
-msgstr ""
-
-#. translators: URL to support forum
-#: wp-admin/update-core.php:771
-msgid "If you see this message after waiting 15 minutes and trying the update again, please make a post on our <a href=\"%s\">support forum</a>."
-msgstr ""
-
-#: wp-admin/update-core.php:779
-msgid "Installation Failed"
-msgstr ""
-
-#: wp-admin/update-core.php:836
-#: wp-admin/update-core.php:879
-msgid "ClassicPress Updates"
-msgstr ""
-
-#: wp-admin/update-core.php:839
-msgid "On this screen, you can update to the latest version of ClassicPress, as well as update your themes, plugins, and translations from the ClassicPress.net repositories."
-msgstr ""
-
-#: wp-admin/update-core.php:840
-msgid "If an update is available, you&#8127;ll see a notification appear in the Toolbar and navigation menu."
-msgstr ""
-
-#: wp-admin/update-core.php:850
-msgid "<strong>ClassicPress</strong> &mdash; Updating your ClassicPress installation is a simple one-click procedure: just <strong>click on the &#8220;Update Now&#8221; button</strong> when you are notified that a new version is available."
-msgstr ""
-
-#: wp-admin/update-core.php:850
-msgid "In most cases, ClassicPress will automatically apply maintenance and security updates in the background for you."
-msgstr ""
-
-#: wp-admin/update-core.php:851
-msgid "<strong>Themes and Plugins</strong> &mdash; To update individual themes or plugins from this screen, use the checkboxes to make your selection, then <strong>click on the appropriate &#8220;Update&#8221; button</strong>. To update all of your themes or plugins at once, you can check the box at the top of the section to select all before clicking the update button."
-msgstr ""
-
-#: wp-admin/update-core.php:854
-msgid "<strong>Translations</strong> &mdash; The files translating ClassicPress into your language are updated for you whenever any other updates occur. But if these files are out of date, you can <strong>click the &#8220;Update Translations&#8221;</strong> button."
-msgstr ""
-
-#: wp-admin/update-core.php:860
-msgid "How to Update"
-msgstr ""
-
-#: wp-admin/update-core.php:867
-msgid "<a href=\"https://codex.wordpress.org/Dashboard_Updates_Screen\">Documentation on Updating ClassicPress</a>"
-msgstr ""
-
-#: wp-admin/update-core.php:880
-msgid "Here you can find information about updates, set auto-updates and see what plugins or themes need updating."
-msgstr ""
-
-#: wp-admin/update-core.php:886
-msgid "Please select one or more themes to update."
-msgstr ""
-
-#: wp-admin/update-core.php:888
-msgid "Please select one or more plugins to update."
-msgstr ""
-
-#. translators: Current version of WordPress.
-#: wp-admin/update-core.php:902
-msgid "Current version: %s"
-msgstr ""
-
-#. translators: 1: Date, 2: Time.
-#: wp-admin/update-core.php:907
-msgid "Last checked on %1$s at %2$s."
-msgstr ""
-
-#. translators: 1: Date, 2: Time.
-#: wp-admin/update-core.php:907
-msgid "g:i a T"
-msgstr ""
-
-#: wp-admin/update-core.php:908
-msgid "Check again."
-msgstr ""
-
-#: wp-admin/update.php:90
-msgid "Plugin Reactivation"
-msgstr ""
-
-#: wp-admin/update.php:92
-msgid "Plugin reactivated successfully."
-msgstr ""
-
-#: wp-admin/update.php:96
-msgid "Plugin failed to reactivate due to a fatal error."
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/update.php:159
-msgid "Installing Plugin: %s"
-msgstr ""
-
-#: wp-admin/update.php:182
-#: wp-admin/update.php:334
-msgid "Only .zip archives may be uploaded."
-msgstr ""
-
-#. translators: %s: File name.
-#: wp-admin/update.php:195
-msgid "Installing plugin from uploaded file: %s"
-msgstr ""
-
-#: wp-admin/update.php:308
-msgid "Install Themes"
-msgstr ""
-
-#. translators: %s: Theme name and version.
-#: wp-admin/update.php:315
-msgid "Installing Theme: %s"
-msgstr ""
-
-#. translators: %s: File name.
-#: wp-admin/update.php:347
-msgid "Installing theme from uploaded file: %s"
-msgstr ""
-
-#: wp-admin/upgrade.php:65
-msgid "ClassicPress &rsaquo; Update"
-msgstr ""
-
-#: wp-admin/upgrade.php:73
-msgid "No Update Required"
-msgstr ""
-
-#: wp-admin/upgrade.php:74
-msgid "Your ClassicPress database is already up to date!"
-msgstr ""
-
-#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required PHP version number, 4: Minimum required MySQL version number, 5: Current PHP version number, 6: Current MySQL version number.
-#: wp-admin/upgrade.php:100
-msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires PHP version %3$s or higher and MySQL version %4$s or higher. You are running PHP version %5$s and MySQL version %6$s."
-msgstr ""
-
-#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required PHP version number, 4: Current PHP version number.
-#: wp-admin/upgrade.php:111
-msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires PHP version %3$s or higher. You are running version %4$s."
-msgstr ""
-
-#. translators: 1: URL to WordPress release notes, 2: WordPress version number, 3: Minimum required MySQL version number, 4: Current MySQL version number.
-#: wp-admin/upgrade.php:120
-msgid "You cannot update because <a href=\"%1$s\">ClassicPress %2$s</a> requires MySQL version %3$s or higher. You are running version %4$s."
-msgstr ""
-
-#: wp-admin/upgrade.php:141
-msgid "ClassicPress has been updated! Next and final step is to update your database to the newest version."
-msgstr ""
-
-#: wp-admin/upgrade.php:143
-msgid "Update ClassicPress Database"
-msgstr ""
-
-#: wp-admin/upgrade.php:153
-msgid "Update Complete"
-msgstr ""
-
-#: wp-admin/upgrade.php:154
-msgid "Your ClassicPress database has been successfully updated!"
-msgstr ""
-
-#: wp-admin/upload.php:26
-msgid "Media file attached."
-msgstr ""
-
-#. translators: %s: Number of media files.
-#: wp-admin/upload.php:29
-msgid "%s media file attached."
-msgid_plural "%s media files attached."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/upload.php:39
-msgid "Media file detached."
-msgstr ""
-
-#. translators: %s: Number of media files.
-#: wp-admin/upload.php:42
-msgid "%s media file detached."
-msgid_plural "%s media files detached."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/upload.php:52
-#: wp-admin/upload.php:90
-msgid "Media file permanently deleted."
-msgstr ""
-
-#. translators: %s: Number of media files.
-#: wp-admin/upload.php:55
-msgid "%s media file permanently deleted."
-msgid_plural "%s media files permanently deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/upload.php:65
-#: wp-admin/upload.php:92
-msgid "Media file moved to the Trash."
-msgstr ""
-
-#. translators: %s: Number of media files.
-#: wp-admin/upload.php:68
-msgid "%s media file moved to the Trash."
-msgid_plural "%s media files moved to the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/upload.php:79
-#: wp-admin/upload.php:93
-msgid "Media file restored from the Trash."
-msgstr ""
-
-#. translators: %s: Number of media files.
-#: wp-admin/upload.php:82
-msgid "%s media file restored from the Trash."
-msgid_plural "%s media files restored from the Trash."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/upload.php:91
-msgid "Error saving media file."
-msgstr ""
-
-#: wp-admin/upload.php:140
-msgid "All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first."
-msgstr ""
-
-#: wp-admin/upload.php:141
-#: wp-admin/upload.php:323
-msgid "You can view your media in a simple visual grid or a list with columns. Switch between these views using the icons to the left above the media."
-msgstr ""
-
-#: wp-admin/upload.php:142
-msgid "To delete media items, click the Bulk Select button at the top of the screen. Select any items you wish to delete, then click the Delete Selected button. Clicking the Cancel Selection button takes you back to viewing your media."
-msgstr ""
-
-#: wp-admin/upload.php:149
-#: wp-includes/media-template.php:647
-msgid "Attachment Details"
-msgstr ""
-
-#: wp-admin/upload.php:151
-msgid "Clicking an item will display an Attachment Details dialog, which allows you to preview media and make quick edits. Any changes you make to the attachment details will be automatically saved."
-msgstr ""
-
-#: wp-admin/upload.php:152
-msgid "Use the arrow buttons at the top of the dialog, or the left and right arrow keys on your keyboard, to navigate between media items quickly."
-msgstr ""
-
-#: wp-admin/upload.php:153
-msgid "You can also delete individual items and access the extended edit screen from the details dialog."
-msgstr ""
-
-#: wp-admin/upload.php:159
-#: wp-admin/upload.php:352
-msgid "<a href=\"https://wordpress.org/documentation/article/media-library-screen/\">Documentation on Media Library</a>"
-msgstr ""
-
-#. translators: %s: List view URL.
-#: wp-admin/upload.php:191
-msgid "The grid view for the Media Library requires JavaScript. <a href=\"%s\">Switch to the list view</a>."
-msgstr ""
-
-#: wp-admin/upload.php:321
-msgid "All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first. You can use the Screen Options tab to customize the display of this screen."
-msgstr ""
-
-#: wp-admin/upload.php:322
-msgid "You can narrow the list by file type/status or by date using the dropdown menus above the media table."
-msgstr ""
-
-#: wp-admin/upload.php:331
-msgid "Hovering over a row reveals action links that allow you to manage media items. You can perform the following actions:"
-msgstr ""
-
-#: wp-admin/upload.php:333
-msgid "<strong>Edit</strong> takes you to a simple screen to edit that individual file&#8217;s metadata. You can also reach that screen by clicking on the media file name or thumbnail."
-msgstr ""
-
-#: wp-admin/upload.php:334
-msgid "<strong>Delete Permanently</strong> will delete the file from the media library (as well as from any posts to which it is currently attached)."
-msgstr ""
-
-#: wp-admin/upload.php:335
-msgid "<strong>View</strong> will take you to a public display page for that file."
-msgstr ""
-
-#: wp-admin/upload.php:336
-msgid "<strong>Copy URL</strong> copies the URL for the media file to your clipboard."
-msgstr ""
-
-#: wp-admin/upload.php:337
-msgid "<strong>Download file</strong> downloads the original media file to your device."
-msgstr ""
-
-#: wp-admin/upload.php:344
-msgid "Attaching Files"
-msgstr ""
-
-#: wp-admin/upload.php:346
-msgid "If a media file has not been attached to any content, you will see that in the Uploaded To column, and can click on Attach to launch a small popup that will allow you to search for existing content and attach the file."
-msgstr ""
-
-#: wp-admin/upload.php:358
-msgid "Filter media items list"
-msgstr ""
-
-#: wp-admin/upload.php:359
-msgid "Media items list navigation"
-msgstr ""
-
-#: wp-admin/upload.php:360
-msgid "Media items list"
-msgstr ""
-
-#: wp-admin/user-edit.php:27
-#: wp-admin/user-edit.php:29
-#: wp-includes/class-wp-xmlrpc-server.php:2712
-#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:692
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:402
-#: wp-includes/user.php:2092
-#: wp-includes/user.php:2525
-#: wp-includes/user.php:2531
-msgid "Invalid user ID."
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/user-edit.php:44
-msgid "Edit User %s"
-msgstr ""
-
-#: wp-admin/user-edit.php:59
-msgid "Your profile contains information about you (your &#8220;account&#8221;) as well as some personal options related to using ClassicPress."
-msgstr ""
-
-#: wp-admin/user-edit.php:60
-msgid "You can change your password, turn on keyboard shortcuts, change the color scheme of your ClassicPress administration screens, and turn off the WYSIWYG (Visual) editor, among other things. You can hide the Toolbar (formerly called the Admin Bar) from the front end of your site, however it cannot be disabled on the admin screens."
-msgstr ""
-
-#: wp-admin/user-edit.php:61
-msgid "You can select the language you wish to use while using the ClassicPress administration screen without affecting the language site visitors see."
-msgstr ""
-
-#: wp-admin/user-edit.php:62
-msgid "Your username cannot be changed, but you can use other fields to enter your real name or a nickname, and change which name to display on your posts."
-msgstr ""
-
-#: wp-admin/user-edit.php:63
-msgid "You can log out of other devices, such as your phone or a public computer, by clicking the Log Out Everywhere Else button."
-msgstr ""
-
-#: wp-admin/user-edit.php:64
-msgid "Required fields are indicated; the rest are optional. Profile information will only be displayed if your theme is set up to do so."
-msgstr ""
-
-#: wp-admin/user-edit.php:65
-msgid "Remember to click the Update Profile button when you are finished."
-msgstr ""
-
-#: wp-admin/user-edit.php:77
-msgid "<a href=\"https://wordpress.org/documentation/article/users-your-profile-screen/\">Documentation on User Profiles</a>"
-msgstr ""
-
-#: wp-admin/user-edit.php:103
-#: wp-admin/user-edit.php:135
-#: wp-admin/user-edit.php:194
-#: wp-admin/users.php:114
-#: wp-admin/users.php:144
-#: wp-admin/users.php:243
-#: wp-includes/class-wp-xmlrpc-server.php:2706
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:699
-msgid "Sorry, you are not allowed to edit this user."
-msgstr ""
-
-#: wp-admin/user-edit.php:204
-msgid "This user has super admin privileges."
-msgstr ""
-
-#: wp-admin/user-edit.php:210
-msgid "Profile updated."
-msgstr ""
-
-#: wp-admin/user-edit.php:212
-msgid "User updated."
-msgstr ""
-
-#: wp-admin/user-edit.php:215
-msgid "&larr; Go to Users"
-msgstr ""
-
-#: wp-admin/user-edit.php:223
-msgid "Error while saving the new email address. Please try again."
-msgstr ""
-
-#: wp-admin/user-edit.php:243
-#: wp-admin/users.php:630
-msgctxt "user"
-msgid "Add Existing"
-msgstr ""
-
-#: wp-admin/user-edit.php:279
-msgid "Personal Options"
-msgstr ""
-
-#: wp-admin/user-edit.php:286
-msgid "Visual Editor"
-msgstr ""
-
-#: wp-admin/user-edit.php:289
-msgid "Disable the visual editor when writing"
-msgstr ""
-
-#: wp-admin/user-edit.php:310
-msgid "Syntax Highlighting"
-msgstr ""
-
-#: wp-admin/user-edit.php:313
-msgid "Disable syntax highlighting when editing code"
-msgstr ""
-
-#: wp-admin/user-edit.php:343
-#: wp-includes/class-wp-editor.php:1398
-msgid "Keyboard Shortcuts"
-msgstr ""
-
-#: wp-admin/user-edit.php:347
-msgid "Enable keyboard shortcuts for comment moderation."
-msgstr ""
-
-#: wp-admin/user-edit.php:355
-#: wp-includes/class-wp-admin-bar.php:469
-msgid "Toolbar"
-msgstr ""
-
-#: wp-admin/user-edit.php:359
-msgid "Show Toolbar when viewing site"
-msgstr ""
-
-#. translators: The user language selection field label.
-#. translators: Hidden accessibility text.
-#: wp-admin/user-edit.php:372
-#: wp-admin/user-new.php:560
-#: wp-includes/class-wp-editor.php:1232
-#: wp-login.php:301
-msgid "Language"
-msgstr ""
-
-#: wp-admin/user-edit.php:433
-msgid "Usernames cannot be changed."
-msgstr ""
-
-#: wp-admin/user-edit.php:466
-msgid "Grant this user super admin privileges for the Network."
-msgstr ""
-
-#: wp-admin/user-edit.php:468
-msgid "Super admin privileges cannot be removed because this user has the network admin email."
-msgstr ""
-
-#: wp-admin/user-edit.php:475
-#: wp-admin/user-new.php:541
-msgid "First Name"
-msgstr ""
-
-#: wp-admin/user-edit.php:480
-#: wp-admin/user-new.php:545
-msgid "Last Name"
-msgstr ""
-
-#: wp-admin/user-edit.php:485
-msgid "Nickname"
-msgstr ""
-
-#: wp-admin/user-edit.php:491
-msgid "Display name publicly as"
-msgstr ""
-
-#: wp-admin/user-edit.php:529
-msgid "Contact Info"
-msgstr ""
-
-#: wp-admin/user-edit.php:538
-msgid "If you change this, an email will be sent at your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>"
-msgstr ""
-
-#. translators: %s: New email.
-#: wp-admin/user-edit.php:549
-msgid "There is a pending change of your email to %s."
-msgstr ""
-
-#: wp-admin/user-edit.php:576
-#: wp-admin/user-new.php:549
-#: wp-includes/comment-template.php:2558
-msgid "Website"
-msgstr ""
-
-#: wp-admin/user-edit.php:618
-msgid "About Yourself"
-msgstr ""
-
-#: wp-admin/user-edit.php:618
-msgid "About the user"
-msgstr ""
-
-#: wp-admin/user-edit.php:630
-msgid "Biographical Info"
-msgstr ""
-
-#: wp-admin/user-edit.php:632
-msgid "Share a little biographical information to fill out your profile. This may be shown publicly."
-msgstr ""
-
-#: wp-admin/user-edit.php:641
-msgid "Profile Picture"
-msgstr ""
-
-#. translators: %s: Gravatar URL.
-#: wp-admin/user-edit.php:649
-msgid "<a href=\"%s\" rel=\"noreferrer\">You can change your profile picture on Gravatar</a>."
-msgstr ""
-
-#: wp-admin/user-edit.php:650
-msgid "https://en.gravatar.com/"
-msgstr ""
-
-#: wp-admin/user-edit.php:687
-msgid "Account Management"
-msgstr ""
-
-#: wp-admin/user-edit.php:691
-msgid "New Password"
-msgstr ""
-
-#: wp-admin/user-edit.php:694
-msgid "Set New Password"
-msgstr ""
-
-#: wp-admin/user-edit.php:703
-msgid "Cancel password change"
-msgstr ""
-
-#: wp-admin/user-edit.php:712
-msgid "Repeat New Password"
-msgstr ""
-
-#: wp-admin/user-edit.php:716
-msgid "Type your new password again."
-msgstr ""
-
-#: wp-admin/user-edit.php:718
-msgid "Type the new password again."
-msgstr ""
-
-#: wp-admin/user-edit.php:736
-#: wp-login.php:941
-msgid "Password Reset"
-msgstr ""
-
-#: wp-admin/user-edit.php:740
-msgid "Send Reset Link"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/user-edit.php:747
-msgid "Send %s a link to reset their password. This will not change their password, nor will it force a change."
-msgstr ""
-
-#: wp-admin/user-edit.php:758
-#: wp-admin/user-edit.php:768
-#: wp-admin/user-edit.php:778
-msgid "Sessions"
-msgstr ""
-
-#: wp-admin/user-edit.php:760
-#: wp-admin/user-edit.php:770
-msgid "Log Out Everywhere Else"
-msgstr ""
-
-#: wp-admin/user-edit.php:762
-msgid "You are only logged in at this location."
-msgstr ""
-
-#: wp-admin/user-edit.php:772
-msgid "Did you lose your phone or leave your account logged in at a public computer? You can log out everywhere else, and stay logged in here."
-msgstr ""
-
-#: wp-admin/user-edit.php:780
-msgid "Log Out Everywhere"
-msgstr ""
-
-#. translators: %s: User's display name.
-#: wp-admin/user-edit.php:784
-msgid "Log %s out of all locations."
-msgstr ""
-
-#: wp-admin/user-edit.php:794
-msgid "Application Passwords"
-msgstr ""
-
-#: wp-admin/user-edit.php:795
-msgid "Application passwords allow authentication via non-interactive systems, such as XML-RPC or the REST API, without providing your actual password. Application passwords can be easily revoked. They cannot be used for traditional logins to your website."
-msgstr ""
-
-#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
-#: wp-admin/user-edit.php:807
-msgid "Application passwords grant access to <a href=\"%1$s\">the %2$s site in this installation that you have permissions on</a>."
-msgid_plural "Application passwords grant access to <a href=\"%1$s\">all %2$s sites in this installation that you have permissions on</a>."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: 1: URL to my-sites.php, 2: Number of sites the user has.
-#: wp-admin/user-edit.php:815
-msgid "Application passwords grant access to <a href=\"%1$s\">the %2$s site on the network as you have Super Admin rights</a>."
-msgid_plural "Application passwords grant access to <a href=\"%1$s\">all %2$s sites on the network as you have Super Admin rights</a>."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/user-edit.php:839
-msgid "Required to create an Application Password, but not to update the user."
-msgstr ""
-
-#: wp-admin/user-edit.php:853
-msgid "Add New Application Password"
-msgstr ""
-
-#: wp-admin/user-edit.php:857
-msgid "Your website appears to use Basic Authentication, which is not currently compatible with Application Passwords."
-msgstr ""
-
-#: wp-admin/user-edit.php:869
-msgid "The application password feature requires HTTPS, which is not enabled on this site."
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-admin/user-edit.php:874
-msgid "If this is a development website you can <a href=\"%s\" target=\"_blank\">set the environment type accordingly</a> to enable application passwords."
-msgstr ""
-
-#: wp-admin/user-edit.php:875
-msgid "https://developer.wordpress.org/apis/wp-config-php/#wp-environment-type"
-msgstr ""
-
-#: wp-admin/user-edit.php:924
-msgid "Additional Capabilities"
-msgstr ""
-
-#: wp-admin/user-edit.php:928
-msgid "Capabilities"
-msgstr ""
-
-#. translators: %s: Capability name.
-#: wp-admin/user-edit.php:942
-msgid "Denied: %s"
-msgstr ""
-
-#: wp-admin/user-edit.php:956
-msgid "Update Profile"
-msgstr ""
-
-#: wp-admin/user-edit.php:956
-msgid "Update User"
-msgstr ""
-
-#. translators: Hidden accessibility text.
-#: wp-admin/user-edit.php:1003
-#: wp-admin/js/application-passwords.js:203
-#: wp-admin/js/common.js:1109
-msgid "Dismiss this notice."
-msgstr ""
-
-#: wp-admin/user-new.php:23
-#: wp-admin/user-new.php:189
-msgid "Sorry, you are not allowed to create users."
-msgstr ""
-
-#. translators: 1: Site title, 2: Site URL, 3: User role, 4: Activation URL.
-#: wp-admin/user-new.php:122
-msgid ""
-"Hi,\n"
-"\n"
-"You've been invited to join '%1$s' at\n"
-"%2$s with the role of %3$s.\n"
-"\n"
-"Please click the following link to confirm the invite:\n"
-"%4$s"
-msgstr ""
-
-#. translators: Joining confirmation notification email subject. %s: Site title.
-#: wp-admin/user-new.php:135
-msgid "[%s] Joining Confirmation"
-msgstr ""
-
-#: wp-admin/user-new.php:263
-msgid "To add a new user to your site, fill in the form on this screen and click the Add New User button at the bottom."
-msgstr ""
-
-#: wp-admin/user-new.php:266
-msgid "Because this is a multisite installation, you may add accounts that already exist on the Network by specifying a username or email, and defining a role. For more options, such as specifying a password, you have to be a Network Administrator and use the hover link under an existing user&#8217;s name to Edit the user profile under Network Admin > All Users."
-msgstr ""
-
-#: wp-admin/user-new.php:267
-msgid "New users will receive an email letting them know they&#8217;ve been added as a user for your site. This email will also contain their password. Check the box if you do not want the user to receive a welcome email."
-msgstr ""
-
-#: wp-admin/user-new.php:269
-msgid "New users are automatically assigned a password, which they can change after logging in. You can view or edit the assigned password by clicking the Show Password button. The username cannot be changed once the user has been added."
-msgstr ""
-
-#: wp-admin/user-new.php:271
-msgid "By default, new users will receive an email letting them know they&#8217;ve been added as a user for your site. This email will also contain a password reset link. Uncheck the box if you do not want to send the new user a welcome email."
-msgstr ""
-
-#: wp-admin/user-new.php:274
-msgid "Remember to click the Add New User button at the bottom of this screen when you are finished."
-msgstr ""
-
-#: wp-admin/user-new.php:287
-msgid "User Roles"
-msgstr ""
-
-#: wp-admin/user-new.php:288
-msgid "Here is a basic overview of the different user roles and the permissions associated with each one:"
-msgstr ""
-
-#: wp-admin/user-new.php:290
-msgid "Subscribers can read comments/comment/receive newsletters, etc. but cannot create regular site content."
-msgstr ""
-
-#: wp-admin/user-new.php:291
-msgid "Contributors can write and manage their posts but not publish posts or upload media files."
-msgstr ""
-
-#: wp-admin/user-new.php:292
-msgid "Authors can publish and manage their own posts, and are able to upload files."
-msgstr ""
-
-#: wp-admin/user-new.php:293
-msgid "Editors can publish posts, manage posts as well as manage other people&#8217;s posts, etc."
-msgstr ""
-
-#: wp-admin/user-new.php:294
-msgid "Administrators have access to all the administration features."
-msgstr ""
-
-#: wp-admin/user-new.php:301
-msgid "<a href=\"https://wordpress.org/documentation/article/users-add-new-screen/\">Documentation on Adding New Users</a>"
-msgstr ""
-
-#: wp-admin/user-new.php:336
-msgid "Invitation email sent to new user. A confirmation link must be clicked before their account is created."
-msgstr ""
-
-#: wp-admin/user-new.php:339
-msgid "Invitation email sent to user. A confirmation link must be clicked for them to be added to your site."
-msgstr ""
-
-#: wp-admin/user-new.php:342
-msgid "User has been added to your site."
-msgstr ""
-
-#: wp-admin/user-new.php:351
-msgid "That user is already a member of this site."
-msgstr ""
-
-#: wp-admin/user-new.php:354
-msgid "That user could not be added to this site."
-msgstr ""
-
-#: wp-admin/user-new.php:357
-msgid "User has been created, but could not be added to this site."
-msgstr ""
-
-#: wp-admin/user-new.php:360
-#: wp-includes/ms-functions.php:159
-msgid "The requested user does not exist."
-msgstr ""
-
-#: wp-admin/user-new.php:363
-#: wp-includes/ms-functions.php:491
-msgid "Please enter a valid email address."
-msgstr ""
-
-#: wp-admin/user-new.php:421
-msgid "Enter the email address of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite."
-msgstr ""
-
-#: wp-admin/user-new.php:425
-msgid "Enter the email address or username of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite."
-msgstr ""
-
-#: wp-admin/user-new.php:426
-msgid "Email or Username"
-msgstr ""
-
-#: wp-admin/user-new.php:475
-#: wp-admin/user-new.php:642
-msgid "Skip Confirmation Email"
-msgstr ""
-
-#: wp-admin/user-new.php:478
-#: wp-admin/user-new.php:645
-msgid "Add the user without sending an email that requires their confirmation."
-msgstr ""
-
-#: wp-admin/user-new.php:507
-msgid "Create a brand new user and add them to this site."
-msgstr ""
-
-#: wp-admin/user-new.php:588
-msgid "Generate password"
-msgstr ""
-
-#: wp-admin/user-new.php:606
-msgid "Type the password again."
-msgstr ""
-
-#: wp-admin/user-new.php:619
-msgid "Send User Notification"
-msgstr ""
-
-#: wp-admin/user-new.php:622
-msgid "Send the new user an email about their account."
-msgstr ""
-
-#: wp-admin/users.php:16
-#: wp-includes/class-wp-xmlrpc-server.php:2769
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:213
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:445
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:451
-msgid "Sorry, you are not allowed to list users."
-msgstr ""
-
-#: wp-admin/users.php:35
-msgid "This screen lists all the existing users for your site. Each user has one of five defined roles as set by the site admin: Site Administrator, Editor, Author, Contributor, or Subscriber. Users with roles other than Administrator will see fewer options in the dashboard navigation when they are logged in, based on their role."
-msgstr ""
-
-#: wp-admin/users.php:36
-msgid "To add a new user for your site, click the Add New button at the top of the screen or Add New in the Users menu section."
-msgstr ""
-
-#: wp-admin/users.php:44
-msgid "You can customize the display of this screen in a number of ways:"
-msgstr ""
-
-#: wp-admin/users.php:46
-msgid "You can hide/display columns based on your needs and decide how many users to list per screen using the Screen Options tab."
-msgstr ""
-
-#: wp-admin/users.php:47
-msgid "You can filter the list of users by User Role using the text links above the users list to show All, Administrator, Editor, Author, Contributor, or Subscriber. The default view is to show all users. Unused User Roles are not listed."
-msgstr ""
-
-#: wp-admin/users.php:48
-msgid "You can view all posts made by a user by clicking on the number under the Posts column."
-msgstr ""
-
-#: wp-admin/users.php:53
-msgid "Hovering over a row in the users list will display action links that allow you to manage users. You can perform the following actions:"
-msgstr ""
-
-#: wp-admin/users.php:55
-msgid "<strong>Edit</strong> takes you to the editable profile screen for that user. You can also reach that screen by clicking on the username."
-msgstr ""
-
-#: wp-admin/users.php:58
-msgid "<strong>Remove</strong> allows you to remove a user from your site. It does not delete their content. You can also remove multiple users at once by using bulk actions."
-msgstr ""
-
-#: wp-admin/users.php:60
-msgid "<strong>Delete</strong> brings you to the Delete Users screen for confirmation, where you can permanently remove a user from your site and delete their content. You can also delete multiple users at once by using bulk actions."
-msgstr ""
-
-#: wp-admin/users.php:63
-msgid "<strong>View</strong> takes you to a public author archive which lists all the posts published by the user."
-msgstr ""
-
-#: wp-admin/users.php:66
-msgid "<strong>Send password reset</strong> sends the user an email with a link to set a new password."
-msgstr ""
-
-#: wp-admin/users.php:82
-msgid "<a href=\"https://wordpress.org/documentation/article/users-screen/\">Documentation on Managing Users</a>"
-msgstr ""
-
-#: wp-admin/users.php:83
-msgid "<a href=\"https://wordpress.org/documentation/article/roles-and-capabilities/\">Descriptions of Roles and Capabilities</a>"
-msgstr ""
-
-#: wp-admin/users.php:172
-#: wp-admin/users.php:270
-msgid "User deletion is not allowed from this screen."
-msgstr ""
-
-#: wp-admin/users.php:192
-#: wp-admin/users.php:281
-msgid "Sorry, you are not allowed to delete users."
-msgstr ""
-
-#: wp-admin/users.php:200
-msgid "Sorry, you are not allowed to delete that user."
-msgstr ""
-
-#: wp-admin/users.php:231
-msgid "Sorry, you are not allowed to edit users."
-msgstr ""
-
-#: wp-admin/users.php:326
-msgid "Delete Users"
-msgstr ""
-
-#: wp-admin/users.php:329
-msgid "Please select an option."
-msgstr ""
-
-#: wp-admin/users.php:334
-msgid "You have specified this user for deletion:"
-msgstr ""
-
-#: wp-admin/users.php:336
-msgid "You have specified these users for deletion:"
-msgstr ""
-
-#. translators: 1: User ID, 2: User login.
-#: wp-admin/users.php:346
-msgid "ID #%1$s: %2$s <strong>The current user will not be deleted.</strong>"
-msgstr ""
-
-#. translators: 1: User ID, 2: User login.
-#: wp-admin/users.php:349
-#: wp-admin/users.php:487
-msgid "ID #%1$s: %2$s"
-msgstr ""
-
-#: wp-admin/users.php:363
-msgid "What should be done with content owned by this user?"
-msgstr ""
-
-#: wp-admin/users.php:365
-msgid "What should be done with content owned by these users?"
-msgstr ""
-
-#: wp-admin/users.php:399
-msgid "There are no valid users selected for deletion."
-msgstr ""
-
-#: wp-admin/users.php:411
-#: wp-admin/users.php:443
-msgid "You cannot remove users."
-msgstr ""
-
-#: wp-admin/users.php:468
-msgid "Remove Users from Site"
-msgstr ""
-
-#: wp-admin/users.php:471
-msgid "You have specified this user for removal:"
-msgstr ""
-
-#: wp-admin/users.php:473
-msgid "You have specified these users for removal:"
-msgstr ""
-
-#. translators: 1: User ID, 2: User login.
-#: wp-admin/users.php:484
-msgid "ID #%1$s: %2$s <strong>Sorry, you are not allowed to remove this user.</strong>"
-msgstr ""
-
-#: wp-admin/users.php:495
-msgid "Confirm Removal"
-msgstr ""
-
-#: wp-admin/users.php:497
-msgid "There are no valid users selected for removal."
-msgstr ""
-
-#. translators: %s: Number of users.
-#: wp-admin/users.php:542
-msgid "%s user deleted."
-msgid_plural "%s users deleted."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/users.php:547
-msgid "New user created."
-msgstr ""
-
-#: wp-admin/users.php:569
-msgid "Password reset link sent."
-msgstr ""
-
-#. translators: %s: Number of users.
-#: wp-admin/users.php:572
-msgid "Password reset links sent to %s user."
-msgid_plural "Password reset links sent to %s users."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-admin/users.php:580
-msgid "The current user&#8217;s role must have user editing capabilities."
-msgstr ""
-
-#: wp-admin/users.php:581
-msgid "Other user roles have been changed."
-msgstr ""
-
-#: wp-admin/users.php:584
-msgid "You cannot delete the current user."
-msgstr ""
-
-#: wp-admin/users.php:585
-msgid "Other users have been deleted."
-msgstr ""
-
-#: wp-admin/users.php:591
-msgid "You cannot remove the current user."
-msgstr ""
-
-#: wp-admin/users.php:592
-msgid "Other users have been removed."
-msgstr ""
-
-#: wp-admin/widgets-form.php:45
-msgid "Widgets are independent sections of content that can be placed into any widgetized area provided by your theme (commonly called sidebars). To populate your sidebars/widget areas with individual widgets, drag and drop the title bars into the desired area. By default, only the first widget area is expanded. To populate additional widget areas, click on their title bars to expand them."
-msgstr ""
-
-#: wp-admin/widgets-form.php:46
-msgid "The Available Widgets section contains all the widgets you can choose from. Once you drag a widget into a sidebar, it will open to allow you to configure its settings. When you are happy with the widget settings, click the Save button and the widget will go live on your site. If you click Delete, it will remove the widget."
-msgstr ""
-
-#: wp-admin/widgets-form.php:52
-msgid "Removing and Reusing"
-msgstr ""
-
-#: wp-admin/widgets-form.php:54
-msgid "If you want to remove the widget but save its setting for possible future use, just drag it into the Inactive Widgets area. You can add them back anytime from there. This is especially helpful when you switch to a theme with fewer or different widget areas."
-msgstr ""
-
-#: wp-admin/widgets-form.php:55
-msgid "Widgets may be used multiple times. You can give each widget a title, to display on your site, but it&#8217;s not required."
-msgstr ""
-
-#: wp-admin/widgets-form.php:56
-msgid "Enabling Accessibility Mode, via Screen Options, allows you to use Add and Edit buttons instead of using drag and drop."
-msgstr ""
-
-#: wp-admin/widgets-form.php:62
-msgid "Missing Widgets"
-msgstr ""
-
-#: wp-admin/widgets-form.php:64
-msgid "Many themes show some sidebar widgets by default until you edit your sidebars, but they are not automatically displayed in your sidebar management tool. After you make your first widget change, you can re-add the default widgets by adding them from the Available Widgets area."
-msgstr ""
-
-#: wp-admin/widgets-form.php:65
-msgid "When changing themes, there is often some variation in the number and setup of widget areas/sidebars and sometimes these conflicts make the transition a bit less smooth. If you changed themes and seem to be missing widgets, scroll down on this screen to the Inactive Widgets area, where all of your widgets and their settings will have been saved."
-msgstr ""
-
-#: wp-admin/widgets-form.php:71
-msgid "<a href=\"https://wordpress.org/documentation/article/appearance-widgets-screen-classic-editor/\">Documentation on Widgets</a>"
-msgstr ""
-
-#: wp-admin/widgets-form.php:91
-msgid "Inactive Sidebar (not used)"
-msgstr ""
-
-#: wp-admin/widgets-form.php:94
-msgid "This sidebar is no longer available and does not show anywhere on your site. Remove each of the widgets below to fully remove this inactive sidebar."
-msgstr ""
-
-#: wp-admin/widgets-form.php:110
-msgid "Inactive Widgets"
-msgstr ""
-
-#: wp-admin/widgets-form.php:113
-msgid "Drag widgets here to remove them from the sidebar but keep their settings."
-msgstr ""
-
-#. translators: %s: Widget name.
-#: wp-admin/widgets-form.php:282
-msgid "Widget %s"
-msgstr ""
-
-#: wp-admin/widgets-form.php:297
-msgid "Select both the sidebar for this widget and the position of the widget in that sidebar."
-msgstr ""
-
-#: wp-admin/widgets-form.php:299
-msgid "Position"
-msgstr ""
-
-#: wp-admin/widgets-form.php:344
-msgid "Save Widget"
-msgstr ""
-
-#: wp-admin/widgets-form.php:362
-#: wp-admin/js/inline-edit-post.js:612
-#: wp-admin/js/inline-edit-tax.js:227
-msgid "Changes saved."
-msgstr ""
-
-#: wp-admin/widgets-form.php:367
-msgid "Error in displaying the widget settings form."
-msgstr ""
-
-#: wp-admin/widgets-form.php:400
-msgid "Enable accessibility mode"
-msgstr ""
-
-#: wp-admin/widgets-form.php:400
-msgid "Disable accessibility mode"
-msgstr ""
-
-#: wp-admin/widgets-form.php:425
-msgid "Available Widgets"
-msgstr ""
-
-#: wp-admin/widgets-form.php:428
-msgid "To activate a widget drag it to a sidebar or click on it. To deactivate a widget and delete its settings, drag it back."
-msgstr ""
-
-#: wp-admin/widgets-form.php:466
-msgid "Clear Inactive Widgets"
-msgstr ""
-
-#: wp-admin/widgets-form.php:476
-msgid "This will clear all items from the inactive widgets list. You will not be able to restore any customizations."
-msgstr ""
-
-#: wp-admin/widgets-form.php:546
-msgid "Add Widget"
-msgstr ""
-
-#: wp-admin/widgets.php:24
-msgid "The theme you are currently using is not widget-aware, meaning that it has no sidebars that you are able to change. For information on making your theme widget-aware, please <a href=\"https://developer.wordpress.org/themes/functionality/widgets/\">follow these instructions</a>."
-msgstr ""
-
 #: wp-comments-post.php:31
 msgid "Comment Submission Failure"
 msgstr ""
@@ -23041,6 +79,12 @@ msgstr ""
 #. translators: 1: Hook name, 2: Error code, 3: Error message, 4: Event data.
 #: wp-cron.php:159
 msgid "Cron unschedule event error for hook: %1$s, Error code: %2$s, Error message: %3$s, Data: %4$s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/admin-bar.php:136
+#: wp-includes/admin-bar.php:156
+msgid "About ClassicPress"
 msgstr ""
 
 #: wp-includes/admin-bar.php:167
@@ -23078,6 +122,16 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
+#. translators: %s: Site title.
+#: wp-includes/admin-bar.php:351
+msgid "Network Admin: %s"
+msgstr ""
+
+#. translators: %s: Site title.
+#: wp-includes/admin-bar.php:354
+msgid "User Dashboard: %s"
+msgstr ""
+
 #: wp-includes/admin-bar.php:375
 #: wp-includes/admin-bar.php:670
 #: wp-includes/deprecated.php:2810
@@ -23088,8 +142,47 @@ msgstr ""
 msgid "Edit Site"
 msgstr ""
 
+#: wp-includes/admin-bar.php:396
+#: wp-includes/admin-bar.php:505
+#: wp-includes/admin-bar.php:629
+#: wp-includes/deprecated.php:2812
+#: wp-includes/deprecated.php:2814
+msgid "Dashboard"
+msgstr ""
+
+#: wp-includes/admin-bar.php:442
+#: wp-includes/customize/class-wp-customize-theme-control.php:244
+msgid "Customize"
+msgstr ""
+
+#: wp-includes/admin-bar.php:479
+msgid "My Sites"
+msgstr ""
+
 #: wp-includes/admin-bar.php:496
 msgid "Network Admin"
+msgstr ""
+
+#: wp-includes/admin-bar.php:515
+msgid "Sites"
+msgstr ""
+
+#: wp-includes/admin-bar.php:526
+msgid "Users"
+msgstr ""
+
+#: wp-includes/admin-bar.php:537
+#: wp-includes/admin-bar.php:979
+#: wp-includes/customize/class-wp-customize-themes-panel.php:82
+msgid "Themes"
+msgstr ""
+
+#: wp-includes/admin-bar.php:548
+msgid "Plugins"
+msgstr ""
+
+#: wp-includes/admin-bar.php:559
+msgid "Settings"
 msgstr ""
 
 #: wp-includes/admin-bar.php:660
@@ -23124,17 +217,62 @@ msgctxt "admin bar menu group label"
 msgid "New"
 msgstr ""
 
+#. translators: Hidden accessibility text. %s: Number of comments.
+#: wp-includes/admin-bar.php:942
+msgid "%s Comment in moderation"
+msgid_plural "%s Comments in moderation"
+msgstr[0] ""
+msgstr[1] ""
+
+#: wp-includes/admin-bar.php:994
+#: wp-includes/class-wp-customize-widgets.php:416
+#: wp-includes/functions.php:5303
+msgid "Widgets"
+msgstr ""
+
+#: wp-includes/admin-bar.php:1005
+#: wp-includes/class-wp-customize-nav-menus.php:673
+#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:113
+msgid "Menus"
+msgstr ""
+
+#: wp-includes/admin-bar.php:1016
+msgid "Background"
+msgstr ""
+
+#: wp-includes/admin-bar.php:1030
+msgid "Header"
+msgstr ""
+
 #. translators: Hidden accessibility text. %s: Total number of updates available.
-#. translators: %s: Total number of updates available.
 #: wp-includes/admin-bar.php:1057
-#: wp-admin/js/updates.js:361
 msgid "%s update available"
 msgid_plural "%s updates available"
 msgstr[0] ""
 msgstr[1] ""
 
+#. translators: Hidden accessibility text.
+#: wp-includes/admin-bar.php:1090
+#: wp-includes/admin-bar.php:1092
+#: wp-includes/class-wp-editor.php:1903
+#: wp-includes/media.php:4578
+#: wp-includes/media.php:4623
+msgid "Search"
+msgstr ""
+
 #: wp-includes/admin-bar.php:1128
 msgid "Exit Recovery Mode"
+msgstr ""
+
+#: wp-includes/atomlib.php:151
+#: wp-includes/feed.php:582
+#: wp-includes/IXR/class-IXR-message.php:48
+msgid "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension."
+msgstr ""
+
+#. translators: 1: Error message, 2: Line number.
+#: wp-includes/atomlib.php:175
+msgid "XML Error: %1$s at line %2$s"
 msgstr ""
 
 #. translators: %s: get_the_author()
@@ -23153,6 +291,14 @@ msgstr ""
 #: wp-includes/author-template.php:322
 #: wp-includes/author-template.php:535
 msgid "Posts by %s"
+msgstr ""
+
+#. translators: 1: User's first name, 2: Last name.
+#: wp-includes/author-template.php:513
+#: wp-includes/user.php:855
+#: wp-includes/user.php:2272
+msgctxt "Display name based on first name and last name"
+msgid "%1$s %2$s"
 msgstr ""
 
 #. translators: %s: Date and time of last update.
@@ -23248,6 +394,10 @@ msgctxt "User role"
 msgid "Subscriber"
 msgstr ""
 
+#: wp-includes/category-template.php:162
+msgid "Uncategorized"
+msgstr ""
+
 #. translators: 1: "type => link", 2: "taxonomy => link_category"
 #. translators: 1: caller_get_posts, 2: ignore_sticky_posts
 #. translators: 1: who, 2: capability
@@ -23262,6 +412,21 @@ msgstr ""
 #: wp-includes/class-wp-taxonomy.php:632
 msgid "No categories"
 msgstr ""
+
+#: wp-includes/category-template.php:560
+#: wp-includes/theme-compat/sidebar.php:129
+#: wp-includes/widgets/class-wp-widget-categories.php:31
+#: wp-includes/widgets/class-wp-widget-categories.php:48
+msgid "Categories"
+msgstr ""
+
+#. translators: %s: Number of items (tags).
+#: wp-includes/category-template.php:878
+#: wp-includes/category-template.php:889
+msgid "%s item"
+msgid_plural "%s items"
+msgstr[0] ""
+msgstr[1] ""
 
 #: wp-includes/category-template.php:1233
 msgid "Tags: "
@@ -23370,6 +535,12 @@ msgstr ""
 msgid "Pingback:"
 msgstr ""
 
+#: wp-includes/class-walker-comment.php:258
+#: wp-includes/class-wp-editor.php:1389
+#: wp-includes/comment-template.php:1233
+msgid "Edit"
+msgstr ""
+
 #: wp-includes/class-walker-comment.php:305
 msgid "Your comment is awaiting moderation."
 msgstr ""
@@ -23393,6 +564,14 @@ msgstr ""
 
 #: wp-includes/class-wp-admin-bar.php:146
 msgid "The menu ID should not be empty."
+msgstr ""
+
+#: wp-includes/class-wp-admin-bar.php:467
+msgid "Skip to toolbar"
+msgstr ""
+
+#: wp-includes/class-wp-admin-bar.php:469
+msgid "Toolbar"
 msgstr ""
 
 #: wp-includes/class-wp-application-passwords.php:80
@@ -23423,6 +602,17 @@ msgstr ""
 msgid "Could not delete application passwords."
 msgstr ""
 
+#: wp-includes/class-wp-customize-control.php:590
+#: wp-includes/class-wp-customize-nav-menus.php:707
+#: wp-includes/widgets/class-wp-nav-menu-widget.php:172
+msgid "&mdash; Select &mdash;"
+msgstr ""
+
+#. translators: %s: Add New Page label.
+#: wp-includes/class-wp-customize-control.php:632
+msgid "+ %s"
+msgstr ""
+
 #. translators: Hidden accessibility text.
 #: wp-includes/class-wp-customize-control.php:639
 msgid "New page title"
@@ -23432,12 +622,43 @@ msgstr ""
 msgid "New page title&hellip;"
 msgstr ""
 
+#: wp-includes/class-wp-customize-control.php:643
+#: wp-includes/class-wp-customize-nav-menus.php:1245
+msgid "Add"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:450
+#: wp-includes/class-wp-xmlrpc-server.php:4009
+#: wp-includes/functions.php:3566
+#: wp-includes/script-loader.php:607
+#: wp-includes/script-loader.php:1105
+msgid "Something went wrong."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:515
+#: wp-includes/script-loader.php:1106
+msgid "You need a higher level of permission."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:516
+#: wp-includes/script-loader.php:1107
+msgid "Sorry, you are not allowed to customize this site."
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:525
 msgid "Invalid changeset UUID"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:552
 msgid "Non-existent changeset UUID."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:571
+msgid "Sorry, you are not allowed to edit theme options on this site."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:581
+msgid "The requested theme does not exist."
 msgstr ""
 
 #. translators: %s: customize_messenger_channel
@@ -23554,6 +775,33 @@ msgstr ""
 msgid "%s is already customizing this site. Do you want to take over?"
 msgstr ""
 
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-manager.php:4291
+#: wp-includes/script-loader.php:805
+#: wp-includes/widgets/class-wp-widget-text.php:539
+#: wp-includes/widgets/class-wp-widget-text.php:554
+#: wp-includes/js/wp-pointer.js:20
+msgid "Dismiss"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4318
+msgid "Go back"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4320
+#: wp-includes/class-wp-editor.php:1249
+#: wp-includes/media-template.php:1531
+msgid "Preview"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4322
+msgid "Take over"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4336
+msgid "Update anyway, even though it might break your site?"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:4355
 msgid "Share Preview Link"
 msgstr ""
@@ -23565,6 +813,18 @@ msgstr ""
 #. translators: Hidden accessibility text.
 #: wp-includes/class-wp-customize-manager.php:4363
 msgid "Preview Link"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-manager.php:4371
+#: wp-includes/class-wp-customize-manager.php:5694
+#: wp-includes/class-wp-customize-manager.php:5715
+#: wp-includes/customize/class-wp-customize-nav-menu-locations-control.php:58
+#: wp-includes/functions.php:8136
+#: wp-includes/media-template.php:167
+#: wp-includes/widgets/class-wp-widget-custom-html.php:318
+#: wp-login.php:631
+msgid "(opens in a new tab)"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:4376
@@ -23586,10 +846,24 @@ msgstr ""
 msgid "Live Preview: %s"
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:4847
+#: wp-includes/script-loader.php:1089
+msgid "Publish"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4852
+#: wp-includes/script-loader.php:1091
+msgid "Save Draft"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:4857
 #: wp-includes/script-loader.php:1094
 msgctxt "customizer changeset action/button label"
 msgid "Schedule"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:4934
+msgid "Are you sure you want to delete this theme?"
 msgstr ""
 
 #. translators: %d: Number of theme search results, which cannot currently consider singular vs. plural forms.
@@ -23639,9 +913,31 @@ msgstr ""
 msgid "Site Identity"
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:5134
+#: wp-includes/class-wp-xmlrpc-server.php:589
+msgid "Site Title"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5151
+msgid "Tagline"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5170
 #: wp-includes/class-wp-customize-manager.php:5277
 msgid "Display Site Title and Tagline"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5192
+msgid "Site Icon"
+msgstr ""
+
+#. translators: %s: Site Icon size in pixels.
+#: wp-includes/class-wp-customize-manager.php:5195
+msgid "The Site Icon is what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. It should be square and at least %s pixels."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5220
+msgid "Logo"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5228
@@ -23653,13 +949,26 @@ msgstr ""
 msgid "Change logo"
 msgstr ""
 
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-manager.php:5230
+#: wp-includes/class-wp-customize-widgets.php:781
+#: wp-includes/class-wp-editor.php:1388
+#: wp-includes/customize/class-wp-customize-media-control.php:228
+#: wp-includes/customize/class-wp-customize-media-control.php:238
+#: wp-includes/customize/class-wp-customize-media-control.php:249
+#: wp-includes/customize/class-wp-customize-media-control.php:259
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:152
+#: wp-includes/media-template.php:608
+#: wp-includes/media.php:4583
+msgid "Remove"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5231
 #: wp-includes/customize/class-wp-customize-color-control.php:54
 #: wp-includes/customize/class-wp-customize-media-control.php:227
 #: wp-includes/customize/class-wp-customize-media-control.php:237
 #: wp-includes/customize/class-wp-customize-media-control.php:248
 #: wp-includes/customize/class-wp-customize-media-control.php:258
-#: wp-admin/js/color-picker.js:149
 msgid "Default"
 msgstr ""
 
@@ -23677,6 +986,10 @@ msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5289
 msgid "Header Text Color"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5313
+msgid "Background Color"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5322
@@ -23702,12 +1015,22 @@ msgstr ""
 msgid "Upload your video in %1$s format and minimize its file size for best results. Your theme recommends a height of %2$s pixels."
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:5350
+#: wp-includes/customize/class-wp-customize-header-image-control.php:55
+msgid "Header Image"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5422
 msgid "Header Video"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5436
 msgid "Or, enter a YouTube URL:"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5459
+#: wp-includes/customize/class-wp-customize-background-image-control.php:40
+msgid "Background Image"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5499
@@ -23720,6 +1043,16 @@ msgctxt "Default Preset"
 msgid "Default"
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:5504
+#: wp-includes/class-wp-customize-manager.php:5563
+msgid "Fill Screen"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5505
+#: wp-includes/class-wp-customize-manager.php:5562
+msgid "Fit to Screen"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5506
 msgctxt "Repeat Image"
 msgid "Repeat"
@@ -23730,6 +1063,29 @@ msgctxt "Custom Preset"
 msgid "Custom"
 msgstr ""
 
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-manager.php:5535
+#: wp-includes/customize/class-wp-customize-background-position-control.php:96
+msgid "Image Position"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5557
+msgid "Image Size"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5561
+msgctxt "Original Size"
+msgid "Original"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5580
+msgid "Repeat Background Image"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5598
+msgid "Scroll with Page"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5621
 msgid "Homepage Settings"
 msgstr ""
@@ -23738,8 +1094,20 @@ msgstr ""
 msgid "You can choose what&#8217;s displayed on the homepage of your site. It can be posts in reverse chronological order (classic blog), or a fixed/static page. To set a static homepage, you first need to create two Pages. One will become the homepage, and the other will be where your posts are displayed."
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:5640
+msgid "Your homepage displays"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5644
+msgid "Your latest posts"
+msgstr ""
+
 #: wp-includes/class-wp-customize-manager.php:5645
 msgid "A static page"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5661
+msgid "Homepage"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5679
@@ -23758,10 +1126,42 @@ msgstr ""
 msgid "Learn more about CSS"
 msgstr ""
 
+#: wp-includes/class-wp-customize-manager.php:5698
+#: wp-includes/widgets/class-wp-widget-custom-html.php:323
+msgid "When using a keyboard to navigate:"
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5700
+#: wp-includes/widgets/class-wp-widget-custom-html.php:325
+msgid "In the editing area, the Tab key enters a tab character."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5701
+#: wp-includes/widgets/class-wp-widget-custom-html.php:326
+msgid "To move away from this area, press the Esc key followed by the Tab key."
+msgstr ""
+
+#: wp-includes/class-wp-customize-manager.php:5702
+#: wp-includes/widgets/class-wp-widget-custom-html.php:327
+msgid "Screen reader users: when in forms mode, you may need to press the Esc key twice."
+msgstr ""
+
 #. translators: 1: Link to user profile, 2: Additional link attributes, 3: Accessibility text.
 #: wp-includes/class-wp-customize-manager.php:5709
 #: wp-includes/widgets/class-wp-widget-custom-html.php:312
 msgid "The edit field automatically highlights code syntax. You can disable this in your <a href=\"%1$s\" %2$s>user profile%3$s</a> to work in plain text mode."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-manager.php:5722
+#: wp-includes/class-wp-editor.php:1183
+#: wp-includes/class-wp-editor.php:1880
+#: wp-includes/script-loader.php:772
+#: wp-includes/script-loader.php:871
+#: wp-includes/script-loader.php:1102
+#: wp-includes/script-loader.php:1263
+#: wp-includes/script-loader.php:1627
+msgid "Close"
 msgstr ""
 
 #: wp-includes/class-wp-customize-manager.php:5728
@@ -23810,6 +1210,12 @@ msgstr ""
 msgid "Please enter a valid YouTube URL."
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:167
+#: wp-includes/class-wp-customize-nav-menus.php:451
+msgctxt "nav menu home label"
+msgid "Home"
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:169
 #: wp-includes/class-wp-customize-nav-menus.php:458
 #: wp-includes/class-wp-customize-nav-menus.php:507
@@ -23824,6 +1230,12 @@ msgstr ""
 msgid "Post Type Archive"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:336
+#: wp-includes/script-loader.php:733
+#: wp-includes/script-loader.php:1058
+msgid "No results found."
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:494
 msgid "Your theme can display menus in one location."
 msgstr ""
@@ -23836,7 +1248,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:505
-#: wp-admin/js/nav-menu.js:1218
 msgctxt "missing menu item navigation label"
 msgid "(no label)"
 msgstr ""
@@ -23861,8 +1272,16 @@ msgstr ""
 msgid "Menu Locations"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:513
+msgid "Menu Name"
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:514
 msgid "If your theme has multiple menus, giving them clear names will help you manage them."
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:515
+msgid "Menu item added"
 msgstr ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:516
@@ -23877,12 +1296,38 @@ msgstr ""
 msgid "Menu deleted"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:519
+msgid "Menu item moved up"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:520
+msgid "Menu item moved down"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:521
+msgid "Menu item moved out of submenu"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:522
+msgid "Menu item is now a sub-item"
+msgstr ""
+
 #. translators: &#9656; is the unicode right-pointing triangle. %s: Section title in the Customizer.
 #: wp-includes/class-wp-customize-nav-menus.php:524
 #: wp-includes/class-wp-customize-nav-menus.php:1160
 #: wp-includes/class-wp-customize-section.php:246
 #: wp-includes/class-wp-customize-widgets.php:842
 msgid "Customizing &#9656; %s"
+msgstr ""
+
+#. translators: %s: Title of an invalid menu item.
+#: wp-includes/class-wp-customize-nav-menus.php:526
+msgid "%s (Invalid)"
+msgstr ""
+
+#. translators: %s: Title of a menu item in draft status.
+#: wp-includes/class-wp-customize-nav-menus.php:528
+msgid "%s (Pending)"
 msgstr ""
 
 #. translators: %d: Number of menu items found.
@@ -23916,6 +1361,48 @@ msgstr ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:537
 msgid "Close reorder mode"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:554
+msgid "Move up one"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:555
+msgid "Move down one"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:556
+msgid "Move to the top"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-includes/class-wp-customize-nav-menus.php:558
+msgid "Move under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-includes/class-wp-customize-nav-menus.php:560
+msgid "Move out from under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-includes/class-wp-customize-nav-menus.php:562
+msgid "Under %s"
+msgstr ""
+
+#. translators: %s: Previous item name.
+#: wp-includes/class-wp-customize-nav-menus.php:564
+msgid "Out from under %s"
+msgstr ""
+
+#. translators: 1: Item name, 2: Item position, 3: Total number of items.
+#: wp-includes/class-wp-customize-nav-menus.php:566
+msgid "%1$s. Menu item %2$d of %3$d."
+msgstr ""
+
+#. translators: 1: Item name, 2: Item position, 3: Parent item name.
+#: wp-includes/class-wp-customize-nav-menus.php:568
+msgid "%1$s. Sub item number %2$d under %3$s."
 msgstr ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:653
@@ -23961,6 +1448,21 @@ msgstr ""
 msgid "New Menu"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:949
+#: wp-includes/class-wp-xmlrpc-server.php:1440
+#: wp-includes/class-wp-xmlrpc-server.php:1996
+#: wp-includes/class-wp-xmlrpc-server.php:3666
+#: wp-includes/class-wp-xmlrpc-server.php:4561
+#: wp-includes/class-wp-xmlrpc-server.php:5379
+#: wp-includes/class-wp-xmlrpc-server.php:5449
+#: wp-includes/class-wp-xmlrpc-server.php:5743
+#: wp-includes/class-wp-xmlrpc-server.php:5816
+#: wp-includes/post.php:1493
+#: wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php:442
+#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:141
+msgid "Invalid post type."
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:952
 msgid "Empty title."
 msgstr ""
@@ -23984,12 +1486,26 @@ msgstr ""
 msgid "Add to menu: %1$s (%2$s)"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:1096
+#: wp-includes/class-wp-customize-widgets.php:701
+msgid "Move up"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:1097
+#: wp-includes/class-wp-customize-widgets.php:700
+msgid "Move down"
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:1098
 msgid "Move one level up"
 msgstr ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:1099
 msgid "Move one level down"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:1108
+msgid "Delete Menu"
 msgstr ""
 
 #: wp-includes/class-wp-customize-nav-menus.php:1114
@@ -24014,6 +1530,17 @@ msgstr ""
 msgid "Create New Menu"
 msgstr ""
 
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-nav-menus.php:1152
+#: wp-includes/class-wp-customize-panel.php:379
+#: wp-includes/class-wp-customize-section.php:374
+#: wp-includes/class-wp-customize-widgets.php:834
+#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:75
+#: wp-includes/customize/class-wp-customize-themes-panel.php:73
+#: wp-includes/media.php:4584
+msgid "Back"
+msgstr ""
+
 #: wp-includes/class-wp-customize-nav-menus.php:1163
 msgid "Add Menu Items"
 msgstr ""
@@ -24028,6 +1555,14 @@ msgid "Search menu items&hellip;"
 msgstr ""
 
 #. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-nav-menus.php:1178
+#: wp-includes/class-wp-customize-widgets.php:866
+#: wp-includes/customize/class-wp-customize-themes-section.php:138
+#: wp-includes/customize/class-wp-customize-themes-section.php:163
+msgid "The search results will be updated as you type."
+msgstr ""
+
+#. translators: Hidden accessibility text.
 #: wp-includes/class-wp-customize-nav-menus.php:1187
 #: wp-includes/class-wp-customize-widgets.php:860
 msgid "Clear Results"
@@ -24037,9 +1572,55 @@ msgstr ""
 msgid "No items"
 msgstr ""
 
+#: wp-includes/class-wp-customize-nav-menus.php:1270
+msgid "Custom Links"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:1275
+#: wp-includes/class-wp-editor.php:1266
+#: wp-includes/class-wp-editor.php:1887
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:88
+#: wp-includes/embed.php:1172
+#: wp-includes/media-template.php:880
+#: wp-includes/media-template.php:1106
+#: wp-includes/media-template.php:1229
+#: wp-includes/media-template.php:1303
+#: wp-includes/media-template.php:1394
+#: wp-includes/media.php:4576
+#: wp-includes/media.php:5134
+#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:62
+#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:176
+#: wp-includes/widgets/class-wp-widget-media-image.php:113
+msgid "URL"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:1279
+#: wp-includes/class-wp-editor.php:1891
+#: wp-includes/media-template.php:1038
+msgid "Link Text"
+msgstr ""
+
+#: wp-includes/class-wp-customize-nav-menus.php:1284
+msgid "Add to Menu"
+msgstr ""
+
 #. translators: Hidden accessibility text.
 #: wp-includes/class-wp-customize-panel.php:354
 msgid "Press return or enter to open this panel"
+msgstr ""
+
+#. translators: %s: The site/panel title in the Customizer.
+#: wp-includes/class-wp-customize-panel.php:386
+#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:83
+msgid "You are customizing %s"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-customize-panel.php:393
+#: wp-includes/class-wp-customize-section.php:388
+#: wp-includes/customize/class-wp-customize-nav-menus-panel.php:90
+#: wp-includes/customize/class-wp-customize-themes-panel.php:91
+msgid "Help"
 msgstr ""
 
 #: wp-includes/class-wp-customize-section.php:248
@@ -24090,12 +1671,22 @@ msgid_plural "Your theme has %s widget areas, but this particular page does not 
 msgstr[0] ""
 msgstr[1] ""
 
+#: wp-includes/class-wp-customize-widgets.php:779
+#: wp-includes/class-wp-editor.php:1391
+#: wp-includes/media.php:4620
+msgid "Apply"
+msgstr ""
+
 #: wp-includes/class-wp-customize-widgets.php:780
 msgid "Save and preview changes before publishing them."
 msgstr ""
 
 #: wp-includes/class-wp-customize-widgets.php:782
 msgid "Keep widget settings and move it to the inactive widgets"
+msgstr ""
+
+#: wp-includes/class-wp-customize-widgets.php:783
+msgid "An error has occurred. Please reload the page and try again."
 msgstr ""
 
 #: wp-includes/class-wp-customize-widgets.php:784
@@ -24331,6 +1922,25 @@ msgstr ""
 msgid "Select all"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1178
+msgid "Undo"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1179
+msgid "Redo"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1181
+msgid "OK"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1182
+#: wp-includes/class-wp-editor.php:1933
+#: wp-includes/media.php:4580
+#: wp-includes/script-loader.php:1101
+msgid "Cancel"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1184
 msgid "Visual aids"
 msgstr ""
@@ -24422,6 +2032,13 @@ msgstr ""
 msgid "Robots"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1209
+#: wp-includes/media-template.php:511
+#: wp-includes/media-template.php:756
+#: wp-includes/revision.php:32
+msgid "Title"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1210
 msgid "Keywords"
 msgstr ""
@@ -24430,12 +2047,34 @@ msgstr ""
 msgid "Encoding"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1212
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:125
+#: wp-includes/media-template.php:533
+#: wp-includes/media-template.php:778
+msgid "Description"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1213
+#: wp-includes/theme-compat/sidebar.php:29
+msgid "Author"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1216
+#: wp-includes/script-loader.php:770
+#: wp-includes/widgets/class-wp-widget-media-image.php:28
+msgid "Image"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1217
 msgid "Insert/edit image"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1218
 msgid "General"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1219
+msgid "Advanced"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1220
@@ -24479,8 +2118,24 @@ msgstr ""
 msgid "Insert date/time"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1230
+msgid "Table of Contents"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1231
 msgid "Insert/edit code sample"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/class-wp-editor.php:1232
+#: wp-login.php:301
+msgid "Language"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1233
+#: wp-includes/media.php:4575
+#: wp-includes/media.php:5141
+msgid "Media"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1234
@@ -24542,6 +2197,10 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1251
+msgid "Save"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1252
 #: wp-includes/script-loader.php:866
 msgid "Fullscreen"
@@ -24577,6 +2236,10 @@ msgstr ""
 #: wp-includes/class-wp-editor.php:1261
 #: wp-includes/script-loader.php:575
 msgid "Insert link"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1263
+msgid "Target"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1264
@@ -24734,6 +2397,11 @@ msgstr ""
 msgid "Column"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1309
+#: wp-includes/media-template.php:946
+msgid "Columns"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1310
 msgctxt "table cell"
 msgid "Cell"
@@ -24806,9 +2474,60 @@ msgstr ""
 msgid "Split table cell"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1329
+#: wp-includes/media-template.php:1198
+#: wp-includes/widgets/class-wp-widget-media-image.php:84
+msgid "Height"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1330
+#: wp-includes/media-template.php:1193
+#: wp-includes/widgets/class-wp-widget-media-image.php:78
+msgid "Width"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1331
+#: wp-includes/media-template.php:529
+#: wp-includes/media-template.php:626
+#: wp-includes/media-template.php:774
+#: wp-includes/media-template.php:1065
+#: wp-includes/media-template.php:1128
+#: wp-includes/widgets/class-wp-widget-media-image.php:91
+msgid "Caption"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1332
+#: wp-includes/media-template.php:811
+msgid "Alignment"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1333
 msgctxt "horizontal table cell alignment"
 msgid "H Align"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1334
+#: wp-includes/customize/class-wp-customize-background-position-control.php:57
+#: wp-includes/media-template.php:819
+#: wp-includes/media-template.php:1075
+#: wp-includes/media-template.php:1139
+msgid "Left"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1335
+#: wp-includes/customize/class-wp-customize-background-position-control.php:61
+#: wp-includes/media-template.php:822
+#: wp-includes/media-template.php:1078
+#: wp-includes/media-template.php:1142
+msgid "Center"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1336
+#: wp-includes/customize/class-wp-customize-background-position-control.php:65
+#: wp-includes/media-template.php:825
+#: wp-includes/media-template.php:1081
+#: wp-includes/media-template.php:1145
+msgid "Right"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1337
@@ -24821,8 +2540,18 @@ msgctxt "vertical table cell alignment"
 msgid "V Align"
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1339
+#: wp-includes/customize/class-wp-customize-background-position-control.php:47
+msgid "Top"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1340
 msgid "Middle"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1341
+#: wp-includes/customize/class-wp-customize-background-position-control.php:75
+msgid "Bottom"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1343
@@ -24906,8 +2635,6 @@ msgstr ""
 #: wp-includes/class-wp-editor.php:1368
 #: wp-includes/script-loader.php:1099
 #: wp-includes/theme.php:3602
-#: wp-admin/js/post.js:510
-#: wp-admin/js/theme-plugin-editor.js:71
 msgid "The changes you made will be lost if you navigate away from this page."
 msgstr ""
 
@@ -24983,6 +2710,14 @@ msgstr ""
 
 #: wp-includes/class-wp-editor.php:1392
 msgid "Link options"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1395
+msgid "Add Media"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1398
+msgid "Keyboard Shortcuts"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1399
@@ -25069,8 +2804,19 @@ msgstr ""
 msgid "The next group of formatting shortcuts are applied as you type or when you insert them around plain text in the same paragraph. Press Escape or the Undo button to undo."
 msgstr ""
 
+#: wp-includes/class-wp-editor.php:1817
+msgid "Y/m/d"
+msgstr ""
+
 #: wp-includes/class-wp-editor.php:1885
 msgid "Enter the destination URL"
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1896
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:102
+#: wp-includes/media-template.php:1249
+#: wp-includes/widgets/class-wp-widget-media-image.php:144
+msgid "Open link in a new tab"
 msgstr ""
 
 #: wp-includes/class-wp-editor.php:1899
@@ -25084,6 +2830,11 @@ msgstr ""
 #. translators: Hidden accessibility text.
 #: wp-includes/class-wp-editor.php:1920
 msgid "Search or use up and down arrow keys to select an item."
+msgstr ""
+
+#: wp-includes/class-wp-editor.php:1936
+#: wp-includes/script-loader.php:1056
+msgid "Add Link"
 msgstr ""
 
 #: wp-includes/class-wp-fatal-error-handler.php:186
@@ -25602,6 +3353,25 @@ msgctxt "text direction"
 msgid "ltr"
 msgstr ""
 
+#. translators: Localized date format, see https://www.php.net/manual/datetime.format.php
+#: wp-includes/class-wp-locale.php:395
+#: wp-includes/media.php:4150
+#: wp-includes/script-loader.php:161
+msgid "F j, Y"
+msgstr ""
+
+#. translators: Localized time format, see https://www.php.net/manual/datetime.format.php
+#: wp-includes/class-wp-locale.php:397
+#: wp-includes/script-loader.php:158
+msgid "g:i a"
+msgstr ""
+
+#. translators: Localized date and time format, see https://www.php.net/manual/datetime.format.php
+#: wp-includes/class-wp-locale.php:399
+#: wp-includes/script-loader.php:162
+msgid "F j, Y g:i a"
+msgstr ""
+
 #. translators: If your word count is based on single characters (e.g. East Asian characters), enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'. Do not translate into your own language.
 #: wp-includes/class-wp-locale.php:428
 msgctxt "Word count type. Do not translate!"
@@ -25649,6 +3419,11 @@ msgstr ""
 
 #: wp-includes/class-wp-oembed-controller.php:216
 msgid "Embed Handler"
+msgstr ""
+
+#: wp-includes/class-wp-post-type.php:800
+msgctxt "post type general name"
+msgid "Posts"
 msgstr ""
 
 #: wp-includes/class-wp-post-type.php:800
@@ -25764,6 +3539,10 @@ msgstr ""
 msgid "Post Attributes"
 msgstr ""
 
+#: wp-includes/class-wp-post-type.php:814
+msgid "Page Attributes"
+msgstr ""
+
 #: wp-includes/class-wp-post-type.php:815
 msgid "Insert into post"
 msgstr ""
@@ -25849,6 +3628,14 @@ msgstr ""
 msgid "Pages list"
 msgstr ""
 
+#: wp-includes/class-wp-post-type.php:825
+msgid "Post published."
+msgstr ""
+
+#: wp-includes/class-wp-post-type.php:825
+msgid "Page published."
+msgstr ""
+
 #: wp-includes/class-wp-post-type.php:826
 msgid "Post published privately."
 msgstr ""
@@ -25871,6 +3658,14 @@ msgstr ""
 
 #: wp-includes/class-wp-post-type.php:828
 msgid "Page scheduled."
+msgstr ""
+
+#: wp-includes/class-wp-post-type.php:829
+msgid "Post updated."
+msgstr ""
+
+#: wp-includes/class-wp-post-type.php:829
+msgid "Page updated."
 msgstr ""
 
 #: wp-includes/class-wp-post-type.php:831
@@ -25914,6 +3709,12 @@ msgstr ""
 
 #: wp-includes/class-wp-recovery-mode-cookie-service.php:119
 msgid "Invalid cookie."
+msgstr ""
+
+#. translators: This string should only be translated if wp-config-sample.php is localized. You can check the localized release package or https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
+#: wp-includes/class-wp-recovery-mode-cookie-service.php:219
+#: wp-includes/pluggable.php:2447
+msgid "put your unique phrase here"
 msgstr ""
 
 #: wp-includes/class-wp-recovery-mode-email-service.php:59
@@ -25976,6 +3777,11 @@ msgstr ""
 msgid "In this case, ClassicPress caught an error with your theme, %s."
 msgstr ""
 
+#. translators: %s: Current WordPress version number.
+#: wp-includes/class-wp-recovery-mode-email-service.php:352
+msgid "ClassicPress version %s"
+msgstr ""
+
 #. translators: 1: Current active theme name. 2: Current active theme version.
 #: wp-includes/class-wp-recovery-mode-email-service.php:357
 msgid "Active theme: %1$s (version %2$s)"
@@ -26030,6 +3836,29 @@ msgstr ""
 #. translators: 1: $l10n, 2: wp_add_inline_script()
 #: wp-includes/class-wp-scripts.php:472
 msgid "The %1$s parameter must be an array. To pass arbitrary data to scripts, use the %2$s function instead."
+msgstr ""
+
+#: wp-includes/class-wp-tax-query.php:549
+#: wp-includes/class-wp-tax-query.php:556
+#: wp-includes/class-wp-term.php:173
+#: wp-includes/class-wp-xmlrpc-server.php:2091
+#: wp-includes/class-wp-xmlrpc-server.php:2196
+#: wp-includes/class-wp-xmlrpc-server.php:2312
+#: wp-includes/class-wp-xmlrpc-server.php:2391
+#: wp-includes/class-wp-xmlrpc-server.php:2456
+#: wp-includes/class-wp-xmlrpc-server.php:2562
+#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:189
+#: wp-includes/taxonomy.php:532
+#: wp-includes/taxonomy.php:790
+#: wp-includes/taxonomy.php:891
+#: wp-includes/taxonomy.php:1083
+#: wp-includes/taxonomy.php:1253
+#: wp-includes/taxonomy.php:2168
+#: wp-includes/taxonomy.php:2310
+#: wp-includes/taxonomy.php:2699
+#: wp-includes/taxonomy.php:2886
+#: wp-includes/taxonomy.php:3097
+msgid "Invalid taxonomy."
 msgstr ""
 
 #: wp-includes/class-wp-tax-query.php:652
@@ -26190,6 +4019,12 @@ msgctxt "tags"
 msgid "Most Used"
 msgstr ""
 
+#. translators: Tab heading when selecting from the most used terms.
+#: wp-includes/class-wp-taxonomy.php:637
+msgctxt "categories"
+msgid "Most Used"
+msgstr ""
+
 #: wp-includes/class-wp-taxonomy.php:638
 msgid "&larr; Go to Tags"
 msgstr ""
@@ -26257,6 +4092,15 @@ msgstr ""
 #. translators: %s: Template.
 #: wp-includes/class-wp-theme.php:317
 msgid "The theme defines itself as its parent theme. Please check the %s header."
+msgstr ""
+
+#. translators: 1: templates/index.html, 2: index.php, 3: Documentation URL, 4: Template, 5: style.css
+#: wp-includes/class-wp-theme.php:343
+msgid "Template is missing. Standalone themes need to have a %1$s or %2$s template file. <a href=\"%3$s\">Child themes</a> need to have a %4$s header in the %5$s stylesheet."
+msgstr ""
+
+#: wp-includes/class-wp-theme.php:346
+msgid "https://developer.wordpress.org/themes/advanced-topics/child-themes/"
 msgstr ""
 
 #. translators: %s: Theme directory name.
@@ -26384,6 +4228,10 @@ msgstr ""
 msgid "Usage of user levels is deprecated. Use capabilities instead."
 msgstr ""
 
+#: wp-includes/class-wp-widget.php:144
+msgid "There are no options for this widget."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:288
 msgid "XML-RPC services are disabled on this site."
 msgstr ""
@@ -26398,6 +4246,14 @@ msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:527
 msgid "Software Version"
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:532
+msgid "ClassicPress Address (URL)"
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:537
+msgid "Site Address (URL)"
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:542
@@ -26420,6 +4276,14 @@ msgstr ""
 msgid "Image default align"
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:567
+msgid "Template"
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:572
+msgid "Stylesheet"
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:577
 msgid "Post Thumbnail"
 msgstr ""
@@ -26430,6 +4294,14 @@ msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:594
 msgid "Site Tagline"
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:599
+msgid "Date Format"
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:604
+msgid "Time Format"
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:609
@@ -26525,6 +4397,21 @@ msgstr ""
 msgid "Invalid post ID."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:1450
+#: wp-includes/class-wp-xmlrpc-server.php:1937
+#: wp-includes/class-wp-xmlrpc-server.php:4776
+#: wp-includes/class-wp-xmlrpc-server.php:4960
+#: wp-includes/class-wp-xmlrpc-server.php:5199
+#: wp-includes/class-wp-xmlrpc-server.php:5738
+#: wp-includes/class-wp-xmlrpc-server.php:6058
+#: wp-includes/class-wp-xmlrpc-server.php:6431
+#: wp-includes/class-wp-xmlrpc-server.php:6620
+#: wp-includes/class-wp-xmlrpc-server.php:6678
+#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:489
+#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:804
+msgid "Sorry, you are not allowed to edit this post."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:1453
 #: wp-includes/class-wp-xmlrpc-server.php:5748
 msgid "The post type may not be changed."
@@ -26547,6 +4434,13 @@ msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:1484
 msgid "Sorry, you are not allowed to create password protected posts in this post type."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:1490
+#: wp-includes/class-wp-xmlrpc-server.php:5440
+#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:601
+#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:617
+msgid "Sorry, you are not allowed to create posts as this user."
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:1496
@@ -26617,6 +4511,19 @@ msgstr ""
 msgid "Sorry, the post could not be deleted."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:2003
+#: wp-includes/class-wp-xmlrpc-server.php:4567
+#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:95
+#: wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php:157
+#: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:161
+msgid "Sorry, you are not allowed to edit posts in this post type."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:2097
+#: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:481
+msgid "Sorry, you are not allowed to create terms in this taxonomy."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:2107
 #: wp-includes/class-wp-xmlrpc-server.php:2224
 msgid "The term name cannot be empty."
@@ -26677,6 +4584,27 @@ msgstr ""
 msgid "Sorry, you are not allowed to assign terms in this taxonomy."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:2706
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:699
+msgid "Sorry, you are not allowed to edit this user."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:2712
+#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:692
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:402
+#: wp-includes/user.php:2092
+#: wp-includes/user.php:2525
+#: wp-includes/user.php:2531
+msgid "Invalid user ID."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:2769
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:213
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:445
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:451
+msgid "Sorry, you are not allowed to list users."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:2787
 msgid "Invalid role."
 msgstr ""
@@ -26690,10 +4618,20 @@ msgstr ""
 msgid "Sorry, the user could not be updated."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:2981
+#: wp-includes/class-wp-xmlrpc-server.php:3197
+msgid "Sorry, you are not allowed to edit this page."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:2992
 #: wp-includes/class-wp-xmlrpc-server.php:3126
 #: wp-includes/class-wp-xmlrpc-server.php:3192
 msgid "Sorry, no such page."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:3024
+#: wp-includes/class-wp-xmlrpc-server.php:3246
+msgid "Sorry, you are not allowed to edit pages."
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:3131
@@ -26702,6 +4640,13 @@ msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:3137
 msgid "Failed to delete the page."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:3307
+#: wp-includes/class-wp-xmlrpc-server.php:4693
+#: wp-includes/class-wp-xmlrpc-server.php:5017
+#: wp-includes/class-wp-xmlrpc-server.php:6199
+msgid "Sorry, you are not allowed to edit posts."
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:3351
@@ -26725,6 +4670,14 @@ msgstr ""
 #: wp-includes/class-wp-xmlrpc-server.php:6320
 #: wp-includes/class-wp-xmlrpc-server.php:6562
 msgid "Sorry, you must be able to edit posts on this site in order to view categories."
+msgstr ""
+
+#: wp-includes/class-wp-xmlrpc-server.php:3595
+#: wp-includes/class-wp-xmlrpc-server.php:3732
+#: wp-includes/class-wp-xmlrpc-server.php:3800
+#: wp-includes/comment.php:2495
+#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:343
+msgid "Invalid comment ID."
 msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:3599
@@ -26792,6 +4745,12 @@ msgstr ""
 msgid "Sorry, you are not allowed to update options."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:4363
+#: wp-includes/class-wp-xmlrpc-server.php:4418
+#: wp-includes/class-wp-xmlrpc-server.php:6388
+msgid "Sorry, you are not allowed to upload files."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:4698
 #: wp-includes/class-wp-xmlrpc-server.php:4781
 msgid "Sorry, revisions are disabled."
@@ -26839,6 +4798,10 @@ msgstr ""
 msgid "Invalid post format."
 msgstr ""
 
+#: wp-includes/class-wp-xmlrpc-server.php:5445
+msgid "Sorry, you are not allowed to create pages as this user."
+msgstr ""
+
 #: wp-includes/class-wp-xmlrpc-server.php:5807
 msgid "Sorry, you are not allowed to change the post author as this user."
 msgstr ""
@@ -26849,6 +4812,11 @@ msgstr ""
 
 #: wp-includes/class-wp-xmlrpc-server.php:5922
 msgid "Sorry, you are not allowed to publish this page."
+msgstr ""
+
+#. translators: %s: Allowed space allocation.
+#: wp-includes/class-wp-xmlrpc-server.php:6397
+msgid "Sorry, you have used your space allocation of %s. Please delete some files to upload more files."
 msgstr ""
 
 #. translators: 1: File name, 2: Error message.
@@ -26897,14 +4865,10 @@ msgid "The specified target URL does not exist."
 msgstr ""
 
 #: wp-includes/class-wp.php:311
-#: wp-includes/ms-deprecated.php:277
-#: wp-includes/ms-deprecated.php:296
 msgid "A variable mismatch has been detected."
 msgstr ""
 
 #: wp-includes/class-wp.php:311
-#: wp-includes/ms-deprecated.php:277
-#: wp-includes/ms-deprecated.php:296
 msgid "Sorry, you are not allowed to view this item."
 msgstr ""
 
@@ -26934,6 +4898,14 @@ msgstr ""
 #. translators: %s: Support forums URL.
 #: wp-includes/class-wpdb.php:1233
 msgid "If you do not know how to set up a database you should <strong>contact your host</strong>. If all else fails you may find help at the <a href=\"%s\">Support forums</a>."
+msgstr ""
+
+#: wp-includes/class-wpdb.php:1234
+#: wp-includes/class-wpdb.php:2003
+#: wp-includes/class-wpdb.php:2157
+#: wp-includes/customize/class-wp-customize-themes-section.php:90
+#: wp-includes/load.php:181
+msgid "https://wordpress.org/support/forums/"
 msgstr ""
 
 #. translators: %s: Database access abstraction class, usually wpdb or a class extending wpdb.
@@ -26972,7 +4944,6 @@ msgstr ""
 
 #: wp-includes/class-wpdb.php:1985
 #: wp-includes/functions.php:5358
-#: wp-includes/ms-load.php:471
 msgid "Error establishing a database connection"
 msgstr ""
 
@@ -27073,6 +5044,11 @@ msgstr ""
 msgid "Plugins on this list may have issues."
 msgstr ""
 
+#: wp-includes/classicpress/class-cp-debug-compat.php:86
+#: wp-includes/classicpress/class-cp-debug-compat.php:122
+msgid "Learn more."
+msgstr ""
+
 #: wp-includes/classicpress/class-cp-debug-compat.php:112
 msgid "No themes are using block functions."
 msgstr ""
@@ -27107,11 +5083,23 @@ msgstr ""
 msgid "%1$s parent theme (%2$s) uses block-related functions and may have issues."
 msgstr ""
 
+#: wp-includes/comment-template.php:635
+msgid "Password protected"
+msgstr ""
+
 #. translators: Maximum number of words used in a comment excerpt.
 #: wp-includes/comment-template.php:639
 msgctxt "comment_excerpt_length"
 msgid "20"
 msgstr ""
+
+#. translators: %s: Number of comments.
+#: wp-includes/comment-template.php:937
+#: wp-includes/comment-template.php:952
+msgid "%s Comment"
+msgid_plural "%s Comments"
+msgstr[0] ""
+msgstr[1] ""
 
 #. translators: If comment number in your language requires declension, translate this to 'on'. Do not translate into your own language.
 #: wp-includes/comment-template.php:944
@@ -27127,10 +5115,35 @@ msgstr ""
 msgid "1 Comment"
 msgstr ""
 
+#. translators: %s: Comment link.
+#: wp-includes/comment-template.php:1010
+msgid "In reply to %s."
+msgstr ""
+
+#: wp-includes/comment-template.php:1156
+#: wp-includes/comment-template.php:2603
+msgctxt "noun"
+msgid "Comment"
+msgstr ""
+
+#: wp-includes/comment-template.php:1159
+msgid "Trackback"
+msgstr ""
+
+#: wp-includes/comment-template.php:1162
+msgid "Pingback"
+msgstr ""
+
 #. translators: %s: Comment author link.
 #: wp-includes/comment-template.php:1200
 #: wp-includes/comment-template.php:1206
 msgid "%s <span class=\"says\">says:</span>"
+msgstr ""
+
+#. translators: 1: Comment date, 2: Comment time.
+#: wp-includes/comment-template.php:1227
+#: wp-includes/comment-template.php:1240
+msgid "%1$s at %2$s"
 msgstr ""
 
 #: wp-includes/comment-template.php:1246
@@ -27161,6 +5174,10 @@ msgstr ""
 
 #: wp-includes/comment-template.php:1715
 msgid "Enter your password to view comments."
+msgstr ""
+
+#: wp-includes/comment-template.php:1787
+msgid "Reply"
 msgstr ""
 
 #. translators: Comment reply button text. %s: Comment author name.
@@ -27195,6 +5212,19 @@ msgstr ""
 msgid "Leave a Reply to %s"
 msgstr ""
 
+#: wp-includes/comment-template.php:2532
+msgid "Name"
+msgstr ""
+
+#: wp-includes/comment-template.php:2545
+#: wp-login.php:1083
+msgid "Email"
+msgstr ""
+
+#: wp-includes/comment-template.php:2558
+msgid "Website"
+msgstr ""
+
 #: wp-includes/comment-template.php:2578
 msgid "Save my name, email, and website in this browser for the next time I comment."
 msgstr ""
@@ -27225,6 +5255,16 @@ msgstr ""
 msgid "Unapproved"
 msgstr ""
 
+#: wp-includes/comment.php:266
+msgctxt "comment status"
+msgid "Approved"
+msgstr ""
+
+#: wp-includes/comment.php:267
+msgctxt "comment status"
+msgid "Spam"
+msgstr ""
+
 #: wp-includes/comment.php:268
 msgctxt "comment status"
 msgid "Trash"
@@ -27253,6 +5293,10 @@ msgstr ""
 
 #: wp-includes/comment.php:1292
 msgid "<strong>Error:</strong> Your comment is too long."
+msgstr ""
+
+#: wp-includes/comment.php:1330
+msgid "Please consider writing more inclusive code."
 msgstr ""
 
 #: wp-includes/comment.php:2440
@@ -27292,6 +5336,10 @@ msgstr ""
 msgid "ClassicPress Comments"
 msgstr ""
 
+#: wp-includes/comment.php:3733
+msgid "Comment Author"
+msgstr ""
+
 #: wp-includes/comment.php:3734
 msgid "Comment Author Email"
 msgstr ""
@@ -27318,6 +5366,12 @@ msgstr ""
 
 #: wp-includes/comment.php:3740
 msgid "Comment URL"
+msgstr ""
+
+#: wp-includes/comment.php:3783
+#: wp-includes/link-template.php:3281
+#: wp-includes/link-template.php:3344
+msgid "Comments"
 msgstr ""
 
 #: wp-includes/comment.php:3784
@@ -27392,16 +5446,62 @@ msgstr ""
 msgid "The cron event list could not be saved."
 msgstr ""
 
+#: wp-includes/customize/class-wp-customize-background-position-control.php:43
+msgid "Top Left"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-background-position-control.php:51
+msgid "Top Right"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-background-position-control.php:71
+msgid "Bottom Left"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-background-position-control.php:79
+msgid "Bottom Right"
+msgstr ""
+
 #: wp-includes/customize/class-wp-customize-custom-css-setting.php:167
 msgid "Markup is not allowed in CSS."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-date-time-control.php:127
+msgid "Date"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-date-time-control.php:130
+msgid "Month"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-date-time-control.php:146
+msgid "Day"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-date-time-control.php:151
+#: wp-includes/media.php:3004
+msgid "Year"
 msgstr ""
 
 #: wp-includes/customize/class-wp-customize-date-time-control.php:160
 msgid "Time"
 msgstr ""
 
+#: wp-includes/customize/class-wp-customize-date-time-control.php:162
+msgid "Hour"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-date-time-control.php:167
+msgid "Minute"
+msgstr ""
+
 #: wp-includes/customize/class-wp-customize-date-time-control.php:170
 msgid "Meridian"
+msgstr ""
+
+#. translators: 1: Month number (01, 02, etc.), 2: Month abbreviation.
+#: wp-includes/customize/class-wp-customize-date-time-control.php:204
+msgid "%1$s-%2$s"
 msgstr ""
 
 #. translators: 1: Timezone name, 2: Timezone abbreviation, 3: UTC abbreviation and offset, 4: UTC offset.
@@ -27575,6 +5675,10 @@ msgstr ""
 msgid "Menu Options"
 msgstr ""
 
+#: wp-includes/customize/class-wp-customize-nav-menu-auto-add-control.php:46
+msgid "Automatically add new top-level pages to this menu"
+msgstr ""
+
 #: wp-includes/customize/class-wp-customize-nav-menu-control.php:40
 msgid "Add Items"
 msgstr ""
@@ -27593,6 +5697,11 @@ msgstr ""
 msgid "Reorder"
 msgstr ""
 
+#: wp-includes/customize/class-wp-customize-nav-menu-control.php:57
+#: wp-includes/customize/class-wp-widget-area-customize-control.php:61
+msgid "Done"
+msgstr ""
+
 #. translators: Hidden accessibility text.
 #: wp-includes/customize/class-wp-customize-nav-menu-control.php:63
 msgid "When in reorder mode, additional controls to reorder menu items will be available in the items list above."
@@ -27601,6 +5710,31 @@ msgstr ""
 #. translators: 1: Title of a menu item, 2: Type of a menu item.
 #: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:77
 msgid "Remove Menu Item: %1$s (%2$s)"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:95
+msgid "Navigation Label"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:107
+msgid "Title Attribute"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:113
+msgid "CSS Classes"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:119
+msgid "Link Relationship (XFN)"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:127
+msgid "The description will be displayed in the menu if the active theme supports it."
+msgstr ""
+
+#. translators: Nav menu item original title. %s: Original title.
+#: wp-includes/customize/class-wp-customize-nav-menu-item-control.php:147
+msgid "Original: %s"
 msgstr ""
 
 #: wp-includes/customize/class-wp-customize-nav-menu-item-setting.php:730
@@ -27614,6 +5748,10 @@ msgstr ""
 
 #: wp-includes/customize/class-wp-customize-nav-menu-location-control.php:85
 msgid "+ Create New Menu"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-nav-menu-location-control.php:86
+msgid "Edit selected menu"
 msgstr ""
 
 #: wp-includes/customize/class-wp-customize-nav-menu-location-control.php:86
@@ -27650,6 +5788,10 @@ msgstr ""
 #. translators: 1: Original menu name, 2: Duplicate count.
 #: wp-includes/customize/class-wp-customize-nav-menu-setting.php:522
 msgid "%1$s (%2$d)"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-new-menu-control.php:59
+msgid "Create Menu"
 msgstr ""
 
 #: wp-includes/customize/class-wp-customize-partial.php:226
@@ -27707,10 +5849,19 @@ msgstr ""
 msgid "Install and preview theme: %s"
 msgstr ""
 
+#: wp-includes/customize/class-wp-customize-theme-control.php:83
+#: wp-includes/customize/class-wp-customize-themes-section.php:78
+msgid "Theme Details"
+msgstr ""
+
 #. translators: Theme author name.
 #: wp-includes/customize/class-wp-customize-theme-control.php:88
 msgctxt "theme author"
 msgid "By %s"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:98
+msgid "New version available."
 msgstr ""
 
 #. translators: %s: "Update now" button.
@@ -27722,9 +5873,93 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
+#. translators: %s: Theme name.
+#: wp-includes/customize/class-wp-customize-theme-control.php:116
+msgid "There is a new version of %s available, but it does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#. translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page.
+#: wp-includes/customize/class-wp-customize-theme-control.php:122
+#: wp-includes/customize/class-wp-customize-theme-control.php:187
+msgid "<a href=\"%1$s\">Please update ClassicPress</a>, and then <a href=\"%2$s\">learn more about updating PHP</a>."
+msgstr ""
+
+#. translators: %s: URL to WordPress Updates screen.
+#: wp-includes/customize/class-wp-customize-theme-control.php:130
+#: wp-includes/customize/class-wp-customize-theme-control.php:152
+#: wp-includes/customize/class-wp-customize-theme-control.php:195
+#: wp-includes/customize/class-wp-customize-theme-control.php:217
+msgid "<a href=\"%s\">Please update ClassicPress</a>."
+msgstr ""
+
+#. translators: %s: URL to Update PHP page.
+#: wp-includes/customize/class-wp-customize-theme-control.php:136
+#: wp-includes/customize/class-wp-customize-theme-control.php:167
+#: wp-includes/customize/class-wp-customize-theme-control.php:201
+#: wp-includes/customize/class-wp-customize-theme-control.php:228
+msgid "<a href=\"%s\">Learn more about updating PHP</a>."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-includes/customize/class-wp-customize-theme-control.php:146
+msgid "There is a new version of %s available, but it does not work with your version of ClassicPress."
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-includes/customize/class-wp-customize-theme-control.php:161
+msgid "There is a new version of %s available, but it does not work with your version of PHP."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:183
+msgid "This theme does not work with your versions of ClassicPress and PHP."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:209
+msgid "FSE themes don't work with ClassicPress."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:213
+msgid "This theme does not work with your version of ClassicPress."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:224
+msgid "This theme does not work with your version of PHP."
+msgstr ""
+
 #: wp-includes/customize/class-wp-customize-theme-control.php:241
 msgctxt "theme"
 msgid "Previewing:"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:247
+#: wp-includes/customize/class-wp-customize-theme-control.php:288
+msgctxt "theme"
+msgid "Installed"
+msgstr ""
+
+#. translators: %s: Theme name.
+#: wp-includes/customize/class-wp-customize-theme-control.php:256
+msgctxt "theme"
+msgid "Activate %s"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:264
+msgid "This theme doesn't support Customizer."
+msgstr ""
+
+#. translators: %s: URL to the themes page (also it activates the theme).
+#: wp-includes/customize/class-wp-customize-theme-control.php:271
+msgid "However, you can still <a href=\"%s\">activate this theme</a>, and use the Site Editor to customize it."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:282
+#: wp-includes/customize/class-wp-customize-theme-control.php:284
+msgid "Live Preview"
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-theme-control.php:295
+#: wp-includes/customize/class-wp-customize-theme-control.php:297
+msgid "Install &amp; Preview"
 msgstr ""
 
 #: wp-includes/customize/class-wp-customize-themes-panel.php:42
@@ -27747,6 +5982,15 @@ msgstr ""
 #. translators: %s: Themes panel title in the Customizer.
 #: wp-includes/customize/class-wp-customize-themes-panel.php:81
 msgid "You are browsing %s"
+msgstr ""
+
+#. translators: %s: Support forums URL.
+#: wp-includes/customize/class-wp-customize-themes-section.php:89
+msgid "An unexpected error occurred. Something may be wrong with WordPress.org, ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
+msgstr ""
+
+#: wp-includes/customize/class-wp-customize-themes-section.php:97
+msgid "No themes found. Try a different search."
 msgstr ""
 
 #. translators: %s: "Search WordPress.org themes" button text.
@@ -27793,6 +6037,20 @@ msgstr ""
 msgid "new ClassicPress Loop"
 msgstr ""
 
+#: wp-includes/deprecated.php:706
+#: wp-includes/media-template.php:828
+#: wp-includes/media-template.php:855
+#: wp-includes/media-template.php:940
+#: wp-includes/media-template.php:1084
+#: wp-includes/media-template.php:1101
+#: wp-includes/media-template.php:1148
+#: wp-includes/media-template.php:1224
+#: wp-includes/media-template.php:1344
+#: wp-includes/media-template.php:1443
+#: wp-includes/script-loader.php:877
+msgid "None"
+msgstr ""
+
 #: wp-includes/deprecated.php:984
 msgid "Last updated"
 msgstr ""
@@ -27800,6 +6058,10 @@ msgstr ""
 #: wp-includes/deprecated.php:1872
 #: wp-includes/post-template.php:1639
 msgid "Missing Attachment"
+msgstr ""
+
+#: wp-includes/deprecated.php:2691
+msgid "First Post"
 msgstr ""
 
 #: wp-includes/deprecated.php:2691
@@ -27822,6 +6084,11 @@ msgstr ""
 #. translators: %s: File name.
 #: wp-includes/deprecated.php:3208
 msgid "File &#8220;%s&#8221; is not an image."
+msgstr ""
+
+#: wp-includes/deprecated.php:3950
+#: wp-includes/deprecated.php:3967
+msgid "The Press This plugin is required."
 msgstr ""
 
 #. translators: 1: Post title, 2: Site title.
@@ -28047,6 +6314,11 @@ msgctxt "excerpt_length"
 msgid "55"
 msgstr ""
 
+#: wp-includes/formatting.php:3996
+#: wp-includes/general-template.php:4561
+msgid "&hellip;"
+msgstr ""
+
 #: wp-includes/formatting.php:4805
 msgid "The email address entered did not appear to be a valid email address. Please enter a valid email address."
 msgstr ""
@@ -28178,6 +6450,11 @@ msgstr ""
 msgid "Empty filename"
 msgstr ""
 
+#: wp-includes/functions.php:2871
+#: wp-includes/script-loader.php:787
+msgid "Sorry, you are not allowed to upload this file type."
+msgstr ""
+
 #. translators: %s: File name.
 #: wp-includes/functions.php:2925
 msgid "Could not write file %s"
@@ -28290,6 +6567,10 @@ msgstr ""
 msgid "Please see <a href=\"%s\">Debugging in ClassicPress</a> for more information."
 msgstr ""
 
+#: wp-includes/functions.php:5863
+msgid "https://wordpress.org/documentation/article/debugging-in-wordpress/"
+msgstr ""
+
 #. translators: Developer debugging message. 1: PHP function name, 2: Explanatory message, 3: WordPress version number.
 #: wp-includes/functions.php:5869
 msgid "Function %1$s was called <strong>incorrectly</strong>. %2$s %3$s"
@@ -28297,6 +6578,11 @@ msgstr ""
 
 #: wp-includes/functions.php:6429
 msgid "Select a city"
+msgstr ""
+
+#: wp-includes/functions.php:6481
+#: wp-includes/functions.php:6486
+msgid "UTC"
 msgstr ""
 
 #: wp-includes/functions.php:6490
@@ -28439,9 +6725,20 @@ msgstr ""
 msgid "Username or Email Address"
 msgstr ""
 
+#: wp-includes/general-template.php:496
+#: wp-login.php:1424
+msgid "Password"
+msgstr ""
+
 #: wp-includes/general-template.php:497
 #: wp-login.php:1442
 msgid "Remember Me"
+msgstr ""
+
+#: wp-includes/general-template.php:498
+#: wp-login.php:1395
+#: wp-login.php:1444
+msgid "Log In"
 msgstr ""
 
 #: wp-includes/general-template.php:663
@@ -28501,6 +6798,13 @@ msgstr ""
 #. translators: 1: Separator, 2: Search query.
 #: wp-includes/general-template.php:1380
 msgid "Search Results %1$s %2$s"
+msgstr ""
+
+#: wp-includes/general-template.php:1675
+#: wp-includes/theme-compat/sidebar.php:119
+#: wp-includes/widgets/class-wp-widget-archives.php:31
+#: wp-includes/widgets/class-wp-widget-archives.php:44
+msgid "Archives"
 msgstr ""
 
 #: wp-includes/general-template.php:1680
@@ -28599,6 +6903,13 @@ msgstr ""
 #: wp-includes/general-template.php:1745
 msgctxt "archive title"
 msgid "%1$s %2$s"
+msgstr ""
+
+#. translators: 1: Month name, 2: 4-digit year.
+#. translators: 1: Month, 2: Year.
+#: wp-includes/general-template.php:2044
+#: wp-includes/media.php:4502
+msgid "%1$s %2$d"
 msgstr ""
 
 #. translators: Calendar caption: 1: Month name, 2: 4-digit year.
@@ -28872,6 +7183,10 @@ msgstr ""
 msgid "Please check that the %s PHP extension is installed and enabled."
 msgstr ""
 
+#: wp-includes/load.php:190
+msgid "Requirements Not Met"
+msgstr ""
+
 #. translators: %s: WP_ENVIRONMENT_TYPES
 #: wp-includes/load.php:230
 msgid "The %s constant is no longer supported."
@@ -28898,6 +7213,11 @@ msgstr ""
 msgid "Scrape key check failed. Please try again."
 msgstr ""
 
+#. translators: 1: Link to tutorial, 2: Additional link attributes, 3: Accessibility text.
+#: wp-includes/media-template.php:161
+msgid "<a href=\"%1$s\" %2$s>Learn how to describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative."
+msgstr ""
+
 #: wp-includes/media-template.php:175
 msgctxt "media modal menu actions"
 msgid "Actions"
@@ -28913,6 +7233,12 @@ msgstr ""
 msgid "Selected media actions"
 msgstr ""
 
+#: wp-includes/media-template.php:214
+#: wp-includes/media-template.php:221
+#: wp-includes/media-template.php:263
+msgid "Drop files to upload"
+msgstr ""
+
 #. translators: Hidden accessibility text.
 #: wp-includes/media-template.php:232
 msgid "Close uploader"
@@ -28922,14 +7248,43 @@ msgstr ""
 msgid "Your browser cannot upload files"
 msgstr ""
 
+#. translators: %s: https://apps.wordpress.org
+#: wp-includes/media-template.php:247
+msgid "The web browser on your device cannot be used to upload files. You may be able to use the <a href=\"%s\">native app for your device</a> instead."
+msgstr ""
+
 #: wp-includes/media-template.php:255
 msgid "Upload Limit Exceeded"
+msgstr ""
+
+#: wp-includes/media-template.php:264
+msgctxt "Uploader: Drop files here - or - Select Files"
+msgid "or"
+msgstr ""
+
+#: wp-includes/media-template.php:265
+msgid "Select Files"
+msgstr ""
+
+#. translators: %s: Maximum allowed file size.
+#: wp-includes/media-template.php:296
+msgid "Maximum upload file size: %s."
 msgstr ""
 
 #. translators: 1: Suggested width number, 2: Suggested height number.
 #: wp-includes/media-template.php:306
 #: wp-includes/media.php:4665
 msgid "Suggested image dimensions: %1$s by %2$s pixels."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/media-template.php:326
+msgid "List view"
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/media-template.php:334
+msgid "Grid view"
 msgstr ""
 
 #: wp-includes/media-template.php:342
@@ -28955,12 +7310,51 @@ msgstr ""
 msgid "Attachment Preview"
 msgstr ""
 
+#: wp-includes/media-template.php:414
+#: wp-includes/media-template.php:712
+msgid "Edit Image"
+msgstr ""
+
 #: wp-includes/media-template.php:416
 msgid "Document Preview"
 msgstr ""
 
+#: wp-includes/media-template.php:424
+#: wp-includes/media-template.php:650
+msgid "Saved."
+msgstr ""
+
+#. translators: Hidden accessibility text.
+#: wp-includes/media-template.php:430
+msgid "Details"
+msgstr ""
+
 #: wp-includes/media-template.php:433
 msgid "Uploaded on:"
+msgstr ""
+
+#: wp-includes/media-template.php:435
+msgid "Uploaded by:"
+msgstr ""
+
+#: wp-includes/media-template.php:444
+msgid "Uploaded to:"
+msgstr ""
+
+#: wp-includes/media-template.php:452
+msgid "File name:"
+msgstr ""
+
+#: wp-includes/media-template.php:453
+msgid "File type:"
+msgstr ""
+
+#: wp-includes/media-template.php:454
+msgid "File size:"
+msgstr ""
+
+#: wp-includes/media-template.php:457
+msgid "Dimensions:"
 msgstr ""
 
 #. translators: 1: A number of pixels wide, 2: A number of pixels tall.
@@ -28969,9 +7363,30 @@ msgstr ""
 msgid "%1$s by %2$s pixels"
 msgstr ""
 
+#: wp-includes/media-template.php:467
+#: wp-includes/media-template.php:706
+msgid "Original image:"
+msgstr ""
+
+#: wp-includes/media-template.php:474
+#: wp-includes/media-template.php:717
+msgid "Length:"
+msgstr ""
+
+#: wp-includes/media-template.php:482
+msgid "Bitrate:"
+msgstr ""
+
 #: wp-includes/media-template.php:490
 #: wp-includes/media-template.php:724
 msgid "Used as:"
+msgstr ""
+
+#: wp-includes/media-template.php:504
+#: wp-includes/media-template.php:1055
+#: wp-includes/media-template.php:1118
+#: wp-includes/widgets/class-wp-widget-media-image.php:98
+msgid "Alternative Text"
 msgstr ""
 
 #: wp-includes/media-template.php:518
@@ -28986,6 +7401,21 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
+#: wp-includes/media-template.php:537
+#: wp-includes/media-template.php:782
+msgid "File URL:"
+msgstr ""
+
+#: wp-includes/media-template.php:540
+#: wp-includes/media-template.php:785
+msgid "Copy URL to clipboard"
+msgstr ""
+
+#: wp-includes/media-template.php:541
+#: wp-includes/media-template.php:786
+msgid "Copied!"
+msgstr ""
+
 #: wp-includes/media-template.php:549
 msgid "View attachment page"
 msgstr ""
@@ -28994,10 +7424,26 @@ msgstr ""
 msgid "Edit more details"
 msgstr ""
 
+#: wp-includes/media-template.php:559
+msgid "Download file"
+msgstr ""
+
 #: wp-includes/media-template.php:567
 #: wp-includes/media-template.php:730
 #: wp-includes/media.php:4617
 msgid "Restore from Trash"
+msgstr ""
+
+#: wp-includes/media-template.php:569
+#: wp-includes/media-template.php:732
+#: wp-includes/media.php:4616
+msgid "Move to Trash"
+msgstr ""
+
+#: wp-includes/media-template.php:572
+#: wp-includes/media-template.php:735
+#: wp-includes/media.php:4618
+msgid "Delete permanently"
 msgstr ""
 
 #. translators: Hidden accessibility text.
@@ -29033,12 +7479,20 @@ msgstr ""
 msgid "Media title&hellip;"
 msgstr ""
 
+#: wp-includes/media-template.php:647
+msgid "Attachment Details"
+msgstr ""
+
 #: wp-includes/media-template.php:749
 msgid "Alt Text"
 msgstr ""
 
 #: wp-includes/media-template.php:796
 msgid "Edit Selection"
+msgstr ""
+
+#: wp-includes/media-template.php:799
+msgid "Clear"
 msgstr ""
 
 #: wp-includes/media-template.php:807
@@ -29075,10 +7529,55 @@ msgstr ""
 msgid "Link to Attachment Page"
 msgstr ""
 
+#: wp-includes/media-template.php:869
+#: wp-includes/media-template.php:934
+#: wp-includes/media-template.php:1213
+msgid "Attachment Page"
+msgstr ""
+
 #: wp-includes/media-template.php:874
 #: wp-includes/media-template.php:1098
 #: wp-includes/media-template.php:1221
 msgid "Custom URL"
+msgstr ""
+
+#: wp-includes/media-template.php:886
+#: wp-includes/media-template.php:965
+#: wp-includes/media-template.php:1157
+#: wp-includes/widgets/class-wp-widget-media-image.php:72
+msgid "Size"
+msgstr ""
+
+#: wp-includes/media-template.php:897
+#: wp-includes/media-template.php:977
+#: wp-includes/media-template.php:1168
+#: wp-includes/media.php:4213
+msgid "Thumbnail"
+msgstr ""
+
+#: wp-includes/media-template.php:898
+#: wp-includes/media-template.php:978
+#: wp-includes/media-template.php:1169
+#: wp-includes/media.php:4214
+msgid "Medium"
+msgstr ""
+
+#: wp-includes/media-template.php:899
+#: wp-includes/media-template.php:979
+#: wp-includes/media-template.php:1170
+#: wp-includes/media.php:4215
+msgid "Large"
+msgstr ""
+
+#: wp-includes/media-template.php:900
+#: wp-includes/media-template.php:980
+#: wp-includes/media-template.php:1171
+#: wp-includes/media.php:4216
+msgid "Full Size"
+msgstr ""
+
+#: wp-includes/media-template.php:921
+msgid "Gallery Settings"
 msgstr ""
 
 #: wp-includes/media-template.php:961
@@ -29183,6 +7682,11 @@ msgctxt "auto preload"
 msgid "Auto"
 msgstr ""
 
+#: wp-includes/media-template.php:1343
+#: wp-includes/media-template.php:1442
+msgid "Metadata"
+msgstr ""
+
 #: wp-includes/media-template.php:1352
 #: wp-includes/media-template.php:1451
 msgid "Autoplay"
@@ -29228,6 +7732,11 @@ msgstr ""
 msgid "There are no associated subtitles."
 msgstr ""
 
+#: wp-includes/media-template.php:1518
+#: wp-includes/media.php:4606
+msgid "No items found."
+msgstr ""
+
 #: wp-includes/media-template.php:1525
 msgid "Image crop area preview. Requires mouse interaction."
 msgstr ""
@@ -29268,9 +7777,29 @@ msgstr ""
 msgid "No editor could be selected."
 msgstr ""
 
+#: wp-includes/media.php:4167
+msgid "(no author)"
+msgstr ""
+
+#: wp-includes/media.php:4173
+#: wp-includes/script-loader.php:1057
+#: wp-includes/widgets/class-wp-widget-recent-posts.php:107
+msgid "(no title)"
+msgstr ""
+
 #: wp-includes/media.php:4577
 #: wp-includes/media.php:4599
 msgid "Add media"
+msgstr ""
+
+#: wp-includes/media.php:4579
+msgid "Select"
+msgstr ""
+
+#: wp-includes/media.php:4581
+#: wp-includes/script-loader.php:1055
+#: wp-login.php:666
+msgid "Update"
 msgstr ""
 
 #. translators: This is a would-be plural string used in the media manager. If there is not a word you can use in your language to avoid issues with the lack of plural support here, turn it into "selected: %d" then translate it.
@@ -29290,6 +7819,10 @@ msgstr ""
 msgid "Upload images"
 msgstr ""
 
+#: wp-includes/media.php:4598
+msgid "Media Library"
+msgstr ""
+
 #: wp-includes/media.php:4600
 msgid "Create a new gallery"
 msgstr ""
@@ -29304,6 +7837,24 @@ msgstr ""
 
 #: wp-includes/media.php:4603
 msgid "&#8592; Go to library"
+msgstr ""
+
+#: wp-includes/media.php:4604
+msgid "All media items"
+msgstr ""
+
+#: wp-includes/media.php:4605
+msgid "All dates"
+msgstr ""
+
+#: wp-includes/media.php:4608
+msgctxt "media items"
+msgid "Unattached"
+msgstr ""
+
+#: wp-includes/media.php:4609
+msgctxt "media items"
+msgid "Mine"
 msgstr ""
 
 #: wp-includes/media.php:4610
@@ -29333,6 +7884,14 @@ msgstr ""
 
 #: wp-includes/media.php:4615
 msgid "Bulk select"
+msgstr ""
+
+#: wp-includes/media.php:4619
+msgid "Error in deleting the attachment."
+msgstr ""
+
+#: wp-includes/media.php:4622
+msgid "Filter by type"
 msgstr ""
 
 #: wp-includes/media.php:4624
@@ -29374,6 +7933,10 @@ msgstr ""
 
 #: wp-includes/media.php:4644
 msgid "&#8592; Cancel gallery"
+msgstr ""
+
+#: wp-includes/media.php:4645
+msgid "Insert gallery"
 msgstr ""
 
 #: wp-includes/media.php:4646
@@ -29551,447 +8114,6 @@ msgstr ""
 msgid "When registering a default meta value the data must match the type provided."
 msgstr ""
 
-#. translators: 1: VHOST, 2: SUBDOMAIN_INSTALL, 3: wp-config.php, 4: is_subdomain_install()
-#: wp-includes/ms-default-constants.php:140
-msgid "The constant %1$s <strong>is deprecated</strong>. Use the boolean constant %2$s in %3$s to enable a subdomain configuration. Use %4$s to check whether a subdomain configuration is enabled."
-msgstr ""
-
-#. translators: 1: VHOST, 2: SUBDOMAIN_INSTALL
-#: wp-includes/ms-default-constants.php:151
-msgid "<strong>Conflicting values for the constants %1$s and %2$s.</strong> The value of %2$s will be assumed to be your subdomain configuration setting."
-msgstr ""
-
-#: wp-includes/ms-deprecated.php:406
-msgid "<strong>Error:</strong> Site URL you&#8217;ve entered is already taken."
-msgstr ""
-
-#: wp-includes/ms-deprecated.php:415
-msgid "<strong>Error:</strong> There was a problem creating site entry."
-msgstr ""
-
-#: wp-includes/ms-functions.php:182
-msgid "User cannot be added to this site."
-msgstr ""
-
-#: wp-includes/ms-functions.php:271
-msgid "That user does not exist."
-msgstr ""
-
-#: wp-includes/ms-functions.php:464
-msgid "Usernames can only contain lowercase letters (a-z) and numbers."
-msgstr ""
-
-#: wp-includes/ms-functions.php:471
-msgid "Please enter a username."
-msgstr ""
-
-#: wp-includes/ms-functions.php:480
-#: wp-includes/ms-functions.php:487
-#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1280
-#: wp-includes/user.php:2140
-msgid "Sorry, that username is not allowed."
-msgstr ""
-
-#: wp-includes/ms-functions.php:493
-msgid "You cannot use that email address to signup. There are problems with them blocking some emails from ClassicPress. Please use another email provider."
-msgstr ""
-
-#: wp-includes/ms-functions.php:497
-msgid "Username must be at least 4 characters."
-msgstr ""
-
-#: wp-includes/ms-functions.php:501
-#: wp-includes/user.php:2123
-msgid "Username may not be longer than 60 characters."
-msgstr ""
-
-#: wp-includes/ms-functions.php:506
-msgid "Sorry, usernames must have letters too!"
-msgstr ""
-
-#: wp-includes/ms-functions.php:514
-msgid "Sorry, that email address is not allowed!"
-msgstr ""
-
-#: wp-includes/ms-functions.php:520
-#: wp-includes/user.php:2127
-msgid "Sorry, that username already exists!"
-msgstr ""
-
-#. translators: %s: Link to the login page.
-#: wp-includes/ms-functions.php:529
-#: wp-includes/user.php:3362
-msgid "<strong>Error:</strong> This email address is already registered. <a href=\"%s\">Log in</a> with this address or choose another one."
-msgstr ""
-
-#: wp-includes/ms-functions.php:545
-msgid "That username is currently reserved but may be available in a couple of days."
-msgstr ""
-
-#: wp-includes/ms-functions.php:556
-msgid "That email address has already been used. Please check your inbox for an activation email. It will become available in a couple of days if you do nothing."
-msgstr ""
-
-#: wp-includes/ms-functions.php:645
-msgid "Please enter a site name."
-msgstr ""
-
-#: wp-includes/ms-functions.php:649
-msgid "Site names can only contain lowercase letters (a-z) and numbers."
-msgstr ""
-
-#: wp-includes/ms-functions.php:653
-msgid "That name is not allowed."
-msgstr ""
-
-#. translators: %s: Minimum site name length.
-#: wp-includes/ms-functions.php:667
-msgid "Site name must be at least %s character."
-msgid_plural "Site name must be at least %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: wp-includes/ms-functions.php:672
-msgid "Sorry, you may not use that site name."
-msgstr ""
-
-#: wp-includes/ms-functions.php:677
-msgid "Sorry, site names must have letters too!"
-msgstr ""
-
-#: wp-includes/ms-functions.php:695
-msgid "Please enter a site title."
-msgstr ""
-
-#: wp-includes/ms-functions.php:707
-#: wp-includes/ms-functions.php:1372
-#: wp-includes/ms-site.php:624
-msgid "Sorry, that site already exists!"
-msgstr ""
-
-#: wp-includes/ms-functions.php:716
-msgid "Sorry, that site is reserved!"
-msgstr ""
-
-#: wp-includes/ms-functions.php:735
-msgid "That site is currently reserved but may be available in a couple days."
-msgstr ""
-
-#. translators: New site notification email. 1: Activation URL, 2: New site URL.
-#: wp-includes/ms-functions.php:980
-msgid ""
-"To activate your site, please click the following link:\n"
-"\n"
-"%1$s\n"
-"\n"
-"After you activate, you will receive *another email* with your login.\n"
-"\n"
-"After you activate, you can visit your site here:\n"
-"\n"
-"%2$s"
-msgstr ""
-
-#. translators: New site notification email subject. 1: Network title, 2: New site URL.
-#: wp-includes/ms-functions.php:1012
-msgctxt "New site notification email subject"
-msgid "[%1$s] Activate %2$s"
-msgstr ""
-
-#. translators: New user notification email. %s: Activation URL.
-#: wp-includes/ms-functions.php:1100
-msgid ""
-"To activate your user, please click the following link:\n"
-"\n"
-"%s\n"
-"\n"
-"After you activate, you will receive *another email* with your login."
-msgstr ""
-
-#. translators: New user notification email subject. 1: Network title, 2: New user login.
-#: wp-includes/ms-functions.php:1124
-msgctxt "New user notification email subject"
-msgid "[%1$s] Activate %2$s"
-msgstr ""
-
-#: wp-includes/ms-functions.php:1164
-msgid "Invalid activation key."
-msgstr ""
-
-#: wp-includes/ms-functions.php:1169
-msgid "The user is already active."
-msgstr ""
-
-#: wp-includes/ms-functions.php:1171
-msgid "The site is already active."
-msgstr ""
-
-#: wp-includes/ms-functions.php:1187
-msgid "Could not create user"
-msgstr ""
-
-#: wp-includes/ms-functions.php:1203
-msgid "That username is already activated."
-msgstr ""
-
-#. translators: New site notification email. 1: Site URL, 2: User IP address, 3: URL to Network Settings screen.
-#: wp-includes/ms-functions.php:1445
-msgid ""
-"New Site: %1$s\n"
-"URL: %2$s\n"
-"Remote IP address: %3$s\n"
-"\n"
-"Disable these notifications: %4$s"
-msgstr ""
-
-#. translators: New site notification email subject. %s: New site URL.
-#: wp-includes/ms-functions.php:1470
-msgid "New Site Registration: %s"
-msgstr ""
-
-#. translators: New user notification email. 1: User login, 2: User IP address, 3: URL to Network Settings screen.
-#: wp-includes/ms-functions.php:1503
-msgid ""
-"New User: %1$s\n"
-"Remote IP address: %2$s\n"
-"\n"
-"Disable these notifications: %3$s"
-msgstr ""
-
-#. translators: New user notification email subject. %s: User login.
-#: wp-includes/ms-functions.php:1526
-msgid "New User Registration: %s"
-msgstr ""
-
-#. translators: New site notification email subject. 1: Network title, 2: New site title.
-#: wp-includes/ms-functions.php:1678
-msgid "New %1$s Site: %2$s"
-msgstr ""
-
-#. translators: New site notification email subject. %s: Network title.
-#: wp-includes/ms-functions.php:1748
-msgid "[%s] New Site Created"
-msgstr ""
-
-#. translators: New site notification email. 1: User login, 2: Site URL, 3: Site title.
-#: wp-includes/ms-functions.php:1754
-msgid ""
-"New site created by %1$s\n"
-"\n"
-"Address: %2$s\n"
-"Name: %3$s"
-msgstr ""
-
-#: wp-includes/ms-functions.php:1767
-msgctxt "email \"From\" field"
-msgid "Site Admin"
-msgstr ""
-
-#. translators: New user notification email subject. 1: Network title, 2: New user login.
-#: wp-includes/ms-functions.php:1884
-msgid "New %1$s User: %2$s"
-msgstr ""
-
-#: wp-includes/ms-functions.php:2122
-msgid "Unable to submit this form, please try again."
-msgstr ""
-
-#. translators: %s: Home URL.
-#: wp-includes/ms-functions.php:2187
-msgid "An error occurred adding you to this site. Go to the <a href=\"%s\">homepage</a>."
-msgstr ""
-
-#. translators: 1: Home URL, 2: Admin URL.
-#: wp-includes/ms-functions.php:2196
-msgid "You have been added to this site. Please visit the <a href=\"%1$s\">homepage</a> or <a href=\"%2$s\">log in</a> using your username and password."
-msgstr ""
-
-#: wp-includes/ms-functions.php:2200
-msgid "ClassicPress &rsaquo; Success"
-msgstr ""
-
-#. translators: Do not translate USERNAME, PASSWORD, LOGINLINK, SITE_NAME: those are placeholders.
-#: wp-includes/ms-functions.php:2338
-msgid ""
-"Hello USERNAME,\n"
-"\n"
-"Your new account is set up.\n"
-"\n"
-"You can log in with the following information:\n"
-"Username: USERNAME\n"
-"Password: PASSWORD\n"
-"LOGINLINK\n"
-"\n"
-"Thanks!\n"
-"\n"
-"--The Team @ SITE_NAME"
-msgstr ""
-
-#. translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders.
-#: wp-includes/ms-functions.php:2735
-msgid ""
-"Hello ###USERNAME###,\n"
-"\n"
-"You recently requested to have the network admin email address on\n"
-"your network changed.\n"
-"\n"
-"If this is correct, please click on the following link to change it:\n"
-"###ADMIN_URL###\n"
-"\n"
-"You can safely ignore and delete this email if you do not want to\n"
-"take this action.\n"
-"\n"
-"This email has been sent to ###EMAIL###\n"
-"\n"
-"Regards,\n"
-"All at ###SITENAME###\n"
-"###SITEURL###"
-msgstr ""
-
-#. translators: Email change notification email subject. %s: Network title.
-#: wp-includes/ms-functions.php:2787
-msgid "[%s] Network Admin Email Change Request"
-msgstr ""
-
-#. translators: Do not translate OLD_EMAIL, NEW_EMAIL, SITENAME, SITEURL: those are placeholders.
-#: wp-includes/ms-functions.php:2833
-msgid ""
-"Hi,\n"
-"\n"
-"This notice confirms that the network admin email address was changed on ###SITENAME###.\n"
-"\n"
-"The new network admin email address is ###NEW_EMAIL###.\n"
-"\n"
-"This email has been sent to ###OLD_EMAIL###\n"
-"\n"
-"Regards,\n"
-"All at ###SITENAME###\n"
-"###SITEURL###"
-msgstr ""
-
-#. translators: Network admin email change notification email subject. %s: Network title.
-#: wp-includes/ms-functions.php:2850
-msgid "[%s] Network Admin Email Changed"
-msgstr ""
-
-#: wp-includes/ms-load.php:99
-msgid "This site is no longer available."
-msgstr ""
-
-#. translators: %s: Admin email link.
-#: wp-includes/ms-load.php:111
-msgid "This site has not been activated yet. If you are having problems activating your site, please contact %s."
-msgstr ""
-
-#: wp-includes/ms-load.php:122
-msgid "This site has been archived or suspended."
-msgstr ""
-
-#: wp-includes/ms-load.php:474
-msgid "If your site does not display, please contact the owner of this network."
-msgstr ""
-
-#: wp-includes/ms-load.php:475
-msgid "If you are the owner of this network please check that your host&#8217;s database server is running properly and all tables are error free."
-msgstr ""
-
-#. translators: %s: Table name.
-#: wp-includes/ms-load.php:480
-msgid "<strong>Database tables are missing.</strong> This means that your host&#8217;s database server is not running, ClassicPress was not installed properly, or someone deleted %s. You really should look at your database now."
-msgstr ""
-
-#. translators: 1: Site URL, 2: Table name, 3: Database name.
-#: wp-includes/ms-load.php:486
-msgid "<strong>Could not find site %1$s.</strong> Searched for table %2$s in database %3$s. Is that right?"
-msgstr ""
-
-#: wp-includes/ms-load.php:492
-msgid "What do I do now?"
-msgstr ""
-
-#. translators: %s: Documentation URL.
-#: wp-includes/ms-load.php:495
-msgid "Read the <a href=\"%s\" target=\"_blank\">Debugging a ClassicPress Network</a> article. Some of the suggestions there may help you figure out what went wrong."
-msgstr ""
-
-#: wp-includes/ms-load.php:496
-msgid "https://wordpress.org/documentation/article/debugging-a-wordpress-network/"
-msgstr ""
-
-#: wp-includes/ms-load.php:498
-msgid "If you are still stuck with this message, then check that your database contains the following tables:"
-msgstr ""
-
-#: wp-includes/ms-site.php:69
-msgid "Could not insert site into the database."
-msgstr ""
-
-#: wp-includes/ms-site.php:79
-msgid "Could not retrieve site data."
-msgstr ""
-
-#: wp-includes/ms-site.php:161
-#: wp-includes/ms-site.php:214
-#: wp-includes/ms-site.php:658
-#: wp-includes/ms-site.php:789
-msgid "Site ID must not be empty."
-msgstr ""
-
-#: wp-includes/ms-site.php:166
-#: wp-includes/ms-site.php:219
-msgid "Site does not exist."
-msgstr ""
-
-#: wp-includes/ms-site.php:180
-msgid "Could not update site in the database."
-msgstr ""
-
-#: wp-includes/ms-site.php:269
-msgid "Could not delete site from the database."
-msgstr ""
-
-#: wp-includes/ms-site.php:579
-msgid "Site domain must not be empty."
-msgstr ""
-
-#: wp-includes/ms-site.php:584
-msgid "Site path must not be empty."
-msgstr ""
-
-#: wp-includes/ms-site.php:589
-msgid "Site network ID must be provided."
-msgstr ""
-
-#: wp-includes/ms-site.php:596
-msgid "Both registration and last updated dates must be provided."
-msgstr ""
-
-#: wp-includes/ms-site.php:607
-msgid "Both registration and last updated dates must be valid dates."
-msgstr ""
-
-#: wp-includes/ms-site.php:663
-#: wp-includes/ms-site.php:794
-msgid "Site with the ID does not exist."
-msgstr ""
-
-#: wp-includes/ms-site.php:667
-msgid "The site appears to be already initialized."
-msgstr ""
-
-#. translators: %d: Site ID.
-#: wp-includes/ms-site.php:680
-msgid "Site %d"
-msgstr ""
-
-#: wp-includes/ms-site.php:798
-msgid "The site appears to be already uninitialized."
-msgstr ""
-
-#. translators: %s: Database table name.
-#: wp-includes/ms-site.php:1319
-msgid "The %s table is not installed. Please run the network database upgrade."
-msgstr ""
-
 #: wp-includes/nav-menu.php:97
 msgid "Nav menu locations must be strings."
 msgstr ""
@@ -30106,6 +8228,15 @@ msgstr ""
 msgid "When registering an \"array\" setting to show in the REST API, you must specify the schema for each array item in \"show_in_rest.schema.items\"."
 msgstr ""
 
+#. translators: %s: misc
+#. translators: %s: privacy
+#: wp-includes/option.php:2448
+#: wp-includes/option.php:2461
+#: wp-includes/option.php:2521
+#: wp-includes/option.php:2534
+msgid "The \"%s\" options group has been removed. Use another settings group."
+msgstr ""
+
 #. translators: 1: $sanitize_callback, 2: register_setting()
 #: wp-includes/option.php:2553
 msgid "%1$s is deprecated. The callback from %2$s is used instead."
@@ -30195,6 +8326,12 @@ msgstr ""
 #: wp-includes/pluggable.php:1960
 #: wp-includes/pluggable.php:2159
 msgid "Email: %s"
+msgstr ""
+
+#. translators: Comment moderation. %s: Parent comment edit URL.
+#: wp-includes/pluggable.php:1782
+#: wp-includes/pluggable.php:1966
+msgid "In reply to: %s"
 msgstr ""
 
 #: wp-includes/pluggable.php:1787
@@ -30387,10 +8524,29 @@ msgstr ""
 msgid "Pages:"
 msgstr ""
 
+#: wp-includes/post-template.php:954
+msgid "Next page"
+msgstr ""
+
+#: wp-includes/post-template.php:955
+msgid "Previous page"
+msgstr ""
+
 #. translators: %s: Post custom field name.
 #: wp-includes/post-template.php:1128
 msgctxt "Post custom field name"
 msgid "%s:"
+msgstr ""
+
+#: wp-includes/post-template.php:1293
+#: wp-includes/theme-compat/sidebar.php:117
+#: wp-includes/widgets/class-wp-widget-pages.php:31
+#: wp-includes/widgets/class-wp-widget-pages.php:44
+msgid "Pages"
+msgstr ""
+
+#: wp-includes/post-template.php:1457
+msgid "Home"
 msgstr ""
 
 #: wp-includes/post-template.php:1766
@@ -30452,12 +8608,25 @@ msgctxt "add new from admin bar"
 msgid "Media"
 msgstr ""
 
+#: wp-includes/post.php:78
+msgctxt "file"
+msgid "Add New"
+msgstr ""
+
+#: wp-includes/post.php:79
+msgid "Edit Media"
+msgstr ""
+
 #: wp-includes/post.php:80
 msgid "View Attachment Page"
 msgstr ""
 
 #: wp-includes/post.php:81
 msgid "Attachment Attributes"
+msgstr ""
+
+#: wp-includes/post.php:111
+msgid "Revisions"
 msgstr ""
 
 #: wp-includes/post.php:112
@@ -30552,6 +8721,11 @@ msgid_plural "Published <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
+#: wp-includes/post.php:298
+msgctxt "post status"
+msgid "Scheduled"
+msgstr ""
+
 #. translators: %s: Number of scheduled posts.
 #: wp-includes/post.php:302
 msgid "Scheduled <span class=\"count\">(%s)</span>"
@@ -30559,12 +8733,22 @@ msgid_plural "Scheduled <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
+#: wp-includes/post.php:312
+msgctxt "post status"
+msgid "Draft"
+msgstr ""
+
 #. translators: %s: Number of draft posts.
 #: wp-includes/post.php:316
 msgid "Draft <span class=\"count\">(%s)</span>"
 msgid_plural "Drafts <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
+
+#: wp-includes/post.php:327
+msgctxt "post status"
+msgid "Pending"
+msgstr ""
 
 #. translators: %s: Number of pending posts.
 #. translators: %s: Number of pending requests.
@@ -30574,6 +8758,11 @@ msgid "Pending <span class=\"count\">(%s)</span>"
 msgid_plural "Pending <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
+
+#: wp-includes/post.php:342
+msgctxt "post status"
+msgid "Private"
+msgstr ""
 
 #. translators: %s: Number of private posts.
 #: wp-includes/post.php:346
@@ -30638,6 +8827,26 @@ msgid "Completed <span class=\"count\">(%s)</span>"
 msgid_plural "Completed <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
+
+#: wp-includes/post.php:936
+#: wp-includes/post.php:957
+msgid "Draft"
+msgstr ""
+
+#: wp-includes/post.php:937
+msgid "Pending Review"
+msgstr ""
+
+#: wp-includes/post.php:938
+#: wp-includes/post.php:958
+msgid "Private"
+msgstr ""
+
+#: wp-includes/post.php:939
+#: wp-includes/post.php:959
+#: wp-includes/script-loader.php:1090
+msgid "Published"
+msgstr ""
 
 #: wp-includes/post.php:1432
 #: wp-includes/post.php:1433
@@ -30749,6 +8958,12 @@ msgstr ""
 msgid "Content, title, and excerpt are empty."
 msgstr ""
 
+#: wp-includes/post.php:3982
+#: wp-includes/rest-api.php:2157
+#: wp-includes/script-loader.php:1148
+msgid "Invalid date."
+msgstr ""
+
 #: wp-includes/post.php:4206
 msgid "Could not update attachment in the database."
 msgstr ""
@@ -30772,6 +8987,11 @@ msgstr ""
 
 #: wp-includes/post.php:4365
 msgid "Invalid page template."
+msgstr ""
+
+#: wp-includes/post.php:5014
+msgctxt "tag delimiter"
+msgid ","
 msgstr ""
 
 #: wp-includes/query.php:165
@@ -30865,6 +9085,11 @@ msgstr ""
 msgid "%1$s (since %2$s; %3$s)"
 msgstr ""
 
+#. translators: Developer debugging message. 1: PHP function name, 2: Explanatory message.
+#: wp-includes/rest-api.php:664
+msgid "%1$s (%2$s)"
+msgstr ""
+
 #: wp-includes/rest-api.php:1028
 msgid "Cookie check failed"
 msgstr ""
@@ -30945,6 +9170,12 @@ msgstr ""
 
 #: wp-includes/rest-api.php:2151
 msgid "Invalid hex color."
+msgstr ""
+
+#: wp-includes/rest-api.php:2163
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:731
+#: wp-includes/user.php:4564
+msgid "Invalid email address."
 msgstr ""
 
 #. translators: %s: IP address.
@@ -31112,7 +9343,6 @@ msgstr ""
 
 #: wp-includes/rest-api/class-wp-rest-server.php:1163
 #: wp-includes/script-loader.php:606
-#: wp-admin/js/tags.js:58
 msgid "Sorry, you are not allowed to do that."
 msgstr ""
 
@@ -31173,9 +9403,19 @@ msgstr ""
 msgid "Sorry, you are not allowed to manage application passwords for this user."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:685
+#: wp-includes/user.php:376
+msgid "Application passwords are not available."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:702
 #: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:493
 msgid "You are not currently logged in."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:729
+#: wp-includes/user.php:381
+msgid "Application passwords are not available for your account. Please contact the site administrator for assistance."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php:796
@@ -31334,6 +9574,20 @@ msgstr ""
 msgid "Limit result set to attachments of a particular MIME type."
 msgstr ""
 
+#. translators: %s: Required disk space in kilobytes.
+#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1293
+msgid "Not enough space to upload. %s KB needed."
+msgstr ""
+
+#. translators: %s: Maximum allowed file size in kilobytes.
+#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1302
+msgid "This file is too big. Files must be less than %s KB in size."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1313
+msgid "You have used your space quota. Please delete files before uploading."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1331
 msgid "URL to the edited image file."
 msgstr ""
@@ -31360,6 +9614,10 @@ msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1364
 msgid "Angle to rotate clockwise in degrees."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1372
+msgid "Crop"
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php:1375
@@ -31419,6 +9677,10 @@ msgstr ""
 msgid "Sorry, you are not allowed to view autosaves of this post."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php:190
+msgid "Invalid item ID."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php:266
 #: wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:1349
 #: wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php:142
@@ -31460,6 +9722,11 @@ msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:140
 msgid "Sorry, you are not allowed to read comments without a post."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:150
+#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:389
+msgid "Sorry, you are not allowed to edit comments."
 msgstr ""
 
 #. translators: %s: List of forbidden parameters.
@@ -31512,6 +9779,10 @@ msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:706
 msgid "Creating comment failed."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:786
+msgid "Sorry, you are not allowed to edit this comment."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php:813
@@ -31917,6 +10188,13 @@ msgstr ""
 msgid "The plugin activation status."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:116
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:166
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:429
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:499
+msgid "Sorry, you are not allowed to manage plugins for this site."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:215
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:657
 msgid "Plugin not found."
@@ -31926,12 +10204,24 @@ msgstr ""
 msgid "Sorry, you are not allowed to manage this plugin."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:245
+msgid "Sorry, you are not allowed to install plugins on this site."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:253
 msgid "Sorry, you are not allowed to activate plugins."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:349
+msgid "Unable to connect to the filesystem. Please confirm your credentials."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:359
 msgid "Unable to determine what plugin was installed."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:507
+msgid "Sorry, you are not allowed to delete plugins for this site."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:542
@@ -31940,6 +10230,14 @@ msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:700
 msgid "Sorry, you are not allowed to manage network plugins."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:708
+msgid "Sorry, you are not allowed to activate this plugin."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:716
+msgid "Sorry, you are not allowed to deactivate this plugin."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php:750
@@ -32650,6 +10948,11 @@ msgstr ""
 msgid "An alphanumeric identifier for the taxonomy."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:99
+#: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:166
+msgid "Sorry, you are not allowed to manage terms in this taxonomy."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php:332
 msgid "All capabilities used by the taxonomy."
 msgstr ""
@@ -32725,6 +11028,10 @@ msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:137
 msgid "Required to be true, as terms do not support trashing."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:194
+msgid "Sorry, you are not allowed to edit terms in this taxonomy."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:215
@@ -33001,8 +11308,18 @@ msgstr ""
 msgid "The role %s does not exist."
 msgstr ""
 
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1228
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1242
+msgid "Sorry, you are not allowed to give users that role."
+msgstr ""
+
 #: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1269
 msgid "This username is invalid because it uses illegal characters. Please enter a valid username."
+msgstr ""
+
+#: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1280
+#: wp-includes/user.php:2140
+msgid "Sorry, that username is not allowed."
 msgstr ""
 
 #: wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:1306
@@ -33126,6 +11443,14 @@ msgstr ""
 
 #: wp-includes/rest-api/fields/class-wp-rest-meta-fields.php:514
 msgid "Meta fields."
+msgstr ""
+
+#: wp-includes/revision.php:33
+msgid "Content"
+msgstr ""
+
+#: wp-includes/revision.php:34
+msgid "Excerpt"
 msgstr ""
 
 #: wp-includes/revision.php:346
@@ -33297,6 +11622,10 @@ msgstr ""
 msgid "The server cannot process the image. This can happen if the server is busy or does not have enough resources to complete the task. Uploading a smaller image may help. Suggested maximum size is 2560 pixels."
 msgstr ""
 
+#: wp-includes/script-loader.php:796
+msgid "Upload failed."
+msgstr ""
+
 #. translators: 1: Opening link tag, 2: Closing link tag.
 #: wp-includes/script-loader.php:798
 msgid "Please try uploading this file with the %1$sbrowser uploader%2$s."
@@ -33331,6 +11660,11 @@ msgstr ""
 msgid "moved to the Trash."
 msgstr ""
 
+#. translators: %s: File name.
+#: wp-includes/script-loader.php:809
+msgid "&#8220;%s&#8221; has failed to upload."
+msgstr ""
+
 #: wp-includes/script-loader.php:810
 msgid "This image cannot be displayed in a web browser. For best results convert it to JPEG before uploading."
 msgstr ""
@@ -33340,8 +11674,6 @@ msgid "This image cannot be processed by the web server. Convert it to JPEG or P
 msgstr ""
 
 #: wp-includes/script-loader.php:812
-#: wp-admin/js/media.js:239
-#: wp-admin/js/post.js:1317
 #: wp-includes/js/media-views.js:8990
 msgid "The file URL has been copied to your clipboard"
 msgstr ""
@@ -33510,6 +11842,10 @@ msgstr ""
 
 #: wp-includes/script-loader.php:903
 msgid "Dutch"
+msgstr ""
+
+#: wp-includes/script-loader.php:904
+msgid "English"
 msgstr ""
 
 #: wp-includes/script-loader.php:905
@@ -33720,6 +12056,10 @@ msgctxt "minimum input length for searching post links"
 msgid "3"
 msgstr ""
 
+#: wp-includes/script-loader.php:1087
+msgid "Activate &amp; Publish"
+msgstr ""
+
 #: wp-includes/script-loader.php:1088
 msgid "Save &amp; Publish"
 msgstr ""
@@ -33746,9 +12086,6 @@ msgid "Please save your changes in order to share the preview."
 msgstr ""
 
 #: wp-includes/script-loader.php:1100
-#: wp-admin/js/widgets.js:183
-#: wp-admin/js/widgets.js:464
-#: wp-admin/js/widgets.js:575
 msgid "Saved"
 msgstr ""
 
@@ -33758,6 +12095,11 @@ msgstr ""
 
 #: wp-includes/script-loader.php:1108
 msgid "Site Preview"
+msgstr ""
+
+#: wp-includes/script-loader.php:1110
+msgctxt "label for hide controls button without length constraints"
+msgid "Hide Controls"
 msgstr ""
 
 #: wp-includes/script-loader.php:1111
@@ -33834,6 +12176,10 @@ msgstr ""
 msgid "You will not be able to install new themes from here yet since your install requires SFTP credentials. For now, please <a href=\"%s\">add themes in the admin</a>."
 msgstr ""
 
+#: wp-includes/script-loader.php:1147
+msgid "Publish Settings"
+msgstr ""
+
 #. translators: 1: Link to Site Editor documentation on HelpHub, 2: HTML button.
 #: wp-includes/script-loader.php:1152
 msgid "Hurray! Your theme supports site editing with blocks. <a href=\"%1$s\">Tell me more</a>. %2$s"
@@ -33869,6 +12215,10 @@ msgstr ""
 #: wp-includes/script-loader.php:1391
 msgctxt "Open Sans font: add new subset (greek, cyrillic, vietnamese)"
 msgid "no-subset"
+msgstr ""
+
+#: wp-includes/script-loader.php:1628
+msgid "Today"
 msgstr ""
 
 #: wp-includes/script-loader.php:1632
@@ -33930,6 +12280,11 @@ msgstr ""
 msgid "Number of URLs in this XML Sitemap: %s."
 msgstr ""
 
+#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:63
+#: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:177
+msgid "Last Modified"
+msgstr ""
+
 #: wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php:64
 msgid "Change Frequency"
 msgstr ""
@@ -33945,6 +12300,10 @@ msgstr ""
 #: wp-includes/taxonomy.php:117
 #: wp-includes/widgets/class-wp-nav-menu-widget.php:30
 msgid "Navigation Menu"
+msgstr ""
+
+#: wp-includes/taxonomy.php:142
+msgid "Link Categories"
 msgstr ""
 
 #: wp-includes/taxonomy.php:143
@@ -33982,6 +12341,11 @@ msgstr ""
 #: wp-includes/taxonomy.php:177
 msgctxt "post format"
 msgid "Formats"
+msgstr ""
+
+#: wp-includes/taxonomy.php:178
+msgctxt "post format"
+msgid "Format"
 msgstr ""
 
 #: wp-includes/taxonomy.php:451
@@ -34475,9 +12839,28 @@ msgstr ""
 msgid "An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please report this issue in our <a href=\"%s\">support forum</a>."
 msgstr ""
 
+#: wp-includes/update.php:160
+msgid "(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)"
+msgstr ""
+
 #. translators: %s: support forums URL
 #: wp-includes/update.php:390
 msgid "An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
+msgstr ""
+
+#: wp-includes/update.php:391
+#: wp-includes/update.php:667
+#: wp-login.php:1243
+msgid "https://forums.classicpress.net/c/support"
+msgstr ""
+
+#: wp-includes/update.php:392
+msgid "(ClassicPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)"
+msgstr ""
+
+#. translators: %s: support forums URL
+#: wp-includes/update.php:666
+msgid "An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href=\"%s\">support forums</a>."
 msgstr ""
 
 #: wp-includes/update.php:668
@@ -34578,6 +12961,14 @@ msgstr ""
 
 #: wp-includes/user.php:2121
 msgid "Cannot create a user with an empty login name."
+msgstr ""
+
+#: wp-includes/user.php:2123
+msgid "Username may not be longer than 60 characters."
+msgstr ""
+
+#: wp-includes/user.php:2127
+msgid "Sorry, that username already exists!"
 msgstr ""
 
 #: wp-includes/user.php:2165
@@ -34715,8 +13106,34 @@ msgstr ""
 msgid "https://wordpress.org/documentation/article/reset-your-password/"
 msgstr ""
 
+#: wp-includes/user.php:3337
+msgid "<strong>Error:</strong> Please enter a username."
+msgstr ""
+
+#: wp-includes/user.php:3339
+msgid "<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username."
+msgstr ""
+
+#: wp-includes/user.php:3342
+msgid "<strong>Error:</strong> This username is already registered. Please choose another one."
+msgstr ""
+
+#: wp-includes/user.php:3347
+msgid "<strong>Error:</strong> Sorry, that username is not allowed."
+msgstr ""
+
 #: wp-includes/user.php:3353
 msgid "<strong>Error:</strong> Please type your email address."
+msgstr ""
+
+#: wp-includes/user.php:3355
+#: wp-includes/user.php:3655
+msgid "<strong>Error:</strong> The email address is not correct."
+msgstr ""
+
+#. translators: %s: Link to the login page.
+#: wp-includes/user.php:3362
+msgid "<strong>Error:</strong> This email address is already registered. <a href=\"%s\">Log in</a> with this address or choose another one."
 msgstr ""
 
 #. translators: %s: Admin email address.
@@ -34969,9 +13386,22 @@ msgstr ""
 msgid "An incomplete personal data request for this email address already exists."
 msgstr ""
 
+#: wp-includes/user.php:4624
+msgid "Export Personal Data"
+msgstr ""
+
+#: wp-includes/user.php:4627
+msgid "Erase Personal Data"
+msgstr ""
+
 #. translators: %s: Action name.
 #: wp-includes/user.php:4631
 msgid "Confirm the \"%s\" action"
+msgstr ""
+
+#: wp-includes/user.php:4661
+#: wp-includes/user.php:4847
+msgid "Invalid personal data request."
 msgstr ""
 
 #. translators: Confirm privacy data request notification email subject. 1: Site title, 2: Name of the action.
@@ -35023,6 +13453,10 @@ msgstr ""
 #: wp-includes/widgets.php:182
 #: wp-includes/widgets.php:268
 msgid "Sidebar %d"
+msgstr ""
+
+#: wp-includes/widgets.php:185
+msgid "Sidebar"
 msgstr ""
 
 #. translators: 1: The 'id' argument, 2: Sidebar name, 3: Recommended 'id' value.
@@ -35187,6 +13621,10 @@ msgstr ""
 msgid "Your blogroll"
 msgstr ""
 
+#: wp-includes/widgets/class-wp-widget-links.php:29
+msgid "Links"
+msgstr ""
+
 #: wp-includes/widgets/class-wp-widget-links.php:147
 msgid "Select Link Category:"
 msgstr ""
@@ -35290,6 +13728,10 @@ msgstr ""
 #: wp-includes/widgets/class-wp-widget-media-image.php:354
 #: wp-includes/widgets/class-wp-widget-media-video.php:240
 msgid "Unable to preview media due to an unknown error."
+msgstr ""
+
+#: wp-includes/widgets/class-wp-widget-media-gallery.php:28
+msgid "Gallery"
 msgstr ""
 
 #: wp-includes/widgets/class-wp-widget-media-gallery.php:30
@@ -35518,6 +13960,11 @@ msgstr ""
 msgid "Your site&#8217;s most recent comments."
 msgstr ""
 
+#: wp-includes/widgets/class-wp-widget-recent-comments.php:31
+#: wp-includes/widgets/class-wp-widget-recent-comments.php:81
+msgid "Recent Comments"
+msgstr ""
+
 #. translators: Comments widget. 1: Comment author, 2: Post link.
 #: wp-includes/widgets/class-wp-widget-recent-comments.php:138
 msgctxt "widgets"
@@ -35547,6 +13994,15 @@ msgstr ""
 
 #: wp-includes/widgets/class-wp-widget-rss.php:26
 msgid "Entries from any RSS or Atom feed."
+msgstr ""
+
+#: wp-includes/widgets/class-wp-widget-rss.php:35
+#: wp-includes/widgets/class-wp-widget-rss.php:98
+msgid "RSS"
+msgstr ""
+
+#: wp-includes/widgets/class-wp-widget-rss.php:84
+msgid "Unknown Feed"
 msgstr ""
 
 #: wp-includes/widgets/class-wp-widget-rss.php:124
@@ -35636,6 +14092,15 @@ msgstr ""
 msgid "There doesn't seem to be a %s file. It is needed before the installation can continue."
 msgstr ""
 
+#. translators: 1: Documentation URL, 2: wp-config.php
+#: wp-load.php:93
+msgid "Need more help? <a href=\"%1$s\">Read the support article on %2$s</a>."
+msgstr ""
+
+#: wp-load.php:94
+msgid "https://wordpress.org/documentation/article/editing-wp-config-php/"
+msgstr ""
+
 #. translators: %s: wp-config.php
 #: wp-load.php:99
 msgid "You can create a %s file through a web interface, but this doesn't work for all server setups. The safest way is to manually create the file."
@@ -35645,10 +14110,24 @@ msgstr ""
 msgid "Create a Configuration File"
 msgstr ""
 
+#. translators: Login screen title. 1: Login screen name, 2: Network or site name.
+#: wp-login.php:72
+msgid "%1$s &lsaquo; %2$s &#8212; ClassicPress"
+msgstr ""
+
+#. translators: %s: Login screen title.
+#: wp-login.php:76
+msgid "Recovery Mode &#8212; %s"
+msgstr ""
+
 #. translators: %s: Site title.
 #: wp-login.php:255
 msgctxt "site"
 msgid "&larr; Go to %s"
+msgstr ""
+
+#: wp-login.php:340
+msgid "Change"
 msgstr ""
 
 #: wp-login.php:590
@@ -35718,6 +14197,10 @@ msgid "<strong>Error:</strong> The passwords do not match."
 msgstr ""
 
 #: wp-login.php:941
+msgid "Password Reset"
+msgstr ""
+
+#: wp-login.php:941
 msgid "Your password has been reset."
 msgstr ""
 
@@ -35733,8 +14216,16 @@ msgstr ""
 msgid "New password"
 msgstr ""
 
+#: wp-login.php:963
+msgid "Hide password"
+msgstr ""
+
 #: wp-login.php:966
 msgid "Strength indicator"
+msgstr ""
+
+#: wp-login.php:970
+msgid "Confirm use of weak password"
 msgstr ""
 
 #: wp-login.php:975
@@ -35757,6 +14248,10 @@ msgstr ""
 msgid "Register For This Site"
 msgstr ""
 
+#: wp-login.php:1079
+msgid "Username"
+msgstr ""
+
 #: wp-login.php:1097
 msgid "Registration confirmation will be emailed to you."
 msgstr ""
@@ -35773,6 +14268,10 @@ msgstr ""
 
 #: wp-login.php:1153
 msgid "Check your email"
+msgstr ""
+
+#: wp-login.php:1159
+msgid "Missing request ID."
 msgstr ""
 
 #: wp-login.php:1163
@@ -35826,7 +14325,6 @@ msgid "Recovery Mode Initialized. Please log in to continue."
 msgstr ""
 
 #: wp-login.php:1427
-#: wp-admin/js/user-profile.js:81
 msgid "Show password"
 msgstr ""
 
@@ -35841,6 +14339,10 @@ msgstr ""
 
 #: wp-mail.php:65
 msgid "There does not seem to be any new mail."
+msgstr ""
+
+#: wp-mail.php:248
+msgid "Author:"
 msgstr ""
 
 #: wp-mail.php:249
@@ -35896,6 +14398,14 @@ msgstr ""
 
 #: wp-signup.php:213
 msgid "Allow search engines to index this site."
+msgstr ""
+
+#: wp-signup.php:218
+msgid "Yes"
+msgstr ""
+
+#: wp-signup.php:222
+msgid "No"
 msgstr ""
 
 #: wp-signup.php:280
@@ -36092,531 +14602,6 @@ msgstr ""
 msgid "There is already a ping from that URL for this post."
 msgstr ""
 
-#: wp-admin/js/application-passwords.js:85
-msgid "Are you sure you want to revoke this password? This action cannot be undone."
-msgstr ""
-
-#: wp-admin/js/application-passwords.js:108
-msgid "Application password revoked."
-msgstr ""
-
-#: wp-admin/js/application-passwords.js:116
-msgid "Are you sure you want to revoke all passwords? This action cannot be undone."
-msgstr ""
-
-#: wp-admin/js/application-passwords.js:136
-msgid "All application passwords revoked."
-msgstr ""
-
-#: wp-admin/js/color-picker.js:121
-msgid "Color value"
-msgstr ""
-
-#: wp-admin/js/color-picker.js:139
-msgid "Select Color"
-msgstr ""
-
-#: wp-admin/js/color-picker.js:150
-msgid "Select default color"
-msgstr ""
-
-#: wp-admin/js/color-picker.js:155
-msgid "Clear color"
-msgstr ""
-
-#: wp-admin/js/comment.js:87
-msgid "Submitted on:"
-msgstr ""
-
-#. translators: 1: Deprecated property name, 2: Version number, 3: Alternative property name.
-#: wp-admin/js/common.js:37
-msgid "%1$s is deprecated since version %2$s! Use %3$s instead."
-msgstr ""
-
-#. translators: 1: Deprecated property name, 2: Version number.
-#: wp-admin/js/common.js:45
-msgid "%1$s is deprecated since version %2$s with no alternative available."
-msgstr ""
-
-#: wp-admin/js/common.js:527
-msgid ""
-"You are about to permanently delete these items from your site.\n"
-"This action cannot be undone.\n"
-"'Cancel' to stop, 'OK' to delete."
-msgstr ""
-
-#: wp-admin/js/common.js:1986
-msgid "Expand Main menu"
-msgstr ""
-
-#: wp-admin/js/edit-comments.js:365
-#: wp-admin/js/edit-comments.js:1012
-msgid "Approve and Reply"
-msgstr ""
-
-#: wp-admin/js/edit-comments.js:851
-msgid ""
-"Are you sure you want to edit this comment?\n"
-"The changes you made will be lost."
-msgstr ""
-
-#: wp-admin/js/edit-comments.js:1231
-msgid ""
-"Are you sure you want to do this?\n"
-"The comment changes you made will be lost."
-msgstr ""
-
-#: wp-admin/js/image-edit.js:420
-msgid "Could not load the preview image. Please reload the page and try again."
-msgstr ""
-
-#: wp-admin/js/image-edit.js:629
-msgid "Could not load the preview image."
-msgstr ""
-
-#. translators: %s: Post title.
-#: wp-admin/js/inline-edit-post.js:359
-msgid "Remove &#8220;%s&#8221; from Bulk Edit"
-msgstr ""
-
-#: wp-admin/js/inline-edit-post.js:388
-msgid "Item removed."
-msgstr ""
-
-#: wp-admin/js/inline-edit-post.js:398
-msgid "All selected items have been removed. Select new items to use Bulk Actions."
-msgstr ""
-
-#: wp-admin/js/inline-edit-post.js:622
-#: wp-admin/js/inline-edit-post.js:623
-#: wp-admin/js/inline-edit-tax.js:241
-#: wp-admin/js/inline-edit-tax.js:242
-msgid "Error while saving the changes."
-msgstr ""
-
-#: wp-admin/js/nav-menu.js:695
-msgid ""
-"You are about to permanently delete this menu.\n"
-"'Cancel' to stop, 'OK' to delete."
-msgstr ""
-
-#. translators: 1: Deprecated function name, 2: Version number, 3: Alternative function name.
-#: wp-admin/js/password-strength-meter.js:66
-msgid "%1$s is deprecated since version %2$s! Use %3$s instead. Please consider writing more inclusive code."
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/js/plugin-install.js:34
-msgid "Plugin: %s"
-msgstr ""
-
-#: wp-admin/js/plugin-install.js:37
-msgid "Plugin details"
-msgstr ""
-
-#: wp-admin/js/post.js:77
-msgid "Show more comments"
-msgstr ""
-
-#: wp-admin/js/post.js:81
-msgid "No more comments found."
-msgstr ""
-
-#: wp-admin/js/post.js:153
-#: wp-admin/js/set-post-thumbnail.js:18
-#: wp-includes/js/media-editor.js:630
-msgid "Could not set that as the thumbnail image. Try a different attachment."
-msgstr ""
-
-#: wp-admin/js/post.js:483
-msgid "Saving Draft…"
-msgstr ""
-
-#: wp-admin/js/post.js:791
-msgid "Schedule for:"
-msgstr ""
-
-#: wp-admin/js/post.js:794
-msgid "Publish on:"
-msgstr ""
-
-#: wp-admin/js/post.js:797
-msgid "Published on:"
-msgstr ""
-
-#: wp-admin/js/post.js:909
-msgid "Password Protected"
-msgstr ""
-
-#: wp-admin/js/post.js:1062
-msgid "Permalink saved"
-msgstr ""
-
-#: wp-admin/js/post.js:1083
-msgid "URL Slug"
-msgstr ""
-
-#: wp-admin/js/postbox.js:25
-msgid "Add boxes from the Screen Options menu"
-msgstr ""
-
-#: wp-admin/js/postbox.js:25
-msgid "Drag boxes here"
-msgstr ""
-
-#: wp-admin/js/postbox.js:62
-msgid "The box is on the first position"
-msgstr ""
-
-#: wp-admin/js/postbox.js:63
-msgid "The box is on the last position"
-msgstr ""
-
-#: wp-admin/js/postbox.js:328
-msgid "The boxes order has been saved."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:80
-msgid "This user&#8217;s personal data export link was sent."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:83
-msgid "This user&#8217;s personal data export file was downloaded."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:93
-msgid "No personal data export file was generated."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:100
-msgid "An error occurred while attempting to export personal data."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:185
-#: wp-admin/js/privacy-tools.js:192
-msgid "No personal data was found for this user."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:194
-msgid "Personal data was found for this user but was not erased."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:199
-msgid "All of the personal data found for this user was erased."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:201
-msgid "Personal data was found for this user but some of the personal data found was not erased."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:211
-msgid "An error occurred while attempting to find and erase personal data."
-msgstr ""
-
-#: wp-admin/js/privacy-tools.js:317
-msgid "The suggested policy text has been copied to your clipboard."
-msgstr ""
-
-#: wp-admin/js/set-post-thumbnail.js:11
-msgid "Saving…"
-msgstr ""
-
-#: wp-admin/js/set-post-thumbnail.js:16
-msgid "Use as featured image"
-msgstr ""
-
-#: wp-admin/js/site-health.js:42
-msgid "Site information has been copied to your clipboard."
-msgstr ""
-
-#: wp-admin/js/site-health.js:227
-msgid "Good"
-msgstr ""
-
-#: wp-admin/js/site-health.js:228
-msgid "All site health tests have finished running. Your site is looking good, and the results are now available on the page."
-msgstr ""
-
-#: wp-admin/js/site-health.js:232
-msgid "Should be improved"
-msgstr ""
-
-#: wp-admin/js/site-health.js:233
-msgid "All site health tests have finished running. There are items that should be addressed, and the results are now available on the page."
-msgstr ""
-
-#: wp-admin/js/site-health.js:291
-#: wp-admin/js/site-health.js:312
-msgid "No details available"
-msgstr ""
-
-#: wp-admin/js/site-health.js:343
-msgid "Unavailable"
-msgstr ""
-
-#: wp-admin/js/site-health.js:382
-msgid "Please wait..."
-msgstr ""
-
-#: wp-admin/js/site-health.js:408
-msgid "All site health tests have finished running."
-msgstr ""
-
-#: wp-admin/js/tags-box.js:170
-msgid "Remove term:"
-msgstr ""
-
-#: wp-admin/js/tags-box.js:340
-msgid "Term removed."
-msgstr ""
-
-#: wp-admin/js/tags-box.js:344
-msgid "Term added."
-msgstr ""
-
-#: wp-admin/js/theme-plugin-editor.js:230
-msgid "Something went wrong. Your change may not have been saved. Please try again. There is also a chance that you may need to manually fix and upload the file over FTP."
-msgstr ""
-
-#. translators: %s: Error count.
-#: wp-admin/js/theme-plugin-editor.js:401
-msgid "There is %s error which must be fixed before you can update this file."
-msgid_plural "There are %s errors which must be fixed before you can update this file."
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:467
-#: wp-admin/js/updates.js:475
-msgctxt "plugin"
-msgid "Updating %s..."
-msgstr ""
-
-#: wp-admin/js/updates.js:485
-#: wp-admin/js/updates.js:491
-#: wp-admin/js/updates.js:1182
-#: wp-admin/js/updates.js:1187
-msgid "Updating..."
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:543
-msgctxt "plugin"
-msgid "%s updated!"
-msgstr ""
-
-#: wp-admin/js/updates.js:547
-msgctxt "plugin"
-msgid "Updated!"
-msgstr ""
-
-#: wp-admin/js/updates.js:549
-#: wp-admin/js/updates.js:1248
-msgid "Update completed successfully."
-msgstr ""
-
-#. translators: %s: Error string for a failed update.
-#: wp-admin/js/updates.js:583
-#: wp-admin/js/updates.js:1274
-#: wp-admin/js/updates.js:1963
-msgid "Update failed: %s"
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:601
-#: wp-admin/js/updates.js:626
-msgctxt "plugin"
-msgid "%s update failed."
-msgstr ""
-
-#: wp-admin/js/updates.js:617
-#: wp-admin/js/updates.js:1997
-msgid "Update failed."
-msgstr ""
-
-#: wp-admin/js/updates.js:681
-#: wp-admin/js/updates.js:695
-#: wp-admin/js/updates.js:1332
-#: wp-admin/js/updates.js:1345
-msgid "Installing..."
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:691
-msgctxt "plugin"
-msgid "Installing %s..."
-msgstr ""
-
-#: wp-admin/js/updates.js:697
-#: wp-admin/js/updates.js:1347
-msgid "Installing... please wait."
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:727
-msgctxt "plugin"
-msgid "%s installed!"
-msgstr ""
-
-#: wp-admin/js/updates.js:731
-msgctxt "plugin"
-msgid "Installed!"
-msgstr ""
-
-#: wp-admin/js/updates.js:733
-#: wp-admin/js/updates.js:867
-#: wp-admin/js/updates.js:1386
-msgid "Installation completed successfully."
-msgstr ""
-
-#. translators: %s: Error string for a failed installation.
-#: wp-admin/js/updates.js:798
-#: wp-admin/js/updates.js:886
-#: wp-admin/js/updates.js:1450
-#: wp-admin/js/updates.js:1968
-msgid "Installation failed: %s"
-msgstr ""
-
-#. translators: %s: Plugin name and version.
-#: wp-admin/js/updates.js:822
-msgctxt "plugin"
-msgid "%s installation failed"
-msgstr ""
-
-#. translators: %s: Activation URL.
-#: wp-admin/js/updates.js:849
-msgid "Importer installed successfully. <a href=\"%s\">Run importer</a>"
-msgstr ""
-
-#: wp-admin/js/updates.js:944
-#: wp-admin/js/updates.js:947
-#: wp-admin/js/updates.js:950
-#: wp-admin/js/updates.js:1528
-#: wp-admin/js/updates.js:1531
-#: wp-admin/js/updates.js:1534
-msgid "Deleting..."
-msgstr ""
-
-#: wp-admin/js/updates.js:1077
-msgctxt "plugin"
-msgid "Deleted!"
-msgstr ""
-
-#: wp-admin/js/updates.js:1186
-msgid "Updating... please wait."
-msgstr ""
-
-#: wp-admin/js/updates.js:1211
-msgctxt "theme"
-msgid "Updated!"
-msgstr ""
-
-#. translators: %s: Theme name and version.
-#: wp-admin/js/updates.js:1341
-msgctxt "theme"
-msgid "Installing %s..."
-msgstr ""
-
-#. translators: %s: Theme name and version.
-#: wp-admin/js/updates.js:1380
-msgctxt "theme"
-msgid "%s installed!"
-msgstr ""
-
-#: wp-admin/js/updates.js:1384
-msgctxt "theme"
-msgid "Installed!"
-msgstr ""
-
-#. translators: %s: Theme name.
-#: wp-admin/js/updates.js:1404
-msgctxt "theme"
-msgid "Network Activate %s"
-msgstr ""
-
-#. translators: %s: Theme name and version.
-#: wp-admin/js/updates.js:1491
-msgctxt "theme"
-msgid "%s installation failed"
-msgstr ""
-
-#: wp-admin/js/updates.js:1625
-msgctxt "theme"
-msgid "Deleted!"
-msgstr ""
-
-#. translators: %s: Error string for a failed deletion.
-#: wp-admin/js/updates.js:1647
-#: wp-admin/js/updates.js:1973
-msgid "Deletion failed: %s"
-msgstr ""
-
-#: wp-admin/js/updates.js:1953
-msgid "Connection lost or the server is busy. Please try again later."
-msgstr ""
-
-#: wp-admin/js/updates.js:2021
-msgid "Updates may not complete if you navigate away from this page."
-msgstr ""
-
-#: wp-admin/js/updates.js:2155
-#: wp-admin/js/updates.js:2233
-#: wp-admin/js/updates.js:2276
-msgid "Update canceled."
-msgstr ""
-
-#. translators: %s: Plugin name.
-#: wp-admin/js/updates.js:2302
-msgid "Are you sure you want to delete %s and its data?"
-msgstr ""
-
-#. translators: %s: Plugin name.
-#. translators: %s: Theme name.
-#: wp-admin/js/updates.js:2308
-#: wp-admin/js/updates.js:2365
-msgid "Are you sure you want to delete %s?"
-msgstr ""
-
-#: wp-admin/js/updates.js:2422
-msgid "Please select at least one item to perform this action on."
-msgstr ""
-
-#: wp-admin/js/updates.js:2434
-msgid "Are you sure you want to delete the selected plugins and their data?"
-msgstr ""
-
-#: wp-admin/js/updates.js:2435
-msgid "Caution: These themes may be active on other sites in the network. Are you sure you want to proceed?"
-msgstr ""
-
-#: wp-admin/js/updates.js:2598
-msgid "You do not appear to have any plugins available at this time."
-msgstr ""
-
-#. translators: %s: Number of plugins.
-#: wp-admin/js/updates.js:2603
-#: wp-admin/js/updates.js:2689
-msgid "Number of plugins found: %d"
-msgstr ""
-
-#: wp-admin/js/updates.js:2912
-msgid "Enabling..."
-msgstr ""
-
-#: wp-admin/js/updates.js:2914
-msgid "Disabling..."
-msgstr ""
-
-#: wp-admin/js/updates.js:2938
-#: wp-admin/js/updates.js:3002
-#: wp-admin/js/updates.js:3004
-msgid "The request could not be completed."
-msgstr ""
-
-#: wp-admin/js/user-profile.js:476
-msgid "Your new password has not been saved."
-msgstr ""
-
 #: wp-includes/js/dist/a11y.js:2218
 msgid "Notifications"
 msgstr ""
@@ -36635,6 +14620,10 @@ msgstr ""
 
 #: wp-includes/js/dist/api-fetch.js:3164
 msgid "You are probably offline."
+msgstr ""
+
+#: wp-includes/js/media-editor.js:630
+msgid "Could not set that as the thumbnail image. Try a different attachment."
 msgstr ""
 
 #. translators: Accessibility text. %d: Number of attachments found in a search.


### PR DESCRIPTION
This PR adds an automation script for the creation of split POT files (4 are used in core, frontend, admin, network / multisite admin and Continents / Cities for timezones)

A Readme is also added with more details on how to deploy this script and a `.gitignore` is added so that when the `ClassicPress/ClassicPress` repository is cloned locally for POT creation it is not inadvertently committed.