### PR TITLE
Update shell scripts for POT and Zip creation

### DIFF
--- a/bin/build_zip.sh
+++ b/bin/build_zip.sh
@@ -27,13 +27,7 @@ mkdir -p zips
 dir="./translations"
 
 cd "$dir"
-
-# clear any existing *.mo files
-echo 'Removing existing MO files for locale'
-mofiles=""
-for f in *${locales}.mo; do
-	rm "${f}" || true
-done
+mkdir "$locales"
 
 # create a list of all available locales
 echo 'Creating list of PO files for locale'
@@ -42,33 +36,63 @@ for f in *${locales}.po; do
 	pofiles+="${f} "
 done
 
-# make *.mo files for all *.po files
-echo ''
-echo 'Creating mo files'
+echo 'Copying PO files to working locale folder'
 for n in ${pofiles[@]};
 do
-	wp i18n make-mo "${n}"
+	cp "${n}" "$locales"
 done
 
-pomofiles=""
-for f in *${locales}.{po,mo}; do
-	pomofiles+="${f} "
-done
+pushd "$locales" > /dev/null
+	# make *.mo files for all *.po files
+	echo 'Working in locale folder'
+	echo ''
+	echo 'Creating mo files'
+	for n in ${pofiles[@]};
+	do
+		wp i18n make-mo "${n}"
+	done
 
-echo ''
-echo 'Creating zip file'
-for n in ${pomofiles[@]};
-do
-	zip "../zips/$locales.zip" "$n"
-done
+	echo ''
+	echo 'Creating JSON files'
+	wp i18n make-json --no-purge .
+	
+	pomofiles=""
+	for f in *${locales}.{po,mo}; do
+		pomofiles+="${f} "
+	done
+	
+	echo ''
+	echo 'Creating zip file'
+	for n in ${pomofiles[@]};
+	do
+		zip "../../zips/$locales.zip" "$n"
+	done
+
+	for f in admin-*${locales}*.json; do
+		mv "${f}" "${f#admin-}"
+	done
+	
+	jsonfiles=""
+	for f in *${locales}*.json; do
+		jsonfiles+="${f} "
+	done
+
+	for n in ${jsonfiles[@]};
+	do
+		zip "../../zips/$locales.zip" "$n"
+	done
+popd > /dev/null
+
+echo 'Removing working locale folder'
+rm -rf "$locales"
 
 # report zip file name and creation date/time
 echo ''
 echo "$locales.zip created"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	stat -c '%.19z' en_GB.zip
+	stat -c '%.19z' "../../zips/$locales.zip"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-	stat -f %SB -t '%Y-%m-%d %H:%M:%S' "../zips/$locales.zip"
+	stat -f %SB -t '%Y-%m-%d %H:%M:%S' "../../zips/$locales.zip"
 fi
 
 # human readable to minified

--- a/bin/create_pot.sh
+++ b/bin/create_pot.sh
@@ -12,6 +12,8 @@ else
 	exit 1
 fi
 
+CP_VERSION="$1"
+
 for gh_repo in ClassicPress/ClassicPress; do
 	user="$(echo "$gh_repo" | cut -d/ -f1)"
 	repo="$(echo "$gh_repo" | cut -d/ -f2)"
@@ -42,7 +44,9 @@ pushd ClassicPress/
 
 	# Get version numbers for substitution later
 	WP_VERSION=$(grep '$wp_version =' build/wp-includes/version.php | head -n 1 | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
-	CP_VERSION=$(grep '$cp_version =' build/wp-includes/version.php | head -n 1 | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
+	if [ -z "$CP_VERSION" ]; then
+		CP_VERSION=$(grep '$cp_version =' build/wp-includes/version.php | head -n 1 | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
+	fi
 popd
 
 # Clean up POT files first


### PR DESCRIPTION
Feat: `bin/create_pot.sh` now optionally takes a command line parameter to build POT files with an appropriate core ClassicPress version number.

Feat: `bin/build_zip.sh` now build JSON translation files for JavaScript libraries and amends the zip build steps accordingly to create a subfolder, copies the *.PO files for the locale to that folder, builds the *.MO and *.json files with the correct file names and then creates the zip. The working folder is delete to avoid polluting the folder  structure.